### PR TITLE
fix: update python SDK error to use standardize error name

### DIFF
--- a/config/clients/python/template/__init__package.mustache
+++ b/config/clients/python/template/__init__package.mustache
@@ -13,7 +13,7 @@ __version__ = "{{packageVersion}}"
 from {{packageName}}.api_client import ApiClient
 from {{packageName}}.configuration import Configuration
 from {{packageName}}.exceptions import OpenApiException
-from {{packageName}}.exceptions import ApiTypeError
+from {{packageName}}.exceptions import FgaValidationException
 from {{packageName}}.exceptions import ApiValueError
 from {{packageName}}.exceptions import ApiKeyError
 from {{packageName}}.exceptions import ApiAttributeError

--- a/config/clients/python/template/api.mustache
+++ b/config/clients/python/template/api.mustache
@@ -10,7 +10,7 @@ import six
 
 from {{packageName}}.api_client import ApiClient
 from {{packageName}}.exceptions import (  # noqa: F401
-    ApiTypeError,
+    FgaValidationException,
     ApiValueError
 )
 
@@ -171,7 +171,7 @@ class {{classname}}(object):
 
         for key, val in six.iteritems(local_var_params['kwargs']):
             if key not in all_params{{#servers.0}} and key != "_host_index"{{/servers.0}}:
-                raise ApiTypeError(
+                raise FgaValidationException(
                     "Got an unexpected keyword argument '%s'"
                     " to method {{operationId}}" % key
                 )

--- a/config/clients/python/template/api_client.mustache
+++ b/config/clients/python/template/api_client.mustache
@@ -26,7 +26,7 @@ import tornado.gen
 from {{packageName}}.configuration import Configuration
 import {{modelPackage}}
 from {{packageName}} import rest
-from {{packageName}}.exceptions import ApiValueError, ApiException, ApiTypeError, RateLimitExceededError
+from {{packageName}}.exceptions import ApiValueError, ApiException, FgaValidationException, RateLimitExceededError
 
 
 def random_time(loop_count, min_wait_in_ms):
@@ -709,11 +709,11 @@ class ApiClient(object):
         """
         Verify that the store id has been configured and not empty string.
         It will return the store ID.
-        Otherwise, raise ApiTypeError
+        Otherwise, raise FgaValidationException
         """
         configuration = self.configuration
         if configuration.store_id is None or configuration.store_id == '':
-            raise ApiTypeError(
+            raise FgaValidationException(
                 'store_id is required but not configured'
             )
         return configuration.store_id

--- a/config/clients/python/template/api_test.mustache
+++ b/config/clients/python/template/api_test.mustache
@@ -14,7 +14,7 @@ import {{packageName}}
 from {{packageName}} import rest
 from {{packageName}}.api import open_fga_api
 from {{packageName}}.credentials import Credentials, CredentialConfiguration
-from {{packageName}}.exceptions import ApiTypeError, ApiValueError, NotFoundException, RateLimitExceededError, ServiceException, ValidationException
+from {{packageName}}.exceptions import FgaValidationException, ApiValueError, NotFoundException, RateLimitExceededError, ServiceException, ValidationException
 from {{packageName}}.models.assertion import Assertion
 from {{packageName}}.models.authorization_model import AuthorizationModel
 from {{packageName}}.models.check_request import CheckRequest
@@ -821,22 +821,22 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
 
     def test_configuration_missing_host(self):
         """
-        Test whether ApiTypeError is raised if configuration does not have host specified
+        Test whether FgaValidationException is raised if configuration does not have host specified
         """
         configuration = {{packageName}}.Configuration(
             api_scheme='http'
         )
-        self.assertRaises(ApiTypeError, configuration.is_valid)
+        self.assertRaises(FgaValidationException, configuration.is_valid)
 
     def test_configuration_missing_scheme(self):
         """
-        Test whether ApiTypeError is raised if configuration does not have scheme specified
+        Test whether FgaValidationException is raised if configuration does not have scheme specified
         """
         configuration = {{packageName}}.Configuration(
             api_host='localhost'
         )
         configuration.api_scheme = None
-        self.assertRaises(ApiTypeError, configuration.is_valid)
+        self.assertRaises(FgaValidationException, configuration.is_valid)
 
     def test_configuration_bad_scheme(self):
         """
@@ -880,7 +880,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
 
     async def test_bad_configuration_read_authorization_model(self):
         """
-        Test whether ApiTypeError is raised for API (reading authorization models)
+        Test whether FgaValidationException is raised for API (reading authorization models)
         with configuration is having incorrect API scheme
         """
         configuration = {{packageName}}.Configuration(
@@ -893,7 +893,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
             # Create an instance of the API class
             api_instance = open_fga_api.OpenFgaApi(api_client)
 
-            # expects ApiTypeError to be thrown because api_scheme is bad
+            # expects FgaValidationException to be thrown because api_scheme is bad
             with self.assertRaises(ApiValueError):
                 await api_instance.read_authorization_models(
                     page_size= 1,
@@ -902,7 +902,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
 
     async def test_configuration_missing_storeid(self):
         """
-        Test whether ApiTypeError is raised for API (reading authorization models)
+        Test whether FgaValidationException is raised for API (reading authorization models)
         required store ID but configuration is missing store ID
         """
         configuration = {{packageName}}.Configuration(
@@ -915,8 +915,8 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
             # Create an instance of the API class
             api_instance = open_fga_api.OpenFgaApi(api_client)
 
-            # expects ApiTypeError to be thrown because store_id is not specified
-            with self.assertRaises(ApiTypeError):
+            # expects FgaValidationException to be thrown because store_id is not specified
+            with self.assertRaises(FgaValidationException):
                 await api_instance.read_authorization_models(
                     page_size= 1,
                     continuation_token= "abcdefg"

--- a/config/clients/python/template/configuration.mustache
+++ b/config/clients/python/template/configuration.mustache
@@ -13,7 +13,7 @@ import urllib3
 import six
 from six.moves import http_client as httplib
 from urllib.parse import urlparse
-from {{packageName}}.exceptions import ApiTypeError, ApiValueError
+from {{packageName}}.exceptions import FgaValidationException, ApiValueError
 
 
 JSON_SCHEMA_VALIDATION_KEYWORDS = {
@@ -523,9 +523,9 @@ class Configuration(object):
         Note that we are only doing basic validation to ensure input is sane.
         """
         if self.api_host is None or self.api_host == '':
-            raise ApiTypeError('api_host is required but not configured.')
+            raise FgaValidationException('api_host is required but not configured.')
         if self.api_scheme is None or self.api_scheme == '':
-            raise ApiTypeError('api_scheme is required but not configured.')
+            raise FgaValidationException('api_scheme is required but not configured.')
         combined_url = self.api_scheme + '://' + self.api_host
         parsed_url = None
         try:

--- a/config/clients/python/template/credentials.mustache
+++ b/config/clients/python/template/credentials.mustache
@@ -7,7 +7,7 @@ import typing
 import urllib3
 from urllib.parse import urlparse
 
-from {{packageName}}.exceptions import ApiTypeError, ApiValueError, AuthenticationError
+from {{packageName}}.exceptions import FgaValidationException, ApiValueError, AuthenticationError
 
 def none_or_empty(value):
     """

--- a/config/clients/python/template/exceptions.mustache
+++ b/config/clients/python/template/exceptions.mustache
@@ -9,7 +9,7 @@ class OpenApiException(Exception):
     """The base exception class for all OpenAPIExceptions"""
 
 
-class ApiTypeError(OpenApiException, TypeError):
+class FgaValidationException(OpenApiException, TypeError):
     def __init__(self, msg, path_to_item=None, valid_classes=None,
                  key_type=None):
         """ Raises an exception for TypeErrors
@@ -35,7 +35,7 @@ class ApiTypeError(OpenApiException, TypeError):
         full_msg = msg
         if path_to_item:
             full_msg = "{0} at {1}".format(msg, render_path(path_to_item))
-        super(ApiTypeError, self).__init__(full_msg)
+        super(FgaValidationException, self).__init__(full_msg)
 
 
 class ApiValueError(OpenApiException, ValueError):


### PR DESCRIPTION
## Description
Update python SDK to use error name similar to other SDKs

## References
N/A

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
