### PR TITLE
fix(go-sdk): validate correct credentials method config

### DIFF
--- a/config/clients/go/template/credentials.mustache
+++ b/config/clients/go/template/credentials.mustache
@@ -70,7 +70,7 @@ func (c *Credentials) ValidateCredentialsConfig() error {
     conf := c.Config
     if c.Method == CredentialsMethodApiToken && (conf == nil || conf.ApiToken == "") {
         return fmt.Errorf("CredentialsConfig.ApiToken is required when CredentialsMethod is CredentialsMethodApiToken (%s)", c.Method)
-    } else if c.Method == CredentialsMethodApiToken {
+    } else if c.Method == CredentialsMethodClientCredentials {
         if conf == nil ||
             conf.ClientCredentialsClientId == "" ||
             conf.ClientCredentialsClientSecret == "" ||

--- a/config/clients/go/template/fga_test.mustache
+++ b/config/clients/go/template/fga_test.mustache
@@ -74,6 +74,49 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 		}
 	})
 
+	t.Run("should issue a successful network call when using ApiToken credential method", func(t *testing.T) {
+		configuration, err := NewConfiguration(Configuration{
+            ApiHost:         "api.{{sampleApiDomain}}",
+			StoreId:      "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			Credentials: &credentials.Credentials{
+				Method: credentials.CredentialsMethodApiToken,
+				Config: &credentials.Config{
+					ApiToken: "some-token",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		apiClient := NewAPIClient(configuration)
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s://%s/stores/%s/authorization-models", configuration.ApiScheme, configuration.ApiHost, configuration.StoreId),
+			func(req *http.Request) (*http.Response, error) {
+                resp, err := httpmock.NewJsonResponse(200, ReadAuthorizationModelsResponse{AuthorizationModels: &[]AuthorizationModel{
+                    {
+                        Id:              PtrString("1uHxCSuTP0VKPYSnkq1pbb1jeZw"),
+                        TypeDefinitions: &[]TypeDefinition{},
+                    },
+                    {
+                        Id:              PtrString("GtQpMohWezFmIbyXxVEocOCxxgq"),
+                        TypeDefinitions: &[]TypeDefinition{},
+                    },
+                }})
+				if err != nil {
+					return httpmock.NewStringResponse(500, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		if _, _, err = apiClient.{{appShortName}}Api.ReadAuthorizationModels(context.Background()).Execute(); err != nil {
+			t.Fatalf("%v", err)
+		}
+	})
+
 	t.Run("In ClientCredentials method, providing no client id, secret, audience or issuer should error", func(t *testing.T) {
 		_, err := NewConfiguration(Configuration{
 			ApiHost: "https://api.{{sampleApiDomain}}",


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Fix validation of config in go-sdk. Validation func is applying client_credentials validation to api_token cred method.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
