### PR TITLE
chore: fix go, js and py sdks to account for schema_version being required

### DIFF
--- a/config/clients/go/template/README_calling_api.mustache
+++ b/config/clients/go/template/README_calling_api.mustache
@@ -115,7 +115,7 @@ fmt.Printf("%s", data.AuthorizationModelId) // 1uHxCSuTP0VKPYSnkq1pbb1jeZw
 // Assuming `1uHxCSuTP0VKPYSnkq1pbb1jeZw` is an id of a single model
 data, response, err := apiClient.{{appShortName}}Api.ReadAuthorizationModel(context.Background(), "1uHxCSuTP0VKPYSnkq1pbb1jeZw").Execute()
 
-// data = {"authorization_model":{"id":"1uHxCSuTP0VKPYSnkq1pbb1jeZw","type_definitions":[{"type":"document","relations":{"writer":{"this":{}},"viewer":{ ... }}},{"type":"user"}]}} // JSON
+// data = {"authorization_model":{"id":"1uHxCSuTP0VKPYSnkq1pbb1jeZw","schema_version":"1.1","type_definitions":[{"type":"document","relations":{"writer":{"this":{}},"viewer":{ ... }}},{"type":"user"}]}} // JSON
 
 fmt.Printf("%s", data.AuthorizationModel.Id) // 1uHxCSuTP0VKPYSnkq1pbb1jeZw
 ```

--- a/config/clients/go/template/api_test.mustache
+++ b/config/clients/go/template/api_test.mustache
@@ -393,7 +393,7 @@ func Test{{appShortName}}Api(t *testing.T) {
 	t.Run("ReadAuthorizationModels", func(t *testing.T) {
 		test := TestDefinition{
 			Name:           "ReadAuthorizationModels",
-            JsonResponse:   `{"authorization_models":[{"id":"1uHxCSuTP0VKPYSnkq1pbb1jeZw","type_definitions":[]}]}`,
+            JsonResponse:   `{"authorization_models":[{"id":"1uHxCSuTP0VKPYSnkq1pbb1jeZw","schema_version":"1.1","type_definitions":[]}]}`,
 			ResponseStatus: 200,
 			Method:         "GET",
 			RequestPath:    "authorization-models",
@@ -498,7 +498,7 @@ func Test{{appShortName}}Api(t *testing.T) {
 	t.Run("ReadAuthorizationModel", func(t *testing.T) {
 		test := TestDefinition{
 			Name:           "ReadAuthorizationModel",
-			JsonResponse:   `{"authorization_model":{"id":"1uHxCSuTP0VKPYSnkq1pbb1jeZw", "type_definitions":[{"type":"github-repo", "relations":{"viewer":{"this":{}}}}]}}`,
+			JsonResponse:   `{"authorization_model":{"id":"1uHxCSuTP0VKPYSnkq1pbb1jeZw", "schema_version":"1.1", "type_definitions":[{"type":"github-repo", "relations":{"viewer":{"this":{}}}}]}}`,
 			ResponseStatus: 200,
 			Method:         "GET",
 			RequestPath:    "authorization-models",

--- a/config/clients/js/template/README_calling_api.mustache
+++ b/config/clients/js/template/README_calling_api.mustache
@@ -76,8 +76,8 @@ const { authorization_models: authorizationModels } = await fgaClient.readAuthor
 
 /*
 authorizationModels = [
- { id: "1uHxCSuTP0VKPYSnkq1pbb1jeZw", type_definitions: [...] },
- { id: "GtQpMohWezFmIbyXxVEocOCxxgq", type_definitions: [...] }];
+ { id: "1uHxCSuTP0VKPYSnkq1pbb1jeZw", schema_version: "1.1", type_definitions: [...] },
+ { id: "GtQpMohWezFmIbyXxVEocOCxxgq", schema_version: "1.1", type_definitions: [...] }];
 */
 ```
 
@@ -97,6 +97,7 @@ Create a new version of the authorization model.
 
 ```javascript
 const { authorization_model_id: id } = await fgaClient.writeAuthorizationModel({
+  schema_version: "1.1",
   type_definitions: [{
       type: "user",
     }, {
@@ -134,7 +135,7 @@ options.authorizationModelId = "1uHxCSuTP0VKPYSnkq1pbb1jeZw";
 
 const { authorization_model: authorizationModel } = await fgaClient.readAuthorizationModel(options);
 
-// authorizationModel = { id: "1uHxCSuTP0VKPYSnkq1pbb1jeZw", type_definitions: [...] }
+// authorizationModel = { id: "1uHxCSuTP0VKPYSnkq1pbb1jeZw", schema_version: "1.1", type_definitions: [...] }
 ```
 
 ##### Read the Latest Authorization Model
