### PR TITLE
fix: allow update head when checking out openfga/sdk-generator

### DIFF
--- a/scripts/setup_new_sdk.sh
+++ b/scripts/setup_new_sdk.sh
@@ -69,7 +69,7 @@ printf "Task 2.2: Run git init"
 # shellcheck disable=SC2091
 $(git init > /dev/null 2>&1) && echo " - Done"
 git remote add origin $TEMPLATE_SOURCE_REPO
-FETCH_CMD="git fetch --depth 1 origin $TEMPLATE_SOURCE_BRANCH:refs/heads/$TEMPLATE_SOURCE_BRANCH"
+FETCH_CMD="git fetch -u --depth 1 origin $TEMPLATE_SOURCE_BRANCH:refs/heads/$TEMPLATE_SOURCE_BRANCH "
 CLONE_CMD="git checkout $TEMPLATE_SOURCE_BRANCH -- $TEMPLATE_SOURCE_PATH"
 printf "Task 2.3: Run fetch command: %s" "$FETCH_CMD"
 # shellcheck disable=SC2091


### PR DESCRIPTION
## Description

If the default branch is master, you will need to allow updating head
when doing git fetch. Otherwise, git fetch will fail with
ambiguous argument 'origin/master'.


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
