### PR TITLE
chore(dotnet-sdk): bump version and update release note

### DIFF
--- a/config/clients/dotnet/CHANGELOG.md.mustache
+++ b/config/clients/dotnet/CHANGELOG.md.mustache
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.1
+
+### [0.1.1](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.1.0...v0.1.1) (2022-10-07)
+
+- Fix for issue in deserializing nullable DateTime (https://github.com/openfga/dotnet-sdk/issues/5)
+
 ## v0.1.0
 
 ### [0.1.0](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.0.3...v0.1.0) (2022-09-29)

--- a/config/clients/dotnet/config.overrides.json
+++ b/config/clients/dotnet/config.overrides.json
@@ -10,7 +10,7 @@
   "packageGuid": "b8d9e3e9-0156-4948-9de7-5e0d3f9c4d9e",
   "testPackageGuid": "d119dfae-509a-4eba-a973-645b739356fc",
   "packageName": "OpenFga.Sdk",
-  "packageVersion": "0.1.0",
+  "packageVersion": "0.1.1",
   "licenseUrl": "https://github.com/openfga/dotnet-sdk/blob/main/LICENSE",
   "fossaComplianceReportId": "4b3a7481-7918-4779-b4ff-b42e5c273517",
   "termsOfService": "",


### PR DESCRIPTION


## Description
chore of bumping .NET version and update release notes

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
