### PR TITLE
fix(dotnet-sdk): v0.2.3 with a fix to the interface of ClientListObjects

### DIFF
--- a/config/clients/dotnet/CHANGELOG.md.mustache
+++ b/config/clients/dotnet/CHANGELOG.md.mustache
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.3
+
+### [0.2.3](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.2.2...v0.2.3) (2023-04-13)
+- fix: changed interface of contextual tuples in `ClientListObjects` to be `ClientTupleKey` instead of `TupleKey`
+- fix: Client `WriteAuthorizationModel` now expects `ClientWriteAuthorizationModelRequest` instead of `WriteAuthorizationModelRequest`
+- chore: changed a few interfaces to expect interfaces instead of classes
+
 ## v0.2.2
 
 ### [0.2.2](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.2.1...v0.2.2) (2023-04-12)

--- a/config/clients/dotnet/config.overrides.json
+++ b/config/clients/dotnet/config.overrides.json
@@ -10,7 +10,7 @@
   "packageGuid": "b8d9e3e9-0156-4948-9de7-5e0d3f9c4d9e",
   "testPackageGuid": "d119dfae-509a-4eba-a973-645b739356fc",
   "packageName": "OpenFga.Sdk",
-  "packageVersion": "0.2.2",
+  "packageVersion": "0.2.3",
   "licenseUrl": "https://github.com/openfga/dotnet-sdk/blob/main/LICENSE",
   "fossaComplianceNoticeId": "f8ac2ec4-84fc-44f4-a617-5800cd3d180e",
   "termsOfService": "",