@@ -148,7 +149,7 @@ Reads the latest authorization model (note: this ignores the model id in configu
 ```javascript
 const { authorization_model: authorizationModel } = await fgaClient.readLatestAuthorizationModel();
 
-// authorizationModel = { id: "1uHxCSuTP0VKPYSnkq1pbb1jeZw", type_definitions: [...] }
+// authorizationModel = { id: "1uHxCSuTP0VKPYSnkq1pbb1jeZw", schema_version: "1.1", type_definitions: [...] }
 ```
 
 #### Relationship Tuples

--- a/config/clients/js/template/tests/client.test.ts.mustache
+++ b/config/clients/js/template/tests/client.test.ts.mustache
@@ -92,6 +92,7 @@ describe("{{appTitleCaseName}} Client", () => {
     describe("WriteAuthorizationModel", () => {
       it("should properly call the {{appShortName}} API", async () => {
         const authorizationModel = {
+          schema_version: "1.1",
           type_definitions: [
             { type: "workspace", relations: { admin: { this: {} } } },
           ],
@@ -123,6 +124,7 @@ describe("{{appTitleCaseName}} Client", () => {
         expect(data).toMatchObject({
           authorization_model: {
             id: expect.any(String),
+            schema_version: "1.1",
             type_definitions: expect.arrayContaining([]),
           },
         });
@@ -136,7 +138,7 @@ describe("{{appTitleCaseName}} Client", () => {
           .get(`/stores/${defaultConfiguration.storeId!}/authorization-models`)
           .query({ page_size: 1 })
           .reply(200, {
-            authorization_models: [{ id: modelId, type_definitions: [] }],
+            authorization_models: [{ id: modelId, schema_version: "1.1", type_definitions: [] }],
           });
 
         expect(scope.isDone()).toBe(false);
@@ -146,6 +148,7 @@ describe("{{appTitleCaseName}} Client", () => {
         expect(data).toMatchObject({
           authorization_model: {
             id: expect.any(String),
+            schema_version: "1.1",
             type_definitions: expect.arrayContaining([]),
           },
         });

--- a/config/clients/js/template/tests/helpers/nocks.ts.mustache
+++ b/config/clients/js/template/tests/helpers/nocks.ts.mustache
@@ -73,7 +73,7 @@ export const getNocks = ((nock: typeof Nock) => ({
   readAuthorizationModels: (
     storeId: string,
     basePath = defaultConfiguration.getBasePath(),
-    authorizationModels: AuthorizationModel[] = [{ id: "some-id", type_definitions: [] }],
+    authorizationModels: AuthorizationModel[] = [{ id: "some-id", schema_version: "1.1", type_definitions: [] }],
   ) => {
     return nock(basePath)
       .get(`/stores/${storeId}/authorization-models`)
@@ -96,7 +96,7 @@ export const getNocks = ((nock: typeof Nock) => ({
     storeId: string,
     configId: string,
     basePath = defaultConfiguration.getBasePath(),
-    authorizationModel: AuthorizationModel = { id: "some-id", type_definitions: [] },
+    authorizationModel: AuthorizationModel = { id: "some-id", schema_version: "1.1", type_definitions: [] },
   ) => {
     return nock(basePath)
       .get(`/stores/${storeId}/authorization-models/${configId}`)

--- a/config/clients/js/template/tests/index.test.ts.mustache
+++ b/config/clients/js/template/tests/index.test.ts.mustache
@@ -696,6 +696,7 @@ describe("{{appTitleCaseName}} SDK", function () {
     describe("writeAuthorizationModel", () => {
       it("should call the api and return the response", async () => {
         const authorizationModel = {
+          schema_version: "1.1",
           type_definitions: [
             { type: "workspace", relations: { admin: { this: {} } } },
           ],
@@ -727,6 +728,7 @@ describe("{{appTitleCaseName}} SDK", function () {
         expect(data).toMatchObject({
           authorization_model: {
             id: expect.any(String),
+            schema_version: "1.1",
             type_definitions: expect.arrayContaining([]),
           },
         });
@@ -735,14 +737,14 @@ describe("{{appTitleCaseName}} SDK", function () {
 
     describe("readAuthorizationModels", () => {
       it("should call the api and return the response", async () => {
-        const scope = nocks.readAuthorizationModels(baseConfig.storeId!, defaultConfiguration.getBasePath(), [{ id: "1", type_definitions: []}]);
+        const scope = nocks.readAuthorizationModels(baseConfig.storeId!, defaultConfiguration.getBasePath(), [{ id: "1", schema_version: "1.1", type_definitions: []}]);
 
         expect(scope.isDone()).toBe(false);
         const data = await fgaApi.readAuthorizationModels();
 
         expect(scope.isDone()).toBe(true);
         expect(data).toMatchObject({
-          authorization_models: expect.arrayContaining([{ id: "1", type_definitions: []}]),
+          authorization_models: expect.arrayContaining([{ id: "1", schema_version: "1.1", type_definitions: []}]),
         });
       });
     });

--- a/config/clients/python/template/README_calling_api.mustache
+++ b/config/clients/python/template/README_calling_api.mustache
@@ -115,7 +115,8 @@ async def write_authorization_model():
     # Create an instance of the API class
     api_client = openfga_sdk.ApiClient(configuration)
     api_instance = open_fga_api.OpenFgaApi(api_client)
-    type_definitions = WriteAuthorizationModelRequest(
+    body = WriteAuthorizationModelRequest(
+        schema_version = "1.1",
         type_definitions=[
             TypeDefinition(
                 type="user",
@@ -142,7 +143,7 @@ async def write_authorization_model():
         ],
     )
 
-    response = await api_instance.write_authorization_model(type_definitions)
+    response = await api_instance.write_authorization_model(body)
     # response.authorization_model_id = "1uHxCSuTP0VKPYSnkq1pbb1jeZw"
     await api_client.close()
 ```
@@ -167,7 +168,7 @@ async def read_authorization_id():
     id = "1uHxCSuTP0VKPYSnkq1pbb1jeZw" #  Assuming `1uHxCSuTP0VKPYSnkq1pbb1jeZw` is an id of an existing model
 
     response = await api_instance.read_authorization_model(id)
-    # response.authorization_model =  AuthorizationModel(id='1uHxCSuTP0VKPYSnkq1pbb1jeZw', type_definitions=type_definitions[...])
+    # response.authorization_model =  AuthorizationModel(id='1uHxCSuTP0VKPYSnkq1pbb1jeZw', schema_version = '1.1', type_definitions=type_definitions[...])
     await api_client.close()
 ```
 
@@ -189,7 +190,7 @@ async def read_authorization_models():
     api_instance = open_fga_api.OpenFgaApi(api_client)
 
     response = await api_instance.read_authorization_models()
-    # response.authorization_models = [AuthorizationModel(id='1uHxCSuTP0VKPYSnkq1pbb1jeZw', type_definitions=type_definitions[...], AuthorizationModel(id='GtQpMohWezFmIbyXxVEocOCxxgq', type_definitions=type_definitions[...])]
+    # response.authorization_models = [AuthorizationModel(id='1uHxCSuTP0VKPYSnkq1pbb1jeZw', schema_version = '1.1', type_definitions=type_definitions[...], AuthorizationModel(id='GtQpMohWezFmIbyXxVEocOCxxgq', schema_version = '1.1', type_definitions=type_definitions[...])]
     await api_client.close()
 ```
 

--- a/config/clients/python/template/api_test.mustache
+++ b/config/clients/python/template/api_test.mustache
@@ -488,6 +488,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
 {
   "authorization_model": {
     "id": "01G5JAVJ41T49E9TT3SKVS7X1J",
+    "schema_version":"1.1",
     "type_definitions": [
       {
         "type": "document",
@@ -550,7 +551,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
 		            )
                 )
             ]
-            authorization_model = AuthorizationModel(id='01G5JAVJ41T49E9TT3SKVS7X1J',
+            authorization_model = AuthorizationModel(id='01G5JAVJ41T49E9TT3SKVS7X1J', schema_version = "1.1",
                 type_definitions=type_definitions)
             self.assertEqual(api_response.authorization_model, authorization_model)
             mock_request.assert_called_once_with(
@@ -762,6 +763,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
 
             # example passing only required values which don't have defaults set
             body = WriteAuthorizationModelRequest(
+                schema_version = "1.1",
                 type_definitions=[
                     TypeDefinition(
                         type="document",
@@ -799,7 +801,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
                 headers=ANY,
                 query_params=[],
                 post_params=[],
-                body={"type_definitions":[{"type":"document","relations":{"writer":{"this":{}},"reader":{"union":{"child":[{"this":{}},{"computedUserset":{"object":"","relation":"writer"}}]}}}}]},
+                body={"schema_version":"1.1","type_definitions":[{"type":"document","relations":{"writer":{"this":{}},"reader":{"union":{"child":[{"this":{}},{"computedUserset":{"object":"","relation":"writer"}}]}}}}]},
                 _preload_content=ANY,
                 _request_timeout=None
             )


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- https://github.com/openfga/api/pull/71
- dotnet is done in https://github.com/openfga/sdk-generator/pull/104

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
