### PR TITLE
chore: update README and unit test for dotnet and Go

### DIFF
--- a/config/clients/dotnet/template/README_calling_api.mustache
+++ b/config/clients/dotnet/template/README_calling_api.mustache
@@ -81,7 +81,7 @@ var relations = new Dictionary<string, Userset>()
             {new(new object(), new ObjectRelation("", "writer"))}))
     }
 };
-var body = new TypeDefinitions(new List<TypeDefinition>() {new("repo", relations)});
+var body = new WriteAuthorizationModelRequest(new List<TypeDefinition>() {new("repo", relations)});
 var response = await {{appCamelCaseName}}Api.WriteAuthorizationModel(body);
 
 // response.AuthorizationModelId = 1uHxCSuTP0VKPYSnkq1pbb1jeZw

--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -589,7 +589,7 @@ namespace {{testPackageName}}.Api {
                     }))
                 }
             };
-            var body = new TypeDefinitions(new List<TypeDefinition>() { new("repo", relations) });
+            var body = new WriteAuthorizationModelRequest(new List<TypeDefinition>() { new("repo", relations) });
             var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
 
             mockHandler.Protected()

--- a/config/clients/go/template/README_calling_api.mustache
+++ b/config/clients/go/template/README_calling_api.mustache
@@ -82,10 +82,10 @@ if err != nil {
 > Learn more about [the {{appName}} configuration language]({{docsUrl}}/configuration-language).
 
 ```golang
-body  := {{packageName}}.TypeDefinitions{TypeDefinitions: &[]{{packageName}}.TypeDefinition{
+body  := {{packageName}}.WriteAuthorizationModelRequest{TypeDefinitions: &[]{{packageName}}.TypeDefinition{
 	{
 		Type: "repo",
-		Relations: map[string]{{packageName}}.Userset{
+		Relations: &map[string]{{packageName}}.Userset{
 			"writer": {This: &map[string]interface{}{}},
 			"reader": {Union: &{{packageName}}.Usersets{
 				Child: &[]{{packageName}}.Userset{

--- a/config/clients/go/template/fga_test.mustache
+++ b/config/clients/go/template/fga_test.mustache
@@ -443,10 +443,10 @@ func Test{{appShortName}}Api(t *testing.T) {
 			RequestPath:    "authorization-models",
 		}
 {{=<% %>=}}
-		requestBody := TypeDefinitions{
+		requestBody := WriteAuthorizationModelRequest{
 			TypeDefinitions: &[]TypeDefinition{{
 				Type: "github-repo",
-				Relations: map[string]Userset{
+				Relations: &map[string]Userset{
 					"repo_writer": {
 						This: &map[string]interface{}{},
 					},
@@ -480,7 +480,7 @@ func Test{{appShortName}}Api(t *testing.T) {
 				return resp, nil
 			},
 		)
-		got, response, err := apiClient.{{appShortName}}Api.WriteAuthorizationModel(context.Background()).TypeDefinitions(requestBody).Execute()
+		got, response, err := apiClient.{{appShortName}}Api.WriteAuthorizationModel(context.Background()).Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}


### PR DESCRIPTION

## Description
Update UT and generated README to reflect the fact that TypeDefinitions is no longer defined

## References
- Close https://github.com/openfga/sdk-generator/issues/30

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
