### PR TITLE
chore(go-sdk): bump dependency packages (x/net)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 OPEN_API_URL = https://raw.githubusercontent.com/openfga/api/main/docs/openapiv2/apidocs.swagger.json
 OPENAPI_GENERATOR_CLI_DOCKER_TAG = v6.0.1
 NODE_DOCKER_TAG = 16-alpine
-GO_DOCKER_TAG = 1
+GO_DOCKER_TAG = 1.19
 DOTNET_DOCKER_TAG = 6.0
 GOLINT_DOCKER_TAG = v1.48
 BUSYBOX_DOCKER_TAG = 1.34.1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 OPEN_API_URL = https://raw.githubusercontent.com/openfga/api/main/docs/openapiv2/apidocs.swagger.json
 OPENAPI_GENERATOR_CLI_DOCKER_TAG = v6.0.1
 NODE_DOCKER_TAG = 16-alpine
-GO_DOCKER_TAG = 1.19
+GO_DOCKER_TAG = 1
 DOTNET_DOCKER_TAG = 6.0
 GOLINT_DOCKER_TAG = v1.48
 BUSYBOX_DOCKER_TAG = 1.34.1

--- a/config/clients/go/template/go.mod.mustache
+++ b/config/clients/go/template/go.mod.mustache
@@ -4,5 +4,5 @@ go 1.19
 
 require (
 	github.com/jarcoal/httpmock v1.2.0
-	golang.org/x/net v0.0.0-20220927171203-f486391704dc
+	golang.org/x/net v0.1.0
 )

--- a/config/clients/go/template/go.sum
+++ b/config/clients/go/template/go.sum
@@ -2,5 +2,5 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/maxatome/go-testdeep v1.11.0 h1:Tgh5efyCYyJFGUYiT0qxBSIDeXw0F5zSoatlou685kk=
-golang.org/x/net v0.0.0-20220927171203-f486391704dc h1:FxpXZdoBqT8RjqTy6i1E8nXHhW21wK7ptQ/EPIGxzPQ=
-golang.org/x/net v0.0.0-20220927171203-f486391704dc/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
+golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=


### PR DESCRIPTION



<!-- Provide a brief summary of the changes -->

## Description
Also use a more recent GoLang Docker image to ensure latest packages are used.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
