### PR TITLE
feat: Python SDK exception should contain specific FGA header info

### DIFF
--- a/config/clients/python/template/api_test.mustache
+++ b/config/clients/python/template/api_test.mustache
@@ -14,7 +14,7 @@ import {{packageName}}
 from {{packageName}} import rest
 from {{packageName}}.api import open_fga_api
 from {{packageName}}.credentials import Credentials, CredentialConfiguration
-from {{packageName}}.exceptions import ApiTypeError, ApiValueError, NotFoundException, RateLimitExceededError, ServiceException, ValidationException
+from {{packageName}}.exceptions import ApiTypeError, ApiValueError, NotFoundException, RateLimitExceededError, ServiceException, ValidationException, FGA_REQUEST_ID
 from {{packageName}}.models.assertion import Assertion
 from {{packageName}}.models.authorization_model import AuthorizationModel
 from {{packageName}}.models.check_request import CheckRequest
@@ -58,11 +58,13 @@ from {{packageName}}.models.write_authorization_model_response import WriteAutho
 from {{packageName}}.models.write_request import WriteRequest
 
 store_id = 'd12345abc'
+request_id = 'x1y2z3'
 
 # Helper function to construct mock response
 def http_mock_response(body, status):
     headers = urllib3.response.HTTPHeaderDict({
-        'content-type': 'application/json'
+        'content-type': 'application/json',
+        'Fga-Request-Id': request_id
     })
     return urllib3.HTTPResponse(
         body.encode('utf-8'),
@@ -953,6 +955,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
             self.assertIsInstance(api_exception.exception.parsed_exception, ValidationErrorMessageResponse)
             self.assertEqual(api_exception.exception.parsed_exception.code, ErrorCode.VALIDATION_ERROR)
             self.assertEqual(api_exception.exception.parsed_exception.message, "Generic validation error")
+            self.assertEqual(api_exception.exception.header.get(FGA_REQUEST_ID), request_id)
 
 
     @patch.object(rest.RESTClientObject, 'request')

--- a/config/clients/python/template/exceptions.mustache
+++ b/config/clients/python/template/exceptions.mustache
@@ -12,7 +12,7 @@ X_RATELIMIT_RESET = 'x_ratelimit_reset'
 FGA_REQUEST_ID = 'fga-request-id' 
 FGA_QUERY_DURATION_MS = 'fga-query-duration-ms'
 OPENFGA_AUTHORIZATION_MODEL_ID = 'openfga_authorization_model_id'
-INTERESTING_HEADERS = [X_RATELIMIT_LIMIT, X_RATELIMIT_REMAINING, X_RATELIMIT_RESET,
+RESPONSE_HEADERS_TO_KEEP = [X_RATELIMIT_LIMIT, X_RATELIMIT_REMAINING, X_RATELIMIT_RESET,
     FGA_REQUEST_ID, FGA_QUERY_DURATION_MS, OPENFGA_AUTHORIZATION_MODEL_ID]
 
 
@@ -113,7 +113,7 @@ class ApiException(OpenApiException):
             self._parsed_exception = None
             normalized_headers = dict((k.lower(), v) for k, v in http_resp.getheaders().items())
             self.header = dict()
-            for key in INTERESTING_HEADERS:
+            for key in RESPONSE_HEADERS_TO_KEEP:
                 self.header[key] = normalized_headers.get(key)
         else:
             self.status = status

--- a/config/clients/python/template/exceptions.mustache
+++ b/config/clients/python/template/exceptions.mustache
@@ -5,6 +5,17 @@
 import six
 
 
+# Specifc FGA header to be parsed
+X_RATELIMIT_LIMIT = 'x-ratelimit-limit'
+X_RATELIMIT_REMAINING = 'x_ratelimit_remaining'
+X_RATELIMIT_RESET = 'x_ratelimit_reset'
+FGA_REQUEST_ID = 'fga-request-id' 
+FGA_QUERY_DURATION_MS = 'fga-query-duration-ms'
+OPENFGA_AUTHORIZATION_MODEL_ID = 'openfga_authorization_model_id'
+INTERESTING_HEADERS = [X_RATELIMIT_LIMIT, X_RATELIMIT_REMAINING, X_RATELIMIT_RESET,
+    FGA_REQUEST_ID, FGA_QUERY_DURATION_MS, OPENFGA_AUTHORIZATION_MODEL_ID]
+
+
 class OpenApiException(Exception):
     """The base exception class for all OpenAPIExceptions"""
 
@@ -100,11 +111,16 @@ class ApiException(OpenApiException):
             self.reason = http_resp.reason
             self.body = http_resp.data
             self._parsed_exception = None
+            normalized_headers = dict((k.lower(), v) for k, v in http_resp.getheaders().items())
+            self.header = dict()
+            for key in INTERESTING_HEADERS:
+                self.header[key] = normalized_headers.get(key)
         else:
             self.status = status
             self.reason = reason
             self.body = None
             self._parsed_exception = None
+            self.header = dict()
 
     def __str__(self):
         """Custom error messages for exception"""


### PR DESCRIPTION
## Description
Python SDK exception should contain selected header info

## References
Close https://github.com/openfga/sdk-generator/issues/38

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
