### PR TITLE
fix: dotnet unable to deserialize ReadChangesResponse

### DIFF
--- a/config/clients/dotnet/config.overrides.json
+++ b/config/clients/dotnet/config.overrides.json
@@ -116,6 +116,10 @@
       "destinationFilename": "src/OpenFga.Sdk.Test/Models/ModelTests.cs",
       "templateType": "SupportingFiles"
     },
+    "modelJsonStringEnumMemberConverter.mustache": {
+      "destinationFilename": "src/OpenFga.Sdk/Model/JsonStringEnumMemberConverter.cs",
+      "templateType": "SupportingFiles"
+    },
     ".fossa.yml.mustache": {
       "destinationFilename": ".fossa.yml",
       "templateType": "SupportingFiles"

--- a/config/clients/dotnet/template/modelEnum.mustache
+++ b/config/clients/dotnet/template/modelEnum.mustache
@@ -8,7 +8,7 @@
     {{#enumVars}}
     {{#-first}}
     {{#isString}}
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumMemberConverter<{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}>))]
     {{/isString}}
     {{/-first}}
     {{/enumVars}}

--- a/config/clients/dotnet/template/modelInnerEnum.mustache
+++ b/config/clients/dotnet/template/modelInnerEnum.mustache
@@ -6,7 +6,7 @@
         /// <value>{{.}}</value>
         {{/description}}
         {{#isString}}
-        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumMemberConverter<{{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}>))]
         {{/isString}}
         {{>visibility}} enum {{datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}{{#vendorExtensions.x-enum-byte}}: byte{{/vendorExtensions.x-enum-byte}}
         {

--- a/config/clients/dotnet/template/modelJsonStringEnumMemberConverter.mustache
+++ b/config/clients/dotnet/template/modelJsonStringEnumMemberConverter.mustache
@@ -5,7 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
-/// This class is based on based on suggestions from https://github.com/dotnet/runtime/issues/31081
+/// This class is based on suggestions from https://github.com/dotnet/runtime/issues/31081
 
 /// <summary>
 /// Helper class to serialize / deserialize enum member to/from JSON

--- a/config/clients/dotnet/template/modelJsonStringEnumMemberConverter.mustache
+++ b/config/clients/dotnet/template/modelJsonStringEnumMemberConverter.mustache
@@ -5,12 +5,18 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
+/// <summary>
+/// Helper class to serialize / deserialize enum member to/from JSON
+/// </summary>
 public class JsonStringEnumMemberConverter<EnumTemplate> : JsonConverter<EnumTemplate> where EnumTemplate : struct, System.Enum
   {
 
     private readonly Dictionary<EnumTemplate, string> _enumToString = new Dictionary<EnumTemplate, string>();
     private readonly Dictionary<string, EnumTemplate> _stringToEnum = new Dictionary<string, EnumTemplate>();
 
+    /// <summary>
+    /// Parsing and converting enum member	
+	/// </summary>
     public JsonStringEnumMemberConverter()
     {
       var type = typeof(EnumTemplate);
@@ -37,11 +43,17 @@ public class JsonStringEnumMemberConverter<EnumTemplate> : JsonConverter<EnumTem
       }
     }
 
+    /// <summary>
+    /// Overwrite write function to provide enum value to string
+	/// </summary>
     public override void Write(Utf8JsonWriter writer, EnumTemplate value, JsonSerializerOptions options)
     {
       writer.WriteStringValue(_enumToString[value]);
     }
 
+    /// <summary>
+    /// Overwrite read function to convert string back to enum value
+	/// </summary>
     public override EnumTemplate Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
       var stringValue = reader.GetString();

--- a/config/clients/dotnet/template/modelJsonStringEnumMemberConverter.mustache
+++ b/config/clients/dotnet/template/modelJsonStringEnumMemberConverter.mustache
@@ -1,0 +1,52 @@
+{{>partial_header}}
+
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.ComponentModel.DataAnnotations;
+
+public class JsonStringEnumMemberConverter<EnumTemplate> : JsonConverter<EnumTemplate> where EnumTemplate : struct, System.Enum
+  {
+
+    private readonly Dictionary<EnumTemplate, string> _enumToString = new Dictionary<EnumTemplate, string>();
+    private readonly Dictionary<string, EnumTemplate> _stringToEnum = new Dictionary<string, EnumTemplate>();
+
+    public JsonStringEnumMemberConverter()
+    {
+      var type = typeof(EnumTemplate);
+      var values = System.Enum.GetValues<EnumTemplate>();
+
+      foreach (var value in values)
+      {
+        var enumMember = type.GetMember(value.ToString())[0];
+        var attr = enumMember.GetCustomAttributes(typeof(EnumMemberAttribute), false)
+          .Cast<EnumMemberAttribute>()
+          .FirstOrDefault();
+
+        _stringToEnum.Add(value.ToString(), value);
+
+        if (attr?.Value != null)
+        {
+          _stringToEnum.Add(attr.Value, value);
+		  _enumToString.Add(value, attr.Value);
+        }
+		else
+        {
+          _enumToString.Add(value, value.ToString());
+        }
+      }
+    }
+
+    public override void Write(Utf8JsonWriter writer, EnumTemplate value, JsonSerializerOptions options)
+    {
+      writer.WriteStringValue(_enumToString[value]);
+    }
+
+    public override EnumTemplate Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+      var stringValue = reader.GetString();
+
+      return ((_stringToEnum.TryGetValue(stringValue, out var enumValue)) ? enumValue : default);
+    }
+
+  }

--- a/config/clients/dotnet/template/modelJsonStringEnumMemberConverter.mustache
+++ b/config/clients/dotnet/template/modelJsonStringEnumMemberConverter.mustache
@@ -5,6 +5,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
+/// This class is based on based on suggestions from https://github.com/dotnet/runtime/issues/31081
+
 /// <summary>
 /// Helper class to serialize / deserialize enum member to/from JSON
 /// </summary>

--- a/config/clients/dotnet/template/models_test.mustache
+++ b/config/clients/dotnet/template/models_test.mustache
@@ -60,7 +60,6 @@ namespace {{testPackageName}}.Models {
         /// <summary>
         /// Deserialize ReadChangesResponse
         /// </summary>
-        [Fact(Skip = "Known issue deserializing TUPLE_OPERATION_WRITE")]
         public void DeserializeReadChangesResponse() {
             var jsonResponse =
                 "{\"changes\":[{\"tuple_key\":{\"object\":\"document:planning\",\"relation\":\"viewer\",\"user\":\"user:jane\"},\"operation\":\"TUPLE_OPERATION_WRITE\",\"timestamp\":\"2022-01-01T00:00:00.000000000Z\"},{\"tuple_key\":{\"object\":\"document:roadmap\",\"relation\":\"owner\",\"user\":\"user:anna\"},\"operation\":\"TUPLE_OPERATION_DELETE\",\"timestamp\":\"2022-01-01T00:00:00.000000000Z\"}],\"continuation_token\":\"abcxyz==\"}";


### PR DESCRIPTION
## Description
Change TupleOperation to TUPLE_OPERATION_WRITE and TUPLE_OPERATION_DELETE Close 


## References
- Close https://github.com/openfga/sdk-generator/issues/7

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
