### PR TITLE
fix: Broken Links in CONTRIBUTING.md

### DIFF
--- a/config/common/files/CONTRIBUTING.md.mustache
+++ b/config/common/files/CONTRIBUTING.md.mustache
@@ -17,13 +17,13 @@ Reading and following these guidelines will help us make the contribution proces
 
 ## Code of Conduct
 
-By participating and contributing to this project, you are expected to uphold our [Code of Conduct](https://{{gitHost}}/{{gitUserId}}/rfcs/blob/main/CODE-OF-CONDUCT.md).
+By participating and contributing to this project, you are expected to uphold our [Code of Conduct](https://{{gitHost}}/{{gitUserId}}/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## Getting Started
 
 ### Making Changes
 
-When contributing to a repository, the first step is to open an issue on [sdk-generator](https://{{gitHost}}/{{gitUserId}}/sd-generator) to discuss the change you wish to make before making them.
+When contributing to a repository, the first step is to open an issue on [sdk-generator](https://{{gitHost}}/{{gitUserId}}/sdk-generator) to discuss the change you wish to make before making them.
 
 ### Opening Issues
 


### PR DESCRIPTION
## Description
Links to SDK-generator and CODE_OF_CONDUCT in CONTRIBUTING.md was incorrect. The existing links are fixed to correct URLs as part of this change

Updated Links
- sdk-generator
- CODE_OF_CONDUCT.md

Author:    Abel Mathew <Abel.Mathew@ny.email.gs.com>

File Change-list
	modified:   config/common/files/CONTRIBUTING.md.mustache

## References
Tracking Issue: #47

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected


Closes: #47 
