### PR TITLE
fix: dotnet sdk not handling null DeletedAt for ListStores

### DIFF
--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -1143,5 +1143,129 @@ namespace {{testPackageName}}.Api {
             Assert.Equal(authorizationModelId, response.AuthorizationModelId);
             Assert.Empty(response.Assertions);
         }
+
+        /// <summary>
+        /// Test ListStores
+        /// </summary>
+        [Fact]
+        public async Task ListStoresTest() {
+            var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var expectedResponse = new ListStoresResponse() {
+                        Stores = new List<Store>() {
+                            new() { Id = "45678", Name = "TestStore", CreatedAt = DateTime.Now, UpdatedAt = DateTime.Now} 
+                        }
+                    };
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.RequestUri ==
+                        new Uri($"{_config.BasePath}/stores") &&
+                        req.Method == HttpMethod.Get),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = Utils.CreateJsonStringContent(expectedResponse),
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var {{appCamelCaseName}}Api = new {{classname}}(_config, httpClient);
+
+            var response = await {{appCamelCaseName}}Api.ListStores();
+            mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri == new Uri($"{_config.BasePath}/stores") &&
+                    req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>()
+            );
+            Assert.IsType<ListStoresResponse>(response);
+            Assert.Single(response.Stores);
+            Assert.Equal(response, expectedResponse);
+        }
+
+
+        /// <summary>
+        /// Test ListStores with Null DateTime
+        /// </summary>
+        [Fact]
+        public async Task ListStoresTestNullDeletedAt() {
+            var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var content = "{ \"stores\": [{\"id\": \"xyz123\", \"name\": \"abcdefg\", \"created_at\": \"2022-10-07T14:00:40.205Z\", \"updated_at\": \"2022-10-07T14:00:40.205Z\", \"deleted_at\": null}], \"continuation_token\": \"eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==\"}";
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.RequestUri ==
+                        new Uri($"{_config.BasePath}/stores") &&
+                        req.Method == HttpMethod.Get),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(content, Encoding.UTF8, "application/json")
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var {{appCamelCaseName}}Api = new {{classname}}(_config, httpClient);
+
+            var response = await {{appCamelCaseName}}Api.ListStores();
+            mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri == new Uri($"{_config.BasePath}/stores") &&
+                    req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>()
+            );
+            Assert.IsType<ListStoresResponse>(response);
+            Assert.Single(response.Stores);
+            Assert.Equal(response.Stores[0].Id, "xyz123");
+            Assert.Equal(response.Stores[0].Name, "abcdefg");
+            Assert.Null(response.Stores[0].DeletedAt);
+        }       
+
+        /// <summary>
+        /// Test ListStores for empty array
+        /// </summary>
+        [Fact]
+        public async Task ListStoresEmptyTest() {
+            var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var expectedResponse = new ListStoresResponse() {
+                        Stores = new List<Store>() {
+                        }
+                    };
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.RequestUri ==
+                        new Uri($"{_config.BasePath}/stores") &&
+                        req.Method == HttpMethod.Get),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = Utils.CreateJsonStringContent(expectedResponse),
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var {{appCamelCaseName}}Api = new {{classname}}(_config, httpClient);
+
+            var response = await {{appCamelCaseName}}Api.ListStores();
+            mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri == new Uri($"{_config.BasePath}/stores") &&
+                    req.Method == HttpMethod.Get),
+                ItExpr.IsAny<CancellationToken>()
+            );
+            Assert.IsType<ListStoresResponse>(response);
+            Assert.Empty(response.Stores);
+            Assert.Equal(response, expectedResponse);
+        }       
     }
 }

--- a/config/clients/dotnet/template/modelGeneric.mustache
+++ b/config/clients/dotnet/template/modelGeneric.mustache
@@ -211,7 +211,7 @@
         {{#deprecated}}
         [Obsolete]
         {{/deprecated}}
-        public {{{dataType}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
+        public {{{dataType}}}{{^required}}?{{/required}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
 
         {{#isReadOnly}}
         /// <summary>


### PR DESCRIPTION

## Description
.NET sdk not able to handle null response for non-required content. 

## References
Close https://github.com/openfga/dotnet-sdk/issues/5


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