@@ -174,6 +174,10 @@
     },
     "Client/Model/ClientWriteAssertionsRequest.mustache": {
       "destinationFilename": "src/OpenFga.Sdk/Client/Model/ClientWriteAssertionsRequest.cs",
+      "templateType": "SupportingFiles"
+    },
+    "Client/Model/ClientWriteAuthorizationModelRequest.mustache": {
+      "destinationFilename": "src/OpenFga.Sdk/Client/Model/ClientWriteAuthorizationModelRequest.cs",
       "templateType": "SupportingFiles"
     },
     "Client/Model/ClientWriteOptions.mustache": {

--- a/config/clients/dotnet/template/Client/Client.mustache
+++ b/config/clients/dotnet/template/Client/Client.mustache
@@ -54,7 +54,7 @@ public class {{appShortName}}Client : IDisposable {
     /**
    * ListStores - Get a paginated list of stores.
    */
-    public async Task<ListStoresResponse> ListStores(ClientListStoresOptions? options = default,
+    public async Task<ListStoresResponse> ListStores(IClientListStoresOptions? options = default,
         CancellationToken cancellationToken = default) =>
         await api.ListStores(options?.PageSize, options?.ContinuationToken, cancellationToken);
 
@@ -86,14 +86,14 @@ public class {{appShortName}}Client : IDisposable {
      * ReadAuthorizationModels - Read all authorization models
      */
     public async Task<ReadAuthorizationModelsResponse> ReadAuthorizationModels(
-        ClientReadAuthorizationModelsOptions? options = default,
+        IClientReadAuthorizationModelsOptions? options = default,
         CancellationToken cancellationToken = default) =>
         await api.ReadAuthorizationModels(options?.PageSize, options?.ContinuationToken, cancellationToken);
 
     /**
      * WriteAuthorizationModel - Create a new version of the authorization model
      */
-    public async Task<WriteAuthorizationModelResponse> WriteAuthorizationModel(WriteAuthorizationModelRequest body,
+    public async Task<WriteAuthorizationModelResponse> WriteAuthorizationModel(ClientWriteAuthorizationModelRequest body,
         ClientRequestOptions? options = default,
         CancellationToken cancellationToken = default) =>
         await api.WriteAuthorizationModel(body, cancellationToken);
@@ -102,7 +102,7 @@ public class {{appShortName}}Client : IDisposable {
      * ReadAuthorizationModel - Read the current authorization model
      */
     public async Task<ReadAuthorizationModelResponse> ReadAuthorizationModel(
-        ClientReadAuthorizationModelOptions? options = default,
+        IClientReadAuthorizationModelOptions? options = default,
         CancellationToken cancellationToken = default) {
         var authorizationModelId = GetAuthorizationModelId(options);
         if (authorizationModelId == null) {
@@ -131,14 +131,14 @@ public class {{appShortName}}Client : IDisposable {
      * Read Changes - Read the list of historical relationship tuple writes and deletes
      */
     public async Task<ReadChangesResponse> ReadChanges(ClientReadChangesRequest body,
-        ClientReadChangesOptions? options = default,
+        IClientReadChangesOptions? options = default,
         CancellationToken cancellationToken = default) =>
         await api.ReadChanges(body.Type, options?.PageSize, options?.ContinuationToken, cancellationToken);
 
     /**
      * Read - Read tuples previously written to the store (does not evaluate)
      */
-    public async Task<ReadResponse> Read(ClientReadRequest body, ClientReadOptions? options = default,
+    public async Task<ReadResponse> Read(ClientReadRequest body, IClientReadOptions? options = default,
         CancellationToken cancellationToken = default) =>
         await api.Read(
             new ReadRequest {
@@ -148,7 +148,7 @@ public class {{appShortName}}Client : IDisposable {
     /**
      * Write - Create or delete relationship tuples
      */
-    public async Task<ClientWriteResponse> Write(ClientWriteRequest body, ClientWriteOptions? options = default,
+    public async Task<ClientWriteResponse> Write(ClientWriteRequest body, IClientWriteOptions? options = default,
         CancellationToken cancellationToken = default) {
         var maxPerChunk =
             options?.Transaction?.MaxPerChunk ??
@@ -172,10 +172,10 @@ public class {{appShortName}}Client : IDisposable {
             return new ClientWriteResponse {
                 Writes =
                     body.Writes?.ConvertAll(tupleKey =>
-                        new ClientWriteSingleResponse { TupleKey = tupleKey, Status = ClientWriteStatus.SUCCESS }) ??
+                        new ClientWriteSingleResponse { TupleKey = tupleKey.ToTupleKey(), Status = ClientWriteStatus.SUCCESS }) ??
                     new List<ClientWriteSingleResponse>(),
                 Deletes = body.Deletes?.ConvertAll(tupleKey => new ClientWriteSingleResponse {
-                    TupleKey = tupleKey,
+                    TupleKey = tupleKey.ToTupleKey(),
                     Status = ClientWriteStatus.SUCCESS
                 }) ?? new List<ClientWriteSingleResponse>()
             };
@@ -194,14 +194,14 @@ public class {{appShortName}}Client : IDisposable {
 
                     foreach (var tupleKey in writes) {
                         writeResponses.Add(new ClientWriteSingleResponse {
-                            TupleKey = tupleKey, Status = ClientWriteStatus.SUCCESS,
+                            TupleKey = tupleKey.ToTupleKey(), Status = ClientWriteStatus.SUCCESS,
                         });
                     }
                 }
                 catch (Exception e) {
                     foreach (var tupleKey in writes) {
                         writeResponses.Add(new ClientWriteSingleResponse {
-                            TupleKey = tupleKey, Status = ClientWriteStatus.FAILURE, Error = e,
+                            TupleKey = tupleKey.ToTupleKey(), Status = ClientWriteStatus.FAILURE, Error = e,
                         });
                     }
                 }
@@ -215,14 +215,14 @@ public class {{appShortName}}Client : IDisposable {
 
                     foreach (var tupleKey in deletes) {
                         deleteResponses.Add(new ClientWriteSingleResponse {
-                            TupleKey = tupleKey, Status = ClientWriteStatus.SUCCESS,
+                            TupleKey = tupleKey.ToTupleKey(), Status = ClientWriteStatus.SUCCESS,
                         });
                     }
                 }
                 catch (Exception e) {
                     foreach (var tupleKey in deletes) {
                         deleteResponses.Add(new ClientWriteSingleResponse {
-                            TupleKey = tupleKey, Status = ClientWriteStatus.FAILURE, Error = e,
+                            TupleKey = tupleKey.ToTupleKey(), Status = ClientWriteStatus.FAILURE, Error = e,
                         });
                     }
                 }
@@ -234,14 +234,14 @@ public class {{appShortName}}Client : IDisposable {
     /**
      * WriteTuples - Utility method to write tuples, wraps Write
      */
-    public async Task<ClientWriteResponse> WriteTuples(List<ClientTupleKey> body, ClientWriteOptions? options = default,
+    public async Task<ClientWriteResponse> WriteTuples(List<ClientTupleKey> body, IClientWriteOptions? options = default,
         CancellationToken cancellationToken = default) =>
         await Write(new ClientWriteRequest {Writes = body}, options, cancellationToken);
 
     /**
      * DeleteTuples - Utility method to delete tuples, wraps Write
      */
-    public async Task<ClientWriteResponse> DeleteTuples(List<ClientTupleKey> body, ClientWriteOptions? options = default,
+    public async Task<ClientWriteResponse> DeleteTuples(List<ClientTupleKey> body, IClientWriteOptions? options = default,
         CancellationToken cancellationToken = default) =>
         await Write(new ClientWriteRequest {Deletes = body}, options, cancellationToken);
 
@@ -252,7 +252,7 @@ public class {{appShortName}}Client : IDisposable {
     /**
    * Check - Check if a user has a particular relation with an object (evaluates)
    */
-    public async Task<CheckResponse> Check(ClientCheckRequest body,
+    public async Task<CheckResponse> Check(IClientCheckRequest body,
         IClientRequestOptionsWithAuthZModelId? options = default,
         CancellationToken cancellationToken = default) =>
         await api.Check(
@@ -293,7 +293,7 @@ public class {{appShortName}}Client : IDisposable {
     /**
    * Expand - Expands the relationships in userset tree format (evaluates)
    */
-    public async Task<ExpandResponse> Expand(ClientExpandRequest body,
+    public async Task<ExpandResponse> Expand(IClientExpandRequest body,
         IClientRequestOptionsWithAuthZModelId? options = default,
         CancellationToken cancellationToken = default) =>
         await api.Expand(
@@ -305,21 +305,25 @@ public class {{appShortName}}Client : IDisposable {
     /**
      * ListObjects - List the objects of a particular type that the user has a certain relation to (evaluates)
      */
-    public async Task<ListObjectsResponse> ListObjects(ClientListObjectsRequest body,
+    public async Task<ListObjectsResponse> ListObjects(IClientListObjectsRequest body,
         IClientRequestOptionsWithAuthZModelId? options = default,
         CancellationToken cancellationToken = default) =>
         await api.ListObjects(new ListObjectsRequest {
             User = body.User,
             Relation = body.Relation,
             Type = body.Type,
-            ContextualTuples = new ContextualTupleKeys {TupleKeys = body.ContextualTuples ?? new List<TupleKey>()},
+            ContextualTuples =
+                new ContextualTupleKeys {
+                    TupleKeys = body.ContextualTuples?.ConvertAll(tupleKey => tupleKey.ToTupleKey()) ??
+                                new List<TupleKey>()
+                },
             AuthorizationModelId = GetAuthorizationModelId(options)
         });
 
     /**
      * ListRelations - List all the relations a user has with an object (evaluates)
      */
-    public async Task<ListRelationsResponse> ListRelations(ClientListRelationsRequest body,
+    public async Task<ListRelationsResponse> ListRelations(IClientListRelationsRequest body,
         IClientBatchCheckOptions? options = default,
         CancellationToken cancellationToken = default) {
         if (body.Relations.Count == 0) {
@@ -354,7 +358,7 @@ public class {{appShortName}}Client : IDisposable {
     /**
    * ReadAssertions - Read assertions for a particular authorization model
    */
-    public async Task<ReadAssertionsResponse> ReadAssertions(ClientReadAssertionsOptions? options = default,
+    public async Task<ReadAssertionsResponse> ReadAssertions(IClientReadAssertionsOptions? options = default,
         CancellationToken cancellationToken = default) {
         var authorizationModelId = GetAuthorizationModelId(options);
         if (authorizationModelId == null) {
@@ -368,7 +372,7 @@ public class {{appShortName}}Client : IDisposable {
      * WriteAssertions - Updates assertions for a particular authorization model
      */
     public async Task WriteAssertions(List<ClientAssertion> body,
-        ClientWriteAssertionsOptions? options = default,
+        IClientWriteAssertionsOptions? options = default,
         CancellationToken cancellationToken = default) {
         var authorizationModelId = GetAuthorizationModelId(options);
         if (authorizationModelId == null) {

--- a/config/clients/dotnet/template/Client/Model/ClientCheckRequest.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientCheckRequest.mustache
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 
 namespace {{packageName}}.Client.Model;
 
-internal interface IClientCheckRequest {
+public interface IClientCheckRequest : IClientContextualTuplesWrapper {
     public string User { get; set; }
     public string Relation { get; set; }
     public string Object { get; set; }

--- a/config/clients/dotnet/template/Client/Model/ClientListObjectsRequest.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListObjectsRequest.mustache
@@ -1,6 +1,5 @@
 {{>partial_header}}
 
-using {{packageName}}.Model;
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 using System.Text.Json;
@@ -8,11 +7,10 @@ using System.Text.Json.Serialization;
 
 namespace {{packageName}}.Client.Model;
 
-internal interface IClientListObjectsRequest {
+public interface IClientListObjectsRequest : IClientContextualTuplesWrapper {
     public string User { get; set; }
     public string Relation { get; set; }
     public string Type { get; set; }
-    public List<TupleKey>? ContextualTuples { get; set; }
 }
 
 /// <summary>
@@ -46,7 +44,7 @@ public class ClientListObjectsRequest : IClientListObjectsRequest, IEquatable<Cl
     /// </summary>
     [DataMember(Name = "contextual_tuples", EmitDefaultValue = false)]
     [JsonPropertyName("contextual_tuples")]
-    public List<TupleKey>? ContextualTuples { get; set; }
+    public List<ClientTupleKey>? ContextualTuples { get; set; }
 
     public bool Equals(ClientListObjectsRequest input) {
         if (input == null) {

--- a/config/clients/dotnet/template/Client/Model/ClientListRelationsRequest.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListRelationsRequest.mustache
@@ -4,12 +4,11 @@ using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 
 namespace {{packageName}}.Client.Model;
-internal interface IClientListRelationsRequest {
+
+public interface IClientListRelationsRequest : IClientContextualTuplesWrapper {
     public string User { get; set; }
 
     public string Object { get; set; }
-
-    public List<ClientTupleKey> ContextualTuples { get; set; }
 
     public List<string> Relations { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientTupleKey.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientTupleKey.mustache
@@ -8,7 +8,17 @@ using System.Text.Json.Serialization;
 
 namespace {{packageName}}.Client.Model;
 
-public class ClientTupleKey : TupleKey {
+public interface IClientTupleKey {
+    public string User { get; set; }
+    public string Relation { get; set; }
+    public string Object { get; set; }
+}
+
+public interface IClientContextualTuplesWrapper {
+    public List<ClientTupleKey>? ContextualTuples { get; set; }
+}
+
+public class ClientTupleKey : IClientTupleKey {
     /// <summary>
     ///     Gets or Sets Object
     /// </summary>

--- a/config/clients/dotnet/template/Client/Model/ClientWriteAssertionsRequest.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientWriteAssertionsRequest.mustache
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 
 namespace {{packageName}}.Client.Model;
 
-internal interface IClientAssertion {
+public interface IClientAssertion {
     public string User { get; set; }
     public string Relation { get; set; }
     public string Object { get; set; }

--- a/config/clients/dotnet/template/Client/Model/ClientWriteAuthorizationModelRequest.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientWriteAuthorizationModelRequest.mustache
@@ -1,0 +1,9 @@
+{{>partial_header}}
+
+using {{packageName}}.Model;
+
+namespace {{packageName}}.Client.Model;
+
+/// <inheritdoc />
+public class ClientWriteAuthorizationModelRequest : WriteAuthorizationModelRequest {
+}

--- a/config/clients/dotnet/template/OpenFgaClientTests.mustache
+++ b/config/clients/dotnet/template/OpenFgaClientTests.mustache
@@ -292,7 +292,7 @@ public class {{appShortName}}ClientTests {
     [Fact]
     public async Task WriteAuthorizationModelTest() {
         const string authorizationModelId = "01GXSA8YR785C4FYS3C0RTG7B1";
-        var body = new WriteAuthorizationModelRequest {
+        var body = new ClientWriteAuthorizationModelRequest {
             SchemaVersion = "1.1",
             TypeDefinitions = new List<TypeDefinition> {
                 new() {
@@ -1136,10 +1136,18 @@ public class {{appShortName}}ClientTests {
             User = "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
             Relation = "can_read",
             Type = "document",
-            ContextualTuples = new List<TupleKey> {
-                new("folder:product", "editor", "user:81684243-9356-4421-8fbf-a4f8d36aa31b"),
-                new("document:roadmap", "parent", "folder:product")
-            }
+            ContextualTuples = new List<ClientTupleKey> {
+                new() {
+                    User = "folder:product",
+                    Relation = "editor",
+                    Object = "folder:product",
+                },
+                new() {
+                    User = "folder:product",
+                    Relation = "parent",
+                    Object = "document:roadmap",
+                },
+            },
         };
         var response = await fgaClient.ListObjects(body, new ClientWriteOptions {
             AuthorizationModelId = "01GXSA8YR785C4FYS3C0RTG7B1",
@@ -1199,7 +1207,7 @@ public class {{appShortName}}ClientTests {
                 Object = "document:roadmap",
                 Relations = new List<string> {"can_view", "can_edit", "can_delete", "can_rename"},
                 ContextualTuples = new List<ClientTupleKey>() {
-                    new ClientTupleKey {
+                    new() {
                         User = "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
                         Relation = "editor",
                         Object = "document:roadmap",

--- a/config/clients/dotnet/template/README_calling_api.mustache
+++ b/config/clients/dotnet/template/README_calling_api.mustache
@@ -95,7 +95,7 @@ Create a new authorization model.
 
 ```csharp
 
-var body = new WriteAuthorizationModelRequest {
+var body = new ClientWriteAuthorizationModelRequest {
     SchemaVersion = "1.1",
     TypeDefinitions = new List<TypeDefinition> {
         new() {Type = "user", Relations = new Dictionary<string, Userset>()},
@@ -468,11 +468,13 @@ var body = new ClientListObjectsRequest {
     User = "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     Relation = "viewer",
     Type = "document",
-    ContextualTuples = new List<TupleKey>() {
-        {
-            new("document:budget", "writer", "user:81684243-9356-4421-8fbf-a4f8d36aa31b")
-        }
-    }
+    ContextualTuples = new List<ClientTupleKey> {
+        new() {
+            User = "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+            Relation = "writer",
+            Object = "document:budget",
+        },
+    },
 };
 var response = await fgaClient.ListObjects(body, options);
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

- fix: changed interface of contextual tuples in `ClientListObjects` to be `ClientTupleKey` instead of `TupleKey`
- fix: Client `WriteAuthorizationModel` now expects `ClientWriteAuthorizationModelRequest` instead of `WriteAuthorizationModelRequest`
- chore: changed a few interfaces to expect interfaces instead of classes

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- fixes: https://github.com/openfga/dotnet-sdk/issues/17

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
