### PR TITLE
fix: python SDK to remove header info from error

### DIFF
--- a/config/clients/python/template/api_client.mustache
+++ b/config/clients/python/template/api_client.mustache
@@ -221,12 +221,14 @@ class ApiClient(object):
                 response_type = response_types_map.get(e.status, None)
                 if response_type is not None:
                     e.parsed_exception = self.__deserialize(json.loads(e.body), response_type)
+                    e.body = None
                 raise e
             except ApiException as e:
                 e.body = e.body.decode('utf-8') if six.PY3 else e.body
                 response_type = response_types_map.get(e.status, None)
                 if response_type is not None:
                     e.parsed_exception = self.__deserialize(json.loads(e.body), response_type)
+                    e.body = None
                 raise e
 
             self.last_response = response_data

--- a/config/clients/python/template/exceptions.mustache
+++ b/config/clients/python/template/exceptions.mustache
@@ -99,22 +99,17 @@ class ApiException(OpenApiException):
             self.status = http_resp.status
             self.reason = http_resp.reason
             self.body = http_resp.data
-            self.headers = http_resp.getheaders()
             self._parsed_exception = None
         else:
             self.status = status
             self.reason = reason
             self.body = None
-            self.headers = None
             self._parsed_exception = None
 
     def __str__(self):
         """Custom error messages for exception"""
         error_message = "({0})\n"\
                         "Reason: {1}\n".format(self.status, self.reason)
-        if self.headers:
-            error_message += "HTTP response headers: {0}\n".format(
-                self.headers)
 
         if self.body:
             error_message += "HTTP response body: {0}\n".format(self.body)


### PR DESCRIPTION
## Description
Python SDK to remove header info from error

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
