### PR TITLE
fix(generator): sdk setup script created the wrong file and missed the sdk id

### DIFF
--- a/scripts/setup_new_sdk.sh
+++ b/scripts/setup_new_sdk.sh
@@ -30,9 +30,10 @@ mkdir -p "${CONFIG_PATH}"
 
 printf "Task 1.1: Initialize files"
 echo "${GENERATOR}" > "${CONFIG_PATH}/generator.txt"
-touch "${CONFIG_PATH}/CHANGELOG.md"
+touch "${CONFIG_PATH}/CHANGELOG.md.mustache"
 CONFIG_OVERRIDES=$(cat <<EOF
 {
+  "sdkId": "${SDK_ID}",
   "gitRepoId": "${SDK_ID}-sdk",
   "packageName": "CHANGE_ME",
   "packageVersion": "0.0.1",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

To be merged after #68 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
