### PR TITLE
fix: update API docs location

### DIFF
--- a/scripts/setup_new_sdk.sh
+++ b/scripts/setup_new_sdk.sh
@@ -7,7 +7,7 @@ CLIENTS_GENERATOR_DIR="${PWD}"
 CONFIG_PATH="${CLIENTS_GENERATOR_DIR}/config/clients/${SDK_ID:?}"
 SDK_OUTPUT_PATH="${CLIENTS_GENERATOR_DIR}/clients/${SDK_ID}"
 appLongName="OpenFGA"
-apiDocsUrl="https://openfga.dev/api/service"
+apiDocsUrl="https://openfga.dev/api"
 
 if [ -d "${CONFIG_PATH}" ]; then
   echo "Config Path: ${CONFIG_PATH} already exists. Clear it or choose a different SDK ID"

--- a/scripts/setup_new_sdk.sh
+++ b/scripts/setup_new_sdk.sh
@@ -7,7 +7,7 @@ CLIENTS_GENERATOR_DIR="${PWD}"
 CONFIG_PATH="${CLIENTS_GENERATOR_DIR}/config/clients/${SDK_ID:?}"
 SDK_OUTPUT_PATH="${CLIENTS_GENERATOR_DIR}/clients/${SDK_ID}"
 appLongName="OpenFGA"
-apiDocsUrl="https://openfga.dev/docs/api"
+apiDocsUrl="https://openfga.dev/api/service"
 
 if [ -d "${CONFIG_PATH}" ]; then
   echo "Config Path: ${CONFIG_PATH} already exists. Clear it or choose a different SDK ID"


### PR DESCRIPTION


## Description
Correct API docs location in setup script

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [ ] The correct base branch is being used, if not `main`
