### PR TITLE
fix(dotnet-sdk): resolve authorization token not send when ApiToken used

### DIFF
--- a/config/clients/dotnet/template/Client_ApiClient.mustache
+++ b/config/clients/dotnet/template/Client_ApiClient.mustache
@@ -23,17 +23,18 @@ public class ApiClient : IDisposable {
         _configuration = configuration;
         _baseClient = new BaseClient(configuration, userHttpClient);
 
-        if (configuration.Credentials == null) {
+        if (_configuration.Credentials == null) {
             return;
         }
 
-        switch (configuration.Credentials.Method)
+        switch (_configuration.Credentials.Method)
         {
             case CredentialsMethod.ApiToken:
-                configuration.DefaultHeaders.Add("Authorization", $"Bearer {configuration.Credentials.Config!.ApiToken}");
+                _configuration.DefaultHeaders.Add("Authorization", $"Bearer {_configuration.Credentials.Config!.ApiToken}");
+                _baseClient = new BaseClient(_configuration, userHttpClient);
                 break;
             case CredentialsMethod.ClientCredentials:
-                _oauth2Client = new OAuth2Client(configuration.Credentials, _baseClient);
+                _oauth2Client = new OAuth2Client(_configuration.Credentials, _baseClient);
                 break;
             case CredentialsMethod.None:
             default:

--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -142,6 +142,56 @@ namespace {{testPackageName}}.Api {
         }
 
         /// <summary>
+        /// Test that the authorization header is being sent
+        /// </summary>
+        [Fact]
+        public async Task ApiTokenSentInHeader() {
+            var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var config = new Configuration.Configuration() {
+                StoreId = _storeId,
+                ApiHost = _host,
+                Credentials = new Credentials() {
+                    Method = CredentialsMethod.ApiToken,
+                    Config = new CredentialsConfig() {
+                        ApiToken = "some-token"
+                    }
+                }
+            };
+
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.RequestUri.ToString()
+                            .StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
+                        req.Method == HttpMethod.Get &&
+                        req.Headers.Contains("Authorization")),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = Utils.CreateJsonStringContent(
+                            new ReadAuthorizationModelsResponse() { AuthorizationModels = { } }),
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var openFgaApi = new OpenFgaApi(config, httpClient);
+
+            var response = await openFgaApi.ReadAuthorizationModels(null, null);
+
+            mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString()
+                        .StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
+                    req.Method == HttpMethod.Get &&
+                    req.Headers.Contains("Authorization")),
+                ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        /// <summary>
         /// Test that providing no client id, secret, api token issuer or api audience when they are required should error
         /// </summary>
         [Fact]
@@ -267,7 +317,8 @@ namespace {{testPackageName}}.Api {
                     ItExpr.Is<HttpRequestMessage>(req =>
                         req.RequestUri.ToString()
                             .StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
-                        req.Method == HttpMethod.Get),
+                        req.Method == HttpMethod.Get &&
+                        req.Headers.Contains("Authorization")),
                     ItExpr.IsAny<CancellationToken>()
                 )
                 .ReturnsAsync(new HttpResponseMessage() {
@@ -294,7 +345,8 @@ namespace {{testPackageName}}.Api {
                 Times.Exactly(1),
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.RequestUri.ToString().StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
-                    req.Method == HttpMethod.Get),
+                    req.Method == HttpMethod.Get &&
+                    req.Headers.Contains("Authorization")),
                 ItExpr.IsAny<CancellationToken>()
             );
             mockHandler.Protected().Verify(

--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -158,14 +159,17 @@ namespace {{testPackageName}}.Api {
                 }
             };
 
+            var readAuthorizationModelsMockExpression = ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri.ToString()
+                    .StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
+                req.Method == HttpMethod.Get &&
+                req.Headers.Contains("Authorization") &&
+                req.Headers.Authorization.Equals(new AuthenticationHeaderValue("Bearer", "some-token")));
+
             mockHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(req =>
-                        req.RequestUri.ToString()
-                            .StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
-                        req.Method == HttpMethod.Get &&
-                        req.Headers.Contains("Authorization")),
+                    readAuthorizationModelsMockExpression,
                     ItExpr.IsAny<CancellationToken>()
                 )
                 .ReturnsAsync(new HttpResponseMessage() {
@@ -175,18 +179,14 @@ namespace {{testPackageName}}.Api {
                 });
 
             var httpClient = new HttpClient(mockHandler.Object);
-            var openFgaApi = new OpenFgaApi(config, httpClient);
+            var {{appCamelCaseName}} = new {{classname}}(config, httpClient);
 
-            var response = await openFgaApi.ReadAuthorizationModels(null, null);
+            var response = await {{appCamelCaseName}}.ReadAuthorizationModels(null, null);
 
             mockHandler.Protected().Verify(
                 "SendAsync",
                 Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.RequestUri.ToString()
-                        .StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
-                    req.Method == HttpMethod.Get &&
-                    req.Headers.Contains("Authorization")),
+                readAuthorizationModelsMockExpression,
                 ItExpr.IsAny<CancellationToken>()
             );
         }
@@ -311,14 +311,16 @@ namespace {{testPackageName}}.Api {
                     }),
                 });
 
+            var readAuthorizationModelsMockExpression = ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri.ToString()
+                    .StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
+                req.Method == HttpMethod.Get &&
+                req.Headers.Contains("Authorization") &&
+                req.Headers.Authorization.Equals(new AuthenticationHeaderValue("Bearer", "some-token")));
             mockHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
-                    ItExpr.Is<HttpRequestMessage>(req =>
-                        req.RequestUri.ToString()
-                            .StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
-                        req.Method == HttpMethod.Get &&
-                        req.Headers.Contains("Authorization")),
+                    readAuthorizationModelsMockExpression,
                     ItExpr.IsAny<CancellationToken>()
                 )
                 .ReturnsAsync(new HttpResponseMessage() {
@@ -343,10 +345,7 @@ namespace {{testPackageName}}.Api {
             mockHandler.Protected().Verify(
                 "SendAsync",
                 Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.RequestUri.ToString().StartsWith($"{config.BasePath}/stores/{config.StoreId}/authorization-models") &&
-                    req.Method == HttpMethod.Get &&
-                    req.Headers.Contains("Authorization")),
+                readAuthorizationModelsMockExpression,
                 ItExpr.IsAny<CancellationToken>()
             );
             mockHandler.Protected().Verify(


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->


## Description
<!-- Provide a detailed description of the changes -->

Authorization header was not being sent along when `ApiToken` credential method was used. The reason is that we were instantiating the client before updating the default headers.

Thanks to @Mattieeec3 for raising the issue and identifying the fix.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- fixes https://github.com/openfga/sdk-generator/issues/58

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
