### PR TITLE
fix: correct CICD tool + remove TypeDefinitions ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,9 @@ tag-client-js: test-client-js
 
 .PHONY: test-client-js
 test-client-js: build-client-js
-	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm test ; npm audit ; npm run lint'"
+	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm test'"
+	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm audit'"
+	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm run lint'"
 
 .PHONY: build-client-js
 build-client-js:

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,7 @@ tag-client-js: test-client-js
 
 .PHONY: test-client-js
 test-client-js: build-client-js
-	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm test'"
-	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm audit'"
-	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm run lint'"
+	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm test && npm audit && npm run lint'"
 
 .PHONY: build-client-js
 build-client-js:
@@ -61,9 +59,9 @@ build-client-js:
 	sed -i -e "s|_this|this|g" ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*.ts
 	sed -i -e "s|_this|this|g" ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*.md
 	rm -rf  ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*-e
-	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm i; npm run lint:fix -- --quiet'"
+	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm i && npm run lint:fix -- --quiet'"
 	make run-in-docker sdk_language=js image=busybox:${BUSYBOX_DOCKER_TAG} command="/bin/sh -c 'patch -p1 /module/api.ts /config/clients/js/patches/add-missing-first-param.patch'"
-	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm run lint:fix; npm run build;'"
+	make run-in-docker sdk_language=js image=node:${NODE_DOCKER_TAG} command="/bin/sh -c 'npm run lint:fix && npm run build;'"
 
 ### Go
 .PHONY: tag-client-go

--- a/config/clients/js/template/tests/index.test.ts.mustache
+++ b/config/clients/js/template/tests/index.test.ts.mustache
@@ -21,8 +21,8 @@ import {
   ReadResponse,
   TupleKey,
   TupleOperation,
-  TypeDefinitions,
   UserConfigurationParams,
+  WriteAuthorizationModelRequest,
 } from "../index";
 import { CallResult } from "../common";
 import { GetDefaultRetryParams } from "../configuration";
@@ -135,7 +135,7 @@ const nocks = {
   },
   writeAuthorizationModel: (
     storeId: string,
-    configurations: TypeDefinitions,
+    configurations: WriteAuthorizationModelRequest,
     basePath = defaultConfiguration.getBasePath(),
   ) => {
     return nock(basePath)


### PR DESCRIPTION
## Description
1.  Fix Makefile so that unit test failure will be identified as CICD failure
2. Remove TypeDefinitions from JS unit test

## References
Close https://github.com/openfga/sdk-generator/issues/32


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
