### PR TITLE
fix: correct links in pypi readme

### DIFF
--- a/config/clients/python/config.overrides.json
+++ b/config/clients/python/config.overrides.json
@@ -8,6 +8,7 @@
   "fossaComplianceNoticeId": "90bbcda0-c2a6-4f00-8d24-7082521be2ce",
   "infoName": "OpenFGA",
   "infoEmail": "community@openfga.dev",
+  "docPrefix": "https://github.com/openfga/python-sdk/blob/main/",
   "files": {
     ".github/workflows/main.yaml": {
     },

--- a/config/clients/python/template/README_api_endpoints.mustache
+++ b/config/clients/python/template/README_api_endpoints.mustache
@@ -1,4 +1,4 @@
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{#summary}}{{summary}}{{/summary}}
+{{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}*{{classname}}* | [**{{operationId}}**]({{docPrefix}}{{apiDocPath}}{{classname}}.md#{{operationIdLowerCase}}) | **{{httpMethod}}** {{path}} | {{#summary}}{{summary}}{{/summary}}
 {{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/config/clients/python/template/README_models.mustache
+++ b/config/clients/python/template/README_models.mustache
@@ -1,4 +1,4 @@
 ## Documentation For Models
 
-{{#models}}{{#model}} - [{{{classname}}}]({{modelDocPath}}{{{classname}}}.md)
+{{#models}}{{#model}} - [{{{classname}}}]({{docPrefix}}{{modelDocPath}}{{{classname}}}.md)
 {{/model}}{{/models}}


### PR DESCRIPTION
## Description
Use absolute links for Python SDK readme so that pypi users can access the README links and point to the github page.

## References
Close https://github.com/openfga/sdk-generator/issues/84


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
