### PR TITLE
fix(go-sdk): change SDK ClientRequest to be interface

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -131,54 +131,54 @@ type SdkClient interface {
 	/*
 	 * ListStores Get a paginated list of stores.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientListStoresRequest
+	 * @return SdkClientListStoresRequestInterface
 	 */
-	ListStores(ctx _context.Context) SdkClientListStoresRequest
+	ListStores(ctx _context.Context) SdkClientListStoresRequestInterface
 
 	/*
 	 * ListStoresExecute executes the ListStores request
 	 * @return *ClientListStoresResponse
 	 */
-	ListStoresExecute(request SdkClientListStoresRequest) (*ClientListStoresResponse, error)
+	ListStoresExecute(request SdkClientListStoresRequestInterface) (*ClientListStoresResponse, error)
 
 	/*
 	 * CreateStore Create and initialize a store
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientCreateStoreRequest
+	 * @return SdkClientCreateStoreRequestInterface
 	 */
-	CreateStore(ctx _context.Context) SdkClientCreateStoreRequest
+	CreateStore(ctx _context.Context) SdkClientCreateStoreRequestInterface
 
 	/*
 	 * CreateStoreExecute executes the CreateStore request
 	 * @return *ClientCreateStoreResponse
 	 */
-	CreateStoreExecute(request SdkClientCreateStoreRequest) (*ClientCreateStoreResponse, error)
+	CreateStoreExecute(request SdkClientCreateStoreRequestInterface) (*ClientCreateStoreResponse, error)
 
 	/*
 	 * GetStore Get information about the current store.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientGetStoreRequest
+	 * @return SdkClientGetStoreRequestInterface
 	 */
-	GetStore(ctx _context.Context) SdkClientGetStoreRequest
+	GetStore(ctx _context.Context) SdkClientGetStoreRequestInterface
 
 	/*
 	 * GetStoreExecute executes the GetStore request
 	 * @return *ClientGetStoreResponse
 	 */
-	GetStoreExecute(request SdkClientGetStoreRequest) (*ClientGetStoreResponse, error)
+	GetStoreExecute(request SdkClientGetStoreRequestInterface) (*ClientGetStoreResponse, error)
 
 	/*
 	 * DeleteStore Delete a store.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientDeleteStoreRequest
+	 * @return SdkClientDeleteStoreRequestInterface
 	 */
-	DeleteStore(ctx _context.Context) SdkClientDeleteStoreRequest
+	DeleteStore(ctx _context.Context) SdkClientDeleteStoreRequestInterface
 
 	/*
 	 * DeleteStoreExecute executes the DeleteStore request
 	 * @return *ClientDeleteStoreResponse
 	 */
-	DeleteStoreExecute(request SdkClientDeleteStoreRequest) (*ClientDeleteStoreResponse, error)
+	DeleteStoreExecute(request SdkClientDeleteStoreRequestInterface) (*ClientDeleteStoreResponse, error)
 
 	/* Authorization Models */
 
@@ -187,26 +187,26 @@ type SdkClient interface {
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return SdkClientReadAuthorizationModelsRequest
 	 */
-	ReadAuthorizationModels(ctx _context.Context) SdkClientReadAuthorizationModelsRequest
+	ReadAuthorizationModels(ctx _context.Context) SdkClientReadAuthorizationModelsRequestInterface
 
 	/*
 	 * ReadAuthorizationModelsExecute executes the ReadAuthorizationModels request
 	 * @return *ClientReadAuthorizationModelsResponse
 	 */
-	ReadAuthorizationModelsExecute(request SdkClientReadAuthorizationModelsRequest) (*ClientReadAuthorizationModelsResponse, error)
+	ReadAuthorizationModelsExecute(request SdkClientReadAuthorizationModelsRequestInterface) (*ClientReadAuthorizationModelsResponse, error)
 
 	/*
 	 * WriteAuthorizationModel Create a new authorization model.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return SdkClientWriteAuthorizationModelRequest
 	 */
-	WriteAuthorizationModel(ctx _context.Context) SdkClientWriteAuthorizationModelRequest
+	WriteAuthorizationModel(ctx _context.Context) SdkClientWriteAuthorizationModelRequestInterface
 
 	/*
 	 * WriteAuthorizationModelExecute executes the WriteAuthorizationModel request
 	 * @return *ClientWriteAuthorizationModelResponse
 	 */
-	WriteAuthorizationModelExecute(request SdkClientWriteAuthorizationModelRequest) (*ClientWriteAuthorizationModelResponse, error)
+	WriteAuthorizationModelExecute(request SdkClientWriteAuthorizationModelRequestInterface) (*ClientWriteAuthorizationModelResponse, error)
 
 	/*
 	 * ReadAuthorizationModel Read a particular authorization model.
@@ -239,162 +239,162 @@ type SdkClient interface {
 	/*
 	 * ReadChanges Reads the list of historical relationship tuple writes and deletes.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientReadChangesRequest
+	 * @return SdkClientReadChangesRequestInterface
 	 */
-	ReadChanges(ctx _context.Context) SdkClientReadChangesRequest
+	ReadChanges(ctx _context.Context) SdkClientReadChangesRequestInterface
 
 	/*
 	 * ReadChangesExecute executes the ReadChanges request
 	 * @return *ClientReadChangesResponse
 	 */
-	ReadChangesExecute(request SdkClientReadChangesRequest) (*ClientReadChangesResponse, error)
+	ReadChangesExecute(request SdkClientReadChangesRequestInterface) (*ClientReadChangesResponse, error)
 
 	/*
 	 * Read Reads the relationship tuples stored in the database. It does not evaluate nor exclude invalid tuples according to the authorization model.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientReadRequest
+	 * @return SdkClientReadRequestInterface
 	 */
-	Read(ctx _context.Context) SdkClientReadRequest
+	Read(ctx _context.Context) SdkClientReadRequestInterface
 
 	/*
 	 * ReadExecute executes the Read request
 	 * @return *ClientReadResponse
 	 */
-	ReadExecute(request SdkClientReadRequest) (*ClientReadResponse, error)
+	ReadExecute(request SdkClientReadRequestInterface) (*ClientReadResponse, error)
 
 	/*
 	 * Write Create and/or delete relationship tuples to update the system state.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientWriteRequest
+	 * @return SdkClientWriteRequestInterface
 	 */
-	Write(ctx _context.Context) SdkClientWriteRequest
+	Write(ctx _context.Context) SdkClientWriteRequestInterface
 
 	/*
 	 * WriteExecute executes the Write request
 	 * @return *ClientWriteResponse
 	 */
-	WriteExecute(request SdkClientWriteRequest) (*ClientWriteResponse, error)
+	WriteExecute(request SdkClientWriteRequestInterface) (*ClientWriteResponse, error)
 
 	/*
 	 * WriteTuples Utility method around Write
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientWriteTuplesRequest
+	 * @return SdkClientWriteTuplesRequestInterface
 	 */
-	WriteTuples(ctx _context.Context) SdkClientWriteTuplesRequest
+	WriteTuples(ctx _context.Context) SdkClientWriteTuplesRequestInterface
 
 	/*
 	 * WriteTuplesExecute executes the WriteTuples request
 	 * @return *ClientWriteResponse
 	 */
-	WriteTuplesExecute(request SdkClientWriteTuplesRequest) (*ClientWriteResponse, error)
+	WriteTuplesExecute(request SdkClientWriteTuplesRequestInterface) (*ClientWriteResponse, error)
 
 	/*
 	 * DeleteTuples Utility method around Write
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientDeleteTuplesRequest
+	 * @return SdkClientDeleteTuplesRequestInterface
 	 */
-	DeleteTuples(ctx _context.Context) SdkClientDeleteTuplesRequest
+	DeleteTuples(ctx _context.Context) SdkClientDeleteTuplesRequestInterface
 
 	/*
 	 * DeleteTuplesExecute executes the DeleteTuples request
 	 * @return *ClientWriteResponse
 	 */
-	DeleteTuplesExecute(request SdkClientDeleteTuplesRequest) (*ClientWriteResponse, error)
+	DeleteTuplesExecute(request SdkClientDeleteTuplesRequestInterface) (*ClientWriteResponse, error)
 
 	/* Relationship Queries */
 
 	/*
 	 * Check Check if a user has a particular relation with an object.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientCheckRequest
+	 * @return SdkClientCheckRequestInterface
 	 */
-	Check(ctx _context.Context) SdkClientCheckRequest
+	Check(ctx _context.Context) SdkClientCheckRequestInterface
 
 	/*
 	 * CheckExecute executes the Check request
 	 * @return *ClientCheckResponse
 	 */
-	CheckExecute(request SdkClientCheckRequest) (*ClientCheckResponse, error)
+	CheckExecute(request SdkClientCheckRequestInterface) (*ClientCheckResponse, error)
 
 	/*
 	 * BatchCheck Run a set of [checks](#check). Batch Check will return `allowed: false` if it encounters an error, and will return the error in the body.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientBatchCheckRequest
+	 * @return SdkClientBatchCheckRequestInterface
 	 */
-	BatchCheck(ctx _context.Context) SdkClientBatchCheckRequest
+	BatchCheck(ctx _context.Context) SdkClientBatchCheckRequestInterface
 
 	/*
 	 * BatchCheckExecute executes the BatchCheck request
 	 * @return *ClientBatchCheckResponse
 	 */
-	BatchCheckExecute(request SdkClientBatchCheckRequest) (*ClientBatchCheckResponse, error)
+	BatchCheckExecute(request SdkClientBatchCheckRequestInterface) (*ClientBatchCheckResponse, error)
 
 	/*
 	 * Expand Expands the relationships in userset tree format.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientExpandRequest
+	 * @return SdkClientExpandRequestInterface
 	 */
-	Expand(ctx _context.Context) SdkClientExpandRequest
+	Expand(ctx _context.Context) SdkClientExpandRequestInterface
 
 	/*
 	 * ExpandExecute executes the Expand request
 	 * @return *ClientExpandResponse
 	 */
-	ExpandExecute(request SdkClientExpandRequest) (*ClientExpandResponse, error)
+	ExpandExecute(request SdkClientExpandRequestInterface) (*ClientExpandResponse, error)
 
 	/*
 	 * ListObjects List the objects of a particular type a user has access to.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientListObjectsRequest
+	 * @return SdkClientListObjectsRequestInterface
 	 */
-	ListObjects(ctx _context.Context) SdkClientListObjectsRequest
+	ListObjects(ctx _context.Context) SdkClientListObjectsRequestInterface
 
 	/*
 	 * ListObjectsExecute executes the ListObjects request
 	 * @return *ClientListObjectsResponse
 	 */
-	ListObjectsExecute(request SdkClientListObjectsRequest) (*ClientListObjectsResponse, error)
+	ListObjectsExecute(request SdkClientListObjectsRequestInterface) (*ClientListObjectsResponse, error)
 
 	/*
 	 * ListRelations List the relations a user has on an object.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientListRelationsRequest
+	 * @return SdkClientListRelationsRequestInterface
 	 */
-	ListRelations(ctx _context.Context) SdkClientListRelationsRequest
+	ListRelations(ctx _context.Context) SdkClientListRelationsRequestInterface
 
 	/*
 	 * ListRelationsExecute executes the ListRelations request
 	 * @return *ClientListRelationsResponse
 	 */
-	ListRelationsExecute(request SdkClientListRelationsRequest) (*ClientListRelationsResponse, error)
+	ListRelationsExecute(request SdkClientListRelationsRequestInterface) (*ClientListRelationsResponse, error)
 
 	/* Assertions */
 
 	/*
 	 * ReadAssertions Read assertions for a particular authorization model.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientReadAssertionsRequest
+	 * @return SdkClientReadAssertionsRequestInterface
 	 */
-	ReadAssertions(ctx _context.Context) SdkClientReadAssertionsRequest
+	ReadAssertions(ctx _context.Context) SdkClientReadAssertionsRequestInterface
 
 	/*
 	 * ReadAssertionsExecute executes the ReadAssertions request
 	 * @return *ClientReadAssertionsResponse
 	 */
-	ReadAssertionsExecute(request SdkClientReadAssertionsRequest) (*ClientReadAssertionsResponse, error)
+	ReadAssertionsExecute(request SdkClientReadAssertionsRequestInterface) (*ClientReadAssertionsResponse, error)
 
 	/*
 	 * WriteAssertions Update the assertions for a particular authorization model.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientWriteAssertionsRequest
+	 * @return SdkClientWriteAssertionsRequestInterface
 	 */
-	WriteAssertions(ctx _context.Context) SdkClientWriteAssertionsRequest
+	WriteAssertions(ctx _context.Context) SdkClientWriteAssertionsRequestInterface
 
 	/*
 	 * WriteAssertionsExecute executes the WriteAssertions request
 	 * @return *ClientWriteAssertionsResponse
 	 */
-	WriteAssertionsExecute(request SdkClientWriteAssertionsRequest) (*ClientWriteAssertionsResponse, error)
+	WriteAssertionsExecute(request SdkClientWriteAssertionsRequestInterface) (*ClientWriteAssertionsResponse, error)
 }
 
 func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModelId *string) *string {
@@ -409,9 +409,16 @@ func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModel
 // / ListStores
 type SdkClientListStoresRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	options *ClientListStoresOptions
+}
+
+type SdkClientListStoresRequestInterface interface {
+	Options(options ClientListStoresOptions) SdkClientListStoresRequestInterface
+	Execute() (*ClientListStoresResponse, error)
+	GetContext()  _context.Context
+	GetOptions() *ClientListStoresOptions
 }
 
 type ClientListStoresOptions struct {
@@ -421,22 +428,30 @@ type ClientListStoresOptions struct {
 
 type ClientListStoresResponse = {{packageName}}.ListStoresResponse
 
-func (request SdkClientListStoresRequest) Options(options ClientListStoresOptions) SdkClientListStoresRequest {
+func (request *SdkClientListStoresRequest) Options(options ClientListStoresOptions) SdkClientListStoresRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientListStoresRequest) Execute() (*ClientListStoresResponse, error) {
+func (request *SdkClientListStoresRequest) Execute() (*ClientListStoresResponse, error) {
 	return request.Client.ListStoresExecute(request)
 }
 
-func (client *{{appShortName}}Client) ListStoresExecute(request SdkClientListStoresRequest) (*ClientListStoresResponse, error) {
-	req := client.{{appShortName}}Api.ListStores(request.ctx)
-	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.options))
+func (request *SdkClientListStoresRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientListStoresRequest) GetOptions() *ClientListStoresOptions {
+	return request.options
+}
+
+func (client *{{appShortName}}Client) ListStoresExecute(request SdkClientListStoresRequestInterface) (*ClientListStoresResponse, error) {
+	req := client.{{appShortName}}Api.ListStores(request.GetContext())
+	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
 		req.PageSize(*pageSize)
 	}
-	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.options))
+	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
 		req.ContinuationToken(*continuationToken)
 	}
@@ -447,20 +462,30 @@ func (client *{{appShortName}}Client) ListStoresExecute(request SdkClientListSto
 	return &data, nil
 }
 
-func (client *{{appShortName}}Client) ListStores(ctx _context.Context) SdkClientListStoresRequest {
-	return SdkClientListStoresRequest{
+func (client *{{appShortName}}Client) ListStores(ctx _context.Context) SdkClientListStoresRequestInterface {
+	return &SdkClientListStoresRequest{
 		ctx:    ctx,
-		Client: *client,
+		Client: client,
 	}
 }
 
 // / CreateStore
 type SdkClientCreateStoreRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientCreateStoreRequest
 	options *ClientCreateStoreOptions
+}
+
+type SdkClientCreateStoreRequestInterface interface {
+    Options(options ClientCreateStoreOptions) SdkClientCreateStoreRequestInterface
+    Body(body ClientCreateStoreRequest) SdkClientCreateStoreRequestInterface
+    Execute()  (*ClientCreateStoreResponse, error)
+
+    GetContext() _context.Context
+    GetOptions() *ClientCreateStoreOptions
+    GetBody() *ClientCreateStoreRequest
 }
 
 type ClientCreateStoreRequest struct {
@@ -472,23 +497,35 @@ type ClientCreateStoreOptions struct {
 
 type ClientCreateStoreResponse = {{packageName}}.CreateStoreResponse
 
-func (request SdkClientCreateStoreRequest) Options(options ClientCreateStoreOptions) SdkClientCreateStoreRequest {
+func (request *SdkClientCreateStoreRequest) Options(options ClientCreateStoreOptions) SdkClientCreateStoreRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientCreateStoreRequest) Body(body ClientCreateStoreRequest) SdkClientCreateStoreRequest {
+func (request *SdkClientCreateStoreRequest) Body(body ClientCreateStoreRequest) SdkClientCreateStoreRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientCreateStoreRequest) Execute() (*ClientCreateStoreResponse, error) {
+func (request *SdkClientCreateStoreRequest) Execute() (*ClientCreateStoreResponse, error) {
 	return request.Client.CreateStoreExecute(request)
 }
 
-func (client *{{appShortName}}Client) CreateStoreExecute(request SdkClientCreateStoreRequest) (*ClientCreateStoreResponse, error) {
-	data, _, err := client.{{appShortName}}Api.CreateStore(request.ctx).Body({{packageName}}.CreateStoreRequest{
-		Name: request.body.Name,
+func (request *SdkClientCreateStoreRequest) GetContext() _context.Context{
+	return request.ctx
+}
+
+func (request *SdkClientCreateStoreRequest) GetOptions() *ClientCreateStoreOptions{
+	return request.options
+}
+
+func (request *SdkClientCreateStoreRequest) GetBody() *ClientCreateStoreRequest{
+	return request.body
+}
+
+func (client *{{appShortName}}Client) CreateStoreExecute(request SdkClientCreateStoreRequestInterface) (*ClientCreateStoreResponse, error) {
+	data, _, err := client.{{appShortName}}Api.CreateStore(request.GetContext()).Body({{packageName}}.CreateStoreRequest{
+		Name: request.GetBody().Name,
 	}).Execute()
 	if err != nil {
 		return nil, err
@@ -496,9 +533,9 @@ func (client *{{appShortName}}Client) CreateStoreExecute(request SdkClientCreate
 	return &data, nil
 }
 
-func (client *{{appShortName}}Client) CreateStore(ctx _context.Context) SdkClientCreateStoreRequest {
-	return SdkClientCreateStoreRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) CreateStore(ctx _context.Context) SdkClientCreateStoreRequestInterface {
+	return &SdkClientCreateStoreRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
@@ -506,9 +543,17 @@ func (client *{{appShortName}}Client) CreateStore(ctx _context.Context) SdkClien
 // / GetStore
 type SdkClientGetStoreRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	options *ClientGetStoreOptions
+}
+
+type SdkClientGetStoreRequestInterface interface{
+	Options(options ClientGetStoreOptions) SdkClientGetStoreRequestInterface
+	Execute() (*ClientGetStoreResponse, error)
+
+    GetContext() _context.Context
+    GetOptions() *ClientGetStoreOptions
 }
 
 type ClientGetStoreOptions struct {
@@ -516,26 +561,34 @@ type ClientGetStoreOptions struct {
 
 type ClientGetStoreResponse = {{packageName}}.GetStoreResponse
 
-func (request SdkClientGetStoreRequest) Options(options ClientGetStoreOptions) SdkClientGetStoreRequest {
+func (request *SdkClientGetStoreRequest) Options(options ClientGetStoreOptions) SdkClientGetStoreRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientGetStoreRequest) Execute() (*ClientGetStoreResponse, error) {
+func (request *SdkClientGetStoreRequest) Execute() (*ClientGetStoreResponse, error) {
 	return request.Client.GetStoreExecute(request)
 }
 
-func (client *{{appShortName}}Client) GetStoreExecute(request SdkClientGetStoreRequest) (*ClientGetStoreResponse, error) {
-	data, _, err := client.{{appShortName}}Api.GetStore(request.ctx).Execute()
+func (request *SdkClientGetStoreRequest) GetContext() _context.Context{
+	return request.ctx
+}
+
+func (request *SdkClientGetStoreRequest) GetOptions() *ClientGetStoreOptions{
+	return request.options
+}
+
+func (client *{{appShortName}}Client) GetStoreExecute(request SdkClientGetStoreRequestInterface) (*ClientGetStoreResponse, error) {
+	data, _, err := client.{{appShortName}}Api.GetStore(request.GetContext()).Execute()
 	if err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (client *{{appShortName}}Client) GetStore(ctx _context.Context) SdkClientGetStoreRequest {
-	return SdkClientGetStoreRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) GetStore(ctx _context.Context) SdkClientGetStoreRequestInterface {
+	return &SdkClientGetStoreRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
@@ -543,35 +596,53 @@ func (client *{{appShortName}}Client) GetStore(ctx _context.Context) SdkClientGe
 // / DeleteStore
 type SdkClientDeleteStoreRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	options *ClientDeleteStoreOptions
 }
+
+type SdkClientDeleteStoreRequestInterface interface{
+	Options(options ClientDeleteStoreOptions) SdkClientDeleteStoreRequestInterface
+	Execute() (*ClientDeleteStoreResponse, error)	
+
+    GetContext() _context.Context
+    GetOptions() *ClientDeleteStoreOptions
+}
+
 type ClientDeleteStoreOptions struct {
 }
 
 type ClientDeleteStoreResponse struct{}
 
-func (request SdkClientDeleteStoreRequest) Options(options ClientDeleteStoreOptions) SdkClientDeleteStoreRequest {
+func (request *SdkClientDeleteStoreRequest) Options(options ClientDeleteStoreOptions) SdkClientDeleteStoreRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientDeleteStoreRequest) Execute() (*ClientDeleteStoreResponse, error) {
+func (request *SdkClientDeleteStoreRequest) Execute() (*ClientDeleteStoreResponse, error) {
 	return request.Client.DeleteStoreExecute(request)
 }
 
-func (client *{{appShortName}}Client) DeleteStoreExecute(request SdkClientDeleteStoreRequest) (*ClientDeleteStoreResponse, error) {
-	_, err := client.{{appShortName}}Api.DeleteStore(request.ctx).Execute()
+func (request *SdkClientDeleteStoreRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientDeleteStoreRequest) GetOptions() *ClientDeleteStoreOptions {
+	return request.options
+}
+
+
+func (client *{{appShortName}}Client) DeleteStoreExecute(request SdkClientDeleteStoreRequestInterface) (*ClientDeleteStoreResponse, error) {
+	_, err := client.{{appShortName}}Api.DeleteStore(request.GetContext()).Execute()
 	if err != nil {
 		return nil, err
 	}
 	return &ClientDeleteStoreResponse{}, nil
 }
 
-func (client *{{appShortName}}Client) DeleteStore(ctx _context.Context) SdkClientDeleteStoreRequest {
-	return SdkClientDeleteStoreRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) DeleteStore(ctx _context.Context) SdkClientDeleteStoreRequestInterface {
+	return &SdkClientDeleteStoreRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
@@ -581,9 +652,17 @@ func (client *{{appShortName}}Client) DeleteStore(ctx _context.Context) SdkClien
 // / ReadAuthorizationModels
 type SdkClientReadAuthorizationModelsRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	options *ClientReadAuthorizationModelsOptions
+}
+
+type SdkClientReadAuthorizationModelsRequestInterface interface{
+    Options(options ClientReadAuthorizationModelsOptions) SdkClientReadAuthorizationModelsRequestInterface
+	Execute() (*ClientReadAuthorizationModelsResponse, error)
+
+	GetContext() _context.Context
+	GetOptions() *ClientReadAuthorizationModelsOptions
 }
 
 type ClientReadAuthorizationModelsOptions struct {
@@ -593,22 +672,30 @@ type ClientReadAuthorizationModelsOptions struct {
 
 type ClientReadAuthorizationModelsResponse = {{packageName}}.ReadAuthorizationModelsResponse
 
-func (request SdkClientReadAuthorizationModelsRequest) Options(options ClientReadAuthorizationModelsOptions) SdkClientReadAuthorizationModelsRequest {
+func (request *SdkClientReadAuthorizationModelsRequest) Options(options ClientReadAuthorizationModelsOptions) SdkClientReadAuthorizationModelsRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientReadAuthorizationModelsRequest) Execute() (*ClientReadAuthorizationModelsResponse, error) {
+func (request *SdkClientReadAuthorizationModelsRequest) Execute() (*ClientReadAuthorizationModelsResponse, error) {
 	return request.Client.ReadAuthorizationModelsExecute(request)
 }
 
-func (client *{{appShortName}}Client) ReadAuthorizationModelsExecute(request SdkClientReadAuthorizationModelsRequest) (*ClientReadAuthorizationModelsResponse, error) {
-	req := client.{{appShortName}}Api.ReadAuthorizationModels(request.ctx)
-	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.options))
+func (request *SdkClientReadAuthorizationModelsRequest) GetContext() _context.Context {
+    return request.ctx
+}
+
+func (request *SdkClientReadAuthorizationModelsRequest) GetOptions() *ClientReadAuthorizationModelsOptions {
+    return request.options
+}
+
+func (client *{{appShortName}}Client) ReadAuthorizationModelsExecute(request SdkClientReadAuthorizationModelsRequestInterface) (*ClientReadAuthorizationModelsResponse, error) {
+	req := client.{{appShortName}}Api.ReadAuthorizationModels(request.GetContext())
+	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
 		req.PageSize(*pageSize)
 	}
-	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.options))
+	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
 		req.ContinuationToken(*continuationToken)
 	}
@@ -619,9 +706,9 @@ func (client *{{appShortName}}Client) ReadAuthorizationModelsExecute(request Sdk
 	return &data, nil
 }
 
-func (client *{{appShortName}}Client) ReadAuthorizationModels(ctx _context.Context) SdkClientReadAuthorizationModelsRequest {
-	return SdkClientReadAuthorizationModelsRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) ReadAuthorizationModels(ctx _context.Context) SdkClientReadAuthorizationModelsRequestInterface {
+	return &SdkClientReadAuthorizationModelsRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
@@ -629,11 +716,22 @@ func (client *{{appShortName}}Client) ReadAuthorizationModels(ctx _context.Conte
 // / WriteAuthorizationModel
 type SdkClientWriteAuthorizationModelRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientWriteAuthorizationModelRequest
 	options *ClientWriteAuthorizationModelOptions
 }
+
+type SdkClientWriteAuthorizationModelRequestInterface interface {
+    Options(options ClientWriteAuthorizationModelOptions) SdkClientWriteAuthorizationModelRequestInterface
+	Body(body ClientWriteAuthorizationModelRequest) SdkClientWriteAuthorizationModelRequestInterface
+	Execute() (*ClientWriteAuthorizationModelResponse, error)
+
+	GetBody() *ClientWriteAuthorizationModelRequest
+	GetOptions() *ClientWriteAuthorizationModelOptions
+	GetContext() _context.Context
+}
+
 
 type ClientWriteAuthorizationModelRequest struct {
 	TypeDefinitions []{{packageName}}.TypeDefinition `json:"type_definitions"`
@@ -645,24 +743,36 @@ type ClientWriteAuthorizationModelOptions struct {
 
 type ClientWriteAuthorizationModelResponse = {{packageName}}.WriteAuthorizationModelResponse
 
-func (request SdkClientWriteAuthorizationModelRequest) Options(options ClientWriteAuthorizationModelOptions) SdkClientWriteAuthorizationModelRequest {
+func (request *SdkClientWriteAuthorizationModelRequest) Options(options ClientWriteAuthorizationModelOptions) SdkClientWriteAuthorizationModelRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientWriteAuthorizationModelRequest) Body(body ClientWriteAuthorizationModelRequest) SdkClientWriteAuthorizationModelRequest {
+func (request *SdkClientWriteAuthorizationModelRequest) Body(body ClientWriteAuthorizationModelRequest) SdkClientWriteAuthorizationModelRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientWriteAuthorizationModelRequest) Execute() (*ClientWriteAuthorizationModelResponse, error) {
+func (request *SdkClientWriteAuthorizationModelRequest) Execute() (*ClientWriteAuthorizationModelResponse, error) {
 	return request.Client.WriteAuthorizationModelExecute(request)
 }
 
-func (client *{{appShortName}}Client) WriteAuthorizationModelExecute(request SdkClientWriteAuthorizationModelRequest) (*ClientWriteAuthorizationModelResponse, error) {
-	data, _, err := client.{{appShortName}}Api.WriteAuthorizationModel(request.ctx).Body({{packageName}}.WriteAuthorizationModelRequest{
-		TypeDefinitions: request.body.TypeDefinitions,
-		SchemaVersion:   {{packageName}}.PtrString(request.body.SchemaVersion),
+func (request *SdkClientWriteAuthorizationModelRequest) GetBody() *ClientWriteAuthorizationModelRequest{
+	return request.body
+}
+
+func (request *SdkClientWriteAuthorizationModelRequest) GetOptions() *ClientWriteAuthorizationModelOptions{
+	return request.options
+}
+
+func (request *SdkClientWriteAuthorizationModelRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (client *{{appShortName}}Client) WriteAuthorizationModelExecute(request SdkClientWriteAuthorizationModelRequestInterface) (*ClientWriteAuthorizationModelResponse, error) {
+	data, _, err := client.{{appShortName}}Api.WriteAuthorizationModel(request.GetContext()).Body({{packageName}}.WriteAuthorizationModelRequest{
+		TypeDefinitions: request.GetBody().TypeDefinitions,
+		SchemaVersion:   {{packageName}}.PtrString(request.GetBody().SchemaVersion),
 	}).Execute()
 	if err != nil {
 		return nil, err
@@ -670,9 +780,9 @@ func (client *{{appShortName}}Client) WriteAuthorizationModelExecute(request Sdk
 	return &data, nil
 }
 
-func (client *{{appShortName}}Client) WriteAuthorizationModel(ctx _context.Context) SdkClientWriteAuthorizationModelRequest {
-	return SdkClientWriteAuthorizationModelRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) WriteAuthorizationModel(ctx _context.Context) SdkClientWriteAuthorizationModelRequestInterface {
+	return &SdkClientWriteAuthorizationModelRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
@@ -680,10 +790,21 @@ func (client *{{appShortName}}Client) WriteAuthorizationModel(ctx _context.Conte
 // / ReadAuthorizationModel
 type SdkClientReadAuthorizationModelRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientReadAuthorizationModelRequest
 	options *ClientReadAuthorizationModelOptions
+}
+
+type SdkClientReadAuthorizationModelRequestInterface interface {
+    Options(options ClientReadAuthorizationModelOptions) SdkClientReadAuthorizationModelRequestInterface
+    Body(body ClientReadAuthorizationModelRequest) SdkClientReadAuthorizationModelRequestInterface
+    Execute() (*ClientReadAuthorizationModelResponse, error)
+	GetAuthorizationModelIdOverride() *string
+
+	GetContext() _context.Context
+	GetBody()  *ClientReadAuthorizationModelRequest
+	GetOptions()  *ClientReadAuthorizationModelOptions
 }
 
 type ClientReadAuthorizationModelRequest struct {
@@ -695,42 +816,55 @@ type ClientReadAuthorizationModelOptions struct {
 
 type ClientReadAuthorizationModelResponse = {{packageName}}.ReadAuthorizationModelResponse
 
-func (request SdkClientReadAuthorizationModelRequest) Options(options ClientReadAuthorizationModelOptions) SdkClientReadAuthorizationModelRequest {
+func (request *SdkClientReadAuthorizationModelRequest) Options(options ClientReadAuthorizationModelOptions) SdkClientReadAuthorizationModelRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientReadAuthorizationModelRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientReadAuthorizationModelRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientReadAuthorizationModelRequest) Body(body ClientReadAuthorizationModelRequest) SdkClientReadAuthorizationModelRequest {
+func (request *SdkClientReadAuthorizationModelRequest) Body(body ClientReadAuthorizationModelRequest) SdkClientReadAuthorizationModelRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientReadAuthorizationModelRequest) Execute() (*ClientReadAuthorizationModelResponse, error) {
+func (request *SdkClientReadAuthorizationModelRequest) Execute() (*ClientReadAuthorizationModelResponse, error) {
 	return request.Client.ReadAuthorizationModelExecute(request)
 }
 
-func (client *{{appShortName}}Client) ReadAuthorizationModelExecute(request SdkClientReadAuthorizationModelRequest) (*ClientReadAuthorizationModelResponse, error) {
-	authorizationModelId := client.getAuthorizationModelId(request.getAuthorizationModelIdOverride())
+func (request *SdkClientReadAuthorizationModelRequest) GetBody()  *ClientReadAuthorizationModelRequest {
+	return request.body
+}
+
+func (request *SdkClientReadAuthorizationModelRequest) GetOptions()  *ClientReadAuthorizationModelOptions {
+	return request.options
+}
+
+func (request *SdkClientReadAuthorizationModelRequest) GetContext() _context.Context {
+    return request.ctx
+}
+
+func (client *{{appShortName}}Client) ReadAuthorizationModelExecute(request SdkClientReadAuthorizationModelRequestInterface) (*ClientReadAuthorizationModelResponse, error) {
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
-	data, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(request.ctx, *authorizationModelId).Execute()
+	data, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(request.GetContext(), *authorizationModelId).Execute()
+
 	if err != nil {
 		return nil, err
 	}
 	return &data, nil
 }
 
-func (client *{{appShortName}}Client) ReadAuthorizationModel(ctx _context.Context) SdkClientReadAuthorizationModelRequest {
-	return SdkClientReadAuthorizationModelRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) ReadAuthorizationModel(ctx _context.Context) SdkClientReadAuthorizationModelRequestInterface {
+	return &SdkClientReadAuthorizationModelRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
@@ -743,27 +877,43 @@ type SdkClientReadLatestAuthorizationModelRequest struct {
 	options *ClientReadLatestAuthorizationModelOptions
 }
 
+type SdkClientReadLatestAuthorizationModelRequestInterface interface {
+    Options(options ClientReadLatestAuthorizationModelOptions) SdkClientReadLatestAuthorizationModelRequestInterface
+    Execute() (*ClientReadAuthorizationModelResponse, error)
+
+    GetContext()  _context.Context
+	GetOptions() *ClientReadLatestAuthorizationModelOptions 
+}
+
 type ClientReadLatestAuthorizationModelOptions struct {
 }
 
-func (client *{{appShortName}}Client) ReadLatestAuthorizationModel(ctx _context.Context) SdkClientReadLatestAuthorizationModelRequest {
-	return SdkClientReadLatestAuthorizationModelRequest{
+func (client *{{appShortName}}Client) ReadLatestAuthorizationModel(ctx _context.Context) SdkClientReadLatestAuthorizationModelRequestInterface {
+	return &SdkClientReadLatestAuthorizationModelRequest{
 		Client: *client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientReadLatestAuthorizationModelRequest) Options(options ClientReadLatestAuthorizationModelOptions) SdkClientReadLatestAuthorizationModelRequest {
+func (request *SdkClientReadLatestAuthorizationModelRequest) Options(options ClientReadLatestAuthorizationModelOptions) SdkClientReadLatestAuthorizationModelRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientReadLatestAuthorizationModelRequest) Execute() (*ClientReadAuthorizationModelResponse, error) {
+func (request *SdkClientReadLatestAuthorizationModelRequest) Execute() (*ClientReadAuthorizationModelResponse, error) {
 	return request.Client.ReadLatestAuthorizationModelExecute(request)
 }
 
-func (client *{{appShortName}}Client) ReadLatestAuthorizationModelExecute(request SdkClientReadLatestAuthorizationModelRequest) (*ClientReadAuthorizationModelResponse, error) {
-	response, err := client.ReadAuthorizationModels(request.ctx).Options(ClientReadAuthorizationModelsOptions{
+func (request *SdkClientReadLatestAuthorizationModelRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientReadLatestAuthorizationModelRequest) GetOptions() *ClientReadLatestAuthorizationModelOptions {
+	return request.options
+}
+
+func (client *{{appShortName}}Client) ReadLatestAuthorizationModelExecute(request SdkClientReadLatestAuthorizationModelRequestInterface) (*ClientReadAuthorizationModelResponse, error) {
+	response, err := client.ReadAuthorizationModels(request.GetContext()).Options(ClientReadAuthorizationModelsOptions{
 		PageSize: {{packageName}}.PtrInt32(1),
 	}).Execute()
 	if err != nil {
@@ -787,10 +937,20 @@ func (client *{{appShortName}}Client) ReadLatestAuthorizationModelExecute(reques
 // / ReadChanges
 type SdkClientReadChangesRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientReadChangesRequest
 	options *ClientReadChangesOptions
+}
+
+type SdkClientReadChangesRequestInterface interface {
+    Options(options ClientReadChangesOptions) SdkClientReadChangesRequestInterface
+    Body(body ClientReadChangesRequest) SdkClientReadChangesRequestInterface
+	Execute() (*ClientReadChangesResponse, error)
+
+	GetContext() _context.Context
+	GetBody() *ClientReadChangesRequest
+    GetOptions() *ClientReadChangesOptions
 }
 
 type ClientReadChangesRequest struct {
@@ -804,34 +964,46 @@ type ClientReadChangesOptions struct {
 
 type ClientReadChangesResponse = {{packageName}}.ReadChangesResponse
 
-func (client *{{appShortName}}Client) ReadChanges(ctx _context.Context) SdkClientReadChangesRequest {
-	return SdkClientReadChangesRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) ReadChanges(ctx _context.Context) SdkClientReadChangesRequestInterface {
+	return &SdkClientReadChangesRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientReadChangesRequest) Options(options ClientReadChangesOptions) SdkClientReadChangesRequest {
+func (request *SdkClientReadChangesRequest) Options(options ClientReadChangesOptions) SdkClientReadChangesRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientReadChangesRequest) Body(body ClientReadChangesRequest) SdkClientReadChangesRequest {
+func (request *SdkClientReadChangesRequest) Body(body ClientReadChangesRequest) SdkClientReadChangesRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientReadChangesRequest) Execute() (*ClientReadChangesResponse, error) {
+func (request *SdkClientReadChangesRequest) Execute() (*ClientReadChangesResponse, error) {
 	return request.Client.ReadChangesExecute(request)
 }
 
-func (client *{{appShortName}}Client) ReadChangesExecute(request SdkClientReadChangesRequest) (*ClientReadChangesResponse, error) {
-	req := client.{{appShortName}}Api.ReadChanges(request.ctx)
-	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.options))
+func (request *SdkClientReadChangesRequest) GetContext() _context.Context{
+	return request.ctx
+}
+
+func (request *SdkClientReadChangesRequest) GetBody() *ClientReadChangesRequest{
+	return request.body
+}
+
+func (request *SdkClientReadChangesRequest) GetOptions() *ClientReadChangesOptions{
+	return request.options
+}
+
+func (client *{{appShortName}}Client) ReadChangesExecute(request SdkClientReadChangesRequestInterface) (*ClientReadChangesResponse, error) {
+	req := client.{{appShortName}}Api.ReadChanges(request.GetContext())
+	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
 		req.PageSize(*pageSize)
 	}
-	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.options))
+	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
 		req.ContinuationToken(*continuationToken)
 	}
@@ -845,10 +1017,20 @@ func (client *{{appShortName}}Client) ReadChangesExecute(request SdkClientReadCh
 // / Read
 type SdkClientReadRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientReadRequest
 	options *ClientReadOptions
+}
+
+type SdkClientReadRequestInterface interface {
+    Options(options ClientReadOptions) SdkClientReadRequestInterface
+    Body(body ClientReadRequest) SdkClientReadRequestInterface
+    Execute() (*ClientReadResponse, error)
+
+    GetContext() _context.Context
+	GetBody() *ClientReadRequest
+	GetOptions() *ClientReadOptions
 }
 
 type ClientReadRequest struct {
@@ -864,40 +1046,52 @@ type ClientReadOptions struct {
 
 type ClientReadResponse = {{packageName}}.ReadResponse
 
-func (client *{{appShortName}}Client) Read(ctx _context.Context) SdkClientReadRequest {
-	return SdkClientReadRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) Read(ctx _context.Context) SdkClientReadRequestInterface {
+	return &SdkClientReadRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientReadRequest) Options(options ClientReadOptions) SdkClientReadRequest {
+func (request *SdkClientReadRequest) Options(options ClientReadOptions) SdkClientReadRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientReadRequest) Body(body ClientReadRequest) SdkClientReadRequest {
+func (request *SdkClientReadRequest) Body(body ClientReadRequest) SdkClientReadRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientReadRequest) Execute() (*ClientReadResponse, error) {
+func (request *SdkClientReadRequest) Execute() (*ClientReadResponse, error) {
 	return request.Client.ReadExecute(request)
 }
 
-func (client *{{appShortName}}Client) ReadExecute(request SdkClientReadRequest) (*ClientReadResponse, error) {
+func (request *SdkClientReadRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientReadRequest) GetBody() *ClientReadRequest{
+	return request.body
+}
+
+func (request *SdkClientReadRequest) GetOptions() *ClientReadOptions {
+	return request.options
+}
+
+func (client *{{appShortName}}Client) ReadExecute(request SdkClientReadRequestInterface) (*ClientReadResponse, error) {
 	body := openfga.ReadRequest{
-		PageSize:          getPageSizeFromRequest((*ClientPaginationOptions)(request.options)),
-		ContinuationToken: getContinuationTokenFromRequest((*ClientPaginationOptions)(request.options)),
+		PageSize:          getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions())),
+		ContinuationToken: getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions())),
 	}
-	if request.body != nil && (request.body.User != nil || request.body.Relation != nil || request.body.Object != nil) {
+	if request.GetBody() != nil && (request.GetBody().User != nil || request.GetBody().Relation != nil || request.GetBody().Object != nil) {
 		body.TupleKey = &openfga.TupleKey{
-			User:     request.body.User,
-			Relation: request.body.Relation,
-			Object:   request.body.Object,
+			User:     request.GetBody().User,
+			Relation: request.GetBody().Relation,
+			Object:   request.GetBody().Object,
 		}
 	}
-	data, _, err := client.OpenFgaApi.Read(request.ctx).Body(body).Execute()
+	data, _, err := client.OpenFgaApi.Read(request.GetContext()).Body(body).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -907,10 +1101,22 @@ func (client *{{appShortName}}Client) ReadExecute(request SdkClientReadRequest) 
 // / Write
 type SdkClientWriteRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientWriteRequest
 	options *ClientWriteOptions
+}
+
+type SdkClientWriteRequestInterface interface {
+    Options(options ClientWriteOptions) SdkClientWriteRequestInterface
+	Body(body ClientWriteRequest) SdkClientWriteRequestInterface
+    Execute() (*ClientWriteResponse, error)
+	GetAuthorizationModelIdOverride() *string
+
+	GetContext() _context.Context
+	GetOptions() *ClientWriteOptions
+	GetBody() *ClientWriteRequest
+
 }
 
 type ClientWriteRequest struct {
@@ -976,42 +1182,54 @@ func (o ClientWriteResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
-func (client *{{appShortName}}Client) Write(ctx _context.Context) SdkClientWriteRequest {
-	return SdkClientWriteRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) Write(ctx _context.Context) SdkClientWriteRequestInterface {
+	return &SdkClientWriteRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientWriteRequest) Options(options ClientWriteOptions) SdkClientWriteRequest {
+func (request *SdkClientWriteRequest) Options(options ClientWriteOptions) SdkClientWriteRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientWriteRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientWriteRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientWriteRequest) Body(body ClientWriteRequest) SdkClientWriteRequest {
+func (request *SdkClientWriteRequest) Body(body ClientWriteRequest) SdkClientWriteRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientWriteRequest) Execute() (*ClientWriteResponse, error) {
+func (request *SdkClientWriteRequest) Execute() (*ClientWriteResponse, error) {
 	return request.Client.WriteExecute(request)
 }
 
-func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest) (*ClientWriteResponse, error) {
+func (request *SdkClientWriteRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientWriteRequest) GetOptions() *ClientWriteOptions {
+	return request.options
+}
+
+func (request *SdkClientWriteRequest) GetBody() *ClientWriteRequest {
+	return request.body
+}
+
+func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequestInterface) (*ClientWriteResponse, error) {
 	var maxPerChunk = int32(1) // 1 has to be the default otherwise the chunks will be sent in transactions
-	if request.options != nil && request.options.Transaction != nil {
-		maxPerChunk = request.options.Transaction.MaxPerChunk
+	if request.GetOptions() != nil && request.GetOptions() .Transaction != nil {
+		maxPerChunk = request.GetOptions().Transaction.MaxPerChunk
 	}
 	var maxParallelReqs = DEFAULT_MAX_METHOD_PARALLEL_REQS
-	if request.options != nil && request.options.Transaction != nil {
-		maxParallelReqs = request.options.Transaction.MaxParallelRequests
+	if request.GetOptions() != nil && request.GetOptions().Transaction != nil {
+		maxParallelReqs = request.GetOptions().Transaction.MaxParallelRequests
 	}
 
 	response := ClientWriteResponse{
@@ -1021,33 +1239,33 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 
 	// Unless explicitly disabled, transaction mode is enabled
 	// In transaction mode, the client will send the request to the server as is
-	if request.options == nil || request.options.Transaction == nil || !request.options.Transaction.Disable {
+	if request.GetOptions() == nil || request.GetOptions().Transaction == nil || !request.GetOptions().Transaction.Disable {
 		writeRequest := {{packageName}}.WriteRequest{
-			AuthorizationModelId: client.getAuthorizationModelId(request.getAuthorizationModelIdOverride()),
+			AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
 		}
-		if request.body.Writes != nil && len(*request.body.Writes) > 0 {
+		if request.GetBody().Writes != nil && len(*request.GetBody().Writes) > 0 {
 			writes := {{packageName}}.TupleKeys{}
-			for index := 0; index < len(*request.body.Writes); index++ {
-				writes.TupleKeys = append(writes.TupleKeys, (*request.body.Writes)[index].ToTupleKey())
+			for index := 0; index < len(*request.GetBody().Writes); index++ {
+				writes.TupleKeys = append(writes.TupleKeys, (*request.GetBody().Writes)[index].ToTupleKey())
 			}
 			writeRequest.Writes = &writes
 		}
-		if request.body.Deletes != nil && len(*request.body.Deletes) > 0 {
+		if request.GetBody().Deletes != nil && len(*request.GetBody().Deletes) > 0 {
 			deletes := {{packageName}}.TupleKeys{}
-			for index := 0; index < len(*request.body.Deletes); index++ {
-				deletes.TupleKeys = append(deletes.TupleKeys, (*request.body.Deletes)[index].ToTupleKey())
+			for index := 0; index < len(*request.GetBody().Deletes); index++ {
+				deletes.TupleKeys = append(deletes.TupleKeys, (*request.GetBody().Deletes)[index].ToTupleKey())
 			}
 			writeRequest.Deletes = &deletes
 		}
-		_, httpResponse, err := client.{{appShortName}}Api.Write(request.ctx).Body(writeRequest).Execute()
+		_, httpResponse, err := client.{{appShortName}}Api.Write(request.GetContext()).Body(writeRequest).Execute()
 
 		clientWriteStatus := SUCCESS
 		if err != nil {
 			clientWriteStatus = FAILURE
 		}
 
-		if request.body != nil && request.body.Writes != nil {
-			writeRequestTupleKeys := *request.body.Writes
+		if request.GetBody() != nil && request.GetBody().Writes != nil {
+			writeRequestTupleKeys := *request.GetBody().Writes
 			for index := 0; index < len(writeRequestTupleKeys); index++ {
 				response.Writes = append(response.Writes, ClientWriteSingleResponse{
 					TupleKey:     writeRequestTupleKeys[index],
@@ -1058,8 +1276,8 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 			}
 		}
 
-		if request.body != nil && request.body.Deletes != nil {
-			deleteRequestTupleKeys := *request.body.Deletes
+		if request.GetBody() != nil && request.GetBody().Deletes != nil {
+			deleteRequestTupleKeys := *request.GetBody().Deletes
 			for index := 0; index < len(deleteRequestTupleKeys); index++ {
 				response.Deletes = append(response.Deletes, ClientWriteSingleResponse{
 					TupleKey:     deleteRequestTupleKeys[index],
@@ -1079,28 +1297,28 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 	// - the max items in each request are based on maxPerChunk (default=1)
 	var writeChunkSize = int(maxPerChunk)
 	var writeChunks [][]ClientTupleKey
-    if request.body != nil {
-        for i := 0; i < len(*request.body.Writes); i += writeChunkSize {
-            end := int(math.Min(float64(i+writeChunkSize), float64(len(*request.body.Writes))))
+    if request.GetBody() != nil {
+        for i := 0; i < len(*request.GetBody().Writes); i += writeChunkSize {
+            end := int(math.Min(float64(i+writeChunkSize), float64(len(*request.GetBody().Writes))))
 
-            writeChunks = append(writeChunks, (*request.body.Writes)[i:end])
+            writeChunks = append(writeChunks, (*request.GetBody().Writes)[i:end])
         }
     }
 
-	writeGroup, ctx := errgroup.WithContext(request.ctx)
+	writeGroup, ctx := errgroup.WithContext(request.GetContext())
 	writeGroup.SetLimit(int(maxParallelReqs))
 	writeResponses := make([]ClientWriteResponse, len(writeChunks))
 	for index, writeBody := range writeChunks {
 		index, writeBody := index, writeBody
 		writeGroup.Go(func() error {
-			singleResponse, _ := client.WriteExecute(SdkClientWriteRequest{
+			singleResponse, _ := client.WriteExecute(&SdkClientWriteRequest{
 				ctx:    ctx,
-				Client: *client,
+				Client: client,
 				body: &ClientWriteRequest{
 					Writes: &writeBody,
 				},
 				options: &ClientWriteOptions{
-					AuthorizationModelId: client.getAuthorizationModelId(request.getAuthorizationModelIdOverride()),
+					AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
 				},
 			})
 
@@ -1114,28 +1332,28 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 
 	var deleteChunkSize = int(maxPerChunk)
 	var deleteChunks [][]ClientTupleKey
-    if request.body != nil {
-        for i := 0; i < len(*request.body.Deletes); i += deleteChunkSize {
-            end := int(math.Min(float64(i+writeChunkSize), float64(len(*request.body.Deletes))))
+    if request.GetBody() != nil {
+        for i := 0; i < len(*request.GetBody().Deletes); i += deleteChunkSize {
+            end := int(math.Min(float64(i+writeChunkSize), float64(len(*request.GetBody().Deletes))))
 
-            deleteChunks = append(deleteChunks, (*request.body.Deletes)[i:end])
+            deleteChunks = append(deleteChunks, (*request.GetBody().Deletes)[i:end])
         }
     }
 
-	deleteGroup, ctx := errgroup.WithContext(request.ctx)
+	deleteGroup, ctx := errgroup.WithContext(request.GetContext())
 	deleteGroup.SetLimit(int(maxParallelReqs))
 	deleteResponses := make([]ClientWriteResponse, len(deleteChunks))
 	for index, deleteBody := range deleteChunks {
 		index, deleteBody := index, deleteBody
 		deleteGroup.Go(func() error {
-			singleResponse, _ := client.WriteExecute(SdkClientWriteRequest{
+			singleResponse, _ := client.WriteExecute(&SdkClientWriteRequest{
 				ctx:    ctx,
-				Client: *client,
+				Client: client,
 				body: &ClientWriteRequest{
 					Deletes: &deleteBody,
 				},
 				options: &ClientWriteOptions{
-					AuthorizationModelId: client.getAuthorizationModelId(request.getAuthorizationModelIdOverride()),
+					AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
 				},
 			})
 
@@ -1165,41 +1383,63 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 // / WriteTuples
 type SdkClientWriteTuplesRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientWriteTuplesBody
 	options *ClientWriteOptions
 }
 
+type SdkClientWriteTuplesRequestInterface interface {
+    Options(options ClientWriteOptions) SdkClientWriteTuplesRequestInterface
+	Body(body ClientWriteTuplesBody) SdkClientWriteTuplesRequestInterface
+	Execute() (*ClientWriteResponse, error)
+
+	GetContext() _context.Context
+	GetBody() *ClientWriteTuplesBody
+	GetOptions() *ClientWriteOptions
+}
+
 type ClientWriteTuplesBody = []ClientTupleKey
 
-func (client *{{appShortName}}Client) WriteTuples(ctx _context.Context) SdkClientWriteTuplesRequest {
-	return SdkClientWriteTuplesRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) WriteTuples(ctx _context.Context) SdkClientWriteTuplesRequestInterface {
+	return &SdkClientWriteTuplesRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientWriteTuplesRequest) Options(options ClientWriteOptions) SdkClientWriteTuplesRequest {
+func (request *SdkClientWriteTuplesRequest) Options(options ClientWriteOptions) SdkClientWriteTuplesRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientWriteTuplesRequest) Body(body ClientWriteTuplesBody) SdkClientWriteTuplesRequest {
+func (request *SdkClientWriteTuplesRequest) Body(body ClientWriteTuplesBody) SdkClientWriteTuplesRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientWriteTuplesRequest) Execute() (*ClientWriteResponse, error) {
+func (request *SdkClientWriteTuplesRequest) Execute() (*ClientWriteResponse, error) {
 	return request.Client.WriteTuplesExecute(request)
 }
 
-func (client *{{appShortName}}Client) WriteTuplesExecute(request SdkClientWriteTuplesRequest) (*ClientWriteResponse, error) {
-	baseReq := client.Write(request.ctx).Body(ClientWriteRequest{
-		Writes: request.body,
+func (request *SdkClientWriteTuplesRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientWriteTuplesRequest) GetBody() *ClientWriteTuplesBody {
+    return request.body
+}
+
+func (request *SdkClientWriteTuplesRequest) GetOptions() *ClientWriteOptions {
+    return request.options
+}
+
+func (client *{{appShortName}}Client) WriteTuplesExecute(request SdkClientWriteTuplesRequestInterface) (*ClientWriteResponse, error) {
+	baseReq := client.Write(request.GetContext()).Body(ClientWriteRequest{
+		Writes: request.GetBody(),
 	})
-	if request.options != nil {
-		baseReq.Options(*request.options)
+	if request.GetOptions() != nil {
+		baseReq.Options(*request.GetOptions())
 	}
 	return baseReq.Execute()
 }
@@ -1207,41 +1447,63 @@ func (client *{{appShortName}}Client) WriteTuplesExecute(request SdkClientWriteT
 // / DeleteTuples
 type SdkClientDeleteTuplesRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientDeleteTuplesBody
 	options *ClientWriteOptions
 }
 
+type SdkClientDeleteTuplesRequestInterface interface {
+    Options(options ClientWriteOptions) SdkClientDeleteTuplesRequestInterface
+    Body(body ClientDeleteTuplesBody) SdkClientDeleteTuplesRequestInterface
+	Execute() (*ClientWriteResponse, error)
+
+	GetContext() _context.Context
+	GetBody() *ClientDeleteTuplesBody
+	GetOptions() *ClientWriteOptions
+}
+
 type ClientDeleteTuplesBody = []ClientTupleKey
 
-func (client *{{appShortName}}Client) DeleteTuples(ctx _context.Context) SdkClientDeleteTuplesRequest {
-	return SdkClientDeleteTuplesRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) DeleteTuples(ctx _context.Context) SdkClientDeleteTuplesRequestInterface {
+	return &SdkClientDeleteTuplesRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientDeleteTuplesRequest) Options(options ClientWriteOptions) SdkClientDeleteTuplesRequest {
+func (request *SdkClientDeleteTuplesRequest) Options(options ClientWriteOptions) SdkClientDeleteTuplesRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientDeleteTuplesRequest) Body(body ClientDeleteTuplesBody) SdkClientDeleteTuplesRequest {
+func (request *SdkClientDeleteTuplesRequest) Body(body ClientDeleteTuplesBody) SdkClientDeleteTuplesRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientDeleteTuplesRequest) Execute() (*ClientWriteResponse, error) {
+func (request *SdkClientDeleteTuplesRequest) Execute() (*ClientWriteResponse, error) {
 	return request.Client.DeleteTuplesExecute(request)
 }
 
-func (client *{{appShortName}}Client) DeleteTuplesExecute(request SdkClientDeleteTuplesRequest) (*ClientWriteResponse, error) {
-	baseReq := client.Write(request.ctx).Body(ClientWriteRequest{
-		Deletes: request.body,
+func (request *SdkClientDeleteTuplesRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientDeleteTuplesRequest) GetBody() *ClientDeleteTuplesBody {
+    return request.body
+}
+
+func (request *SdkClientDeleteTuplesRequest) GetOptions() *ClientWriteOptions {
+    return request.options
+}
+
+func (client *{{appShortName}}Client) DeleteTuplesExecute(request SdkClientDeleteTuplesRequestInterface) (*ClientWriteResponse, error) {
+	baseReq := client.Write(request.GetContext()).Body(ClientWriteRequest{
+		Deletes: request.GetBody(),
 	})
-	if request.options != nil {
-		baseReq.Options(*request.options)
+	if request.GetOptions() != nil {
+		baseReq.Options(*request.GetOptions())
 	}
 	return baseReq.Execute()
 }
@@ -1252,10 +1514,21 @@ func (client *{{appShortName}}Client) DeleteTuplesExecute(request SdkClientDelet
 
 type SdkClientCheckRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientCheckRequest
 	options *ClientCheckOptions
+}
+
+type SdkClientCheckRequestInterface interface {
+	Options(options ClientCheckOptions) SdkClientCheckRequestInterface
+	Body(body ClientCheckRequest) SdkClientCheckRequestInterface
+	Execute() (*ClientCheckResponse, error)
+	GetAuthorizationModelIdOverride() *string
+
+	GetContext()    _context.Context
+	GetBody()    *ClientCheckRequest
+	GetOptions() *ClientCheckOptions
 }
 
 type ClientCheckRequest struct {
@@ -1274,52 +1547,64 @@ type ClientCheckResponse struct {
 	HttpResponse *_nethttp.Response
 }
 
-func (client *{{appShortName}}Client) Check(ctx _context.Context) SdkClientCheckRequest {
-	return SdkClientCheckRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) Check(ctx _context.Context) SdkClientCheckRequestInterface {
+	return &SdkClientCheckRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientCheckRequest) Options(options ClientCheckOptions) SdkClientCheckRequest {
+func (request *SdkClientCheckRequest) Options(options ClientCheckOptions) SdkClientCheckRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientCheckRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientCheckRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientCheckRequest) Body(body ClientCheckRequest) SdkClientCheckRequest {
+func (request *SdkClientCheckRequest) Body(body ClientCheckRequest) SdkClientCheckRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientCheckRequest) Execute() (*ClientCheckResponse, error) {
+func (request *SdkClientCheckRequest) Execute() (*ClientCheckResponse, error) {
 	return request.Client.CheckExecute(request)
 }
 
-func (client *{{appShortName}}Client) CheckExecute(request SdkClientCheckRequest) (*ClientCheckResponse, error) {
+func (request *SdkClientCheckRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientCheckRequest) GetBody() *ClientCheckRequest {
+	return request.body
+}
+
+func (request *SdkClientCheckRequest) GetOptions() *ClientCheckOptions {
+	return request.options
+}
+
+func (client *{{appShortName}}Client) CheckExecute(request SdkClientCheckRequestInterface) (*ClientCheckResponse, error) {
 	var contextualTuples []{{packageName}}.TupleKey
-	if request.body.ContextualTuples != nil {
-		for index := 0; index < len(*request.body.ContextualTuples); index++ {
-			contextualTuples = append(contextualTuples, (*request.body.ContextualTuples)[index].ToTupleKey())
+	if request.GetBody().ContextualTuples != nil {
+		for index := 0; index < len(*request.GetBody().ContextualTuples); index++ {
+			contextualTuples = append(contextualTuples, (*request.GetBody().ContextualTuples)[index].ToTupleKey())
 		}
 	}
 	requestBody := {{packageName}}.CheckRequest{
 		TupleKey: {{packageName}}.TupleKey{
-			User:     {{packageName}}.PtrString(request.body.User),
-			Relation: {{packageName}}.PtrString(request.body.Relation),
-			Object:   {{packageName}}.PtrString(request.body.Object),
+			User:     {{packageName}}.PtrString(request.GetBody().User),
+			Relation: {{packageName}}.PtrString(request.GetBody().Relation),
+			Object:   {{packageName}}.PtrString(request.GetBody().Object),
 		},
 		ContextualTuples:     {{packageName}}.NewContextualTupleKeys(contextualTuples),
-		AuthorizationModelId: client.getAuthorizationModelId(request.getAuthorizationModelIdOverride()),
+		AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
 	}
 
-	data, httpResponse, err := client.{{appShortName}}Api.Check(request.ctx).Body(requestBody).Execute()
+	data, httpResponse, err := client.{{appShortName}}Api.Check(request.GetContext()).Body(requestBody).Execute()
 	return &ClientCheckResponse{CheckResponse: data, HttpResponse: httpResponse}, err
 }
 
@@ -1327,10 +1612,21 @@ func (client *{{appShortName}}Client) CheckExecute(request SdkClientCheckRequest
 
 type SdkClientBatchCheckRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientBatchCheckBody
 	options *ClientBatchCheckOptions
+}
+
+type SdkClientBatchCheckRequestInterface interface {
+	Options(options ClientBatchCheckOptions) SdkClientBatchCheckRequestInterface
+	Body(body ClientBatchCheckBody) SdkClientBatchCheckRequestInterface
+	Execute() (*ClientBatchCheckResponse, error)
+	GetAuthorizationModelIdOverride() *string 
+
+	GetContext() _context.Context
+	GetBody() *ClientBatchCheckBody
+	GetOptions() *ClientBatchCheckOptions
 }
 
 type ClientBatchCheckBody = []ClientCheckRequest
@@ -1348,54 +1644,66 @@ type ClientBatchCheckSingleResponse struct {
 
 type ClientBatchCheckResponse = []ClientBatchCheckSingleResponse
 
-func (client *{{appShortName}}Client) BatchCheck(ctx _context.Context) SdkClientBatchCheckRequest {
-	return SdkClientBatchCheckRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) BatchCheck(ctx _context.Context) SdkClientBatchCheckRequestInterface {
+	return &SdkClientBatchCheckRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientBatchCheckRequest) Options(options ClientBatchCheckOptions) SdkClientBatchCheckRequest {
+func (request *SdkClientBatchCheckRequest) Options(options ClientBatchCheckOptions) SdkClientBatchCheckRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientBatchCheckRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientBatchCheckRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientBatchCheckRequest) Body(body ClientBatchCheckBody) SdkClientBatchCheckRequest {
+func (request *SdkClientBatchCheckRequest) Body(body ClientBatchCheckBody) SdkClientBatchCheckRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientBatchCheckRequest) Execute() (*ClientBatchCheckResponse, error) {
+func (request *SdkClientBatchCheckRequest) Execute() (*ClientBatchCheckResponse, error) {
 	return request.Client.BatchCheckExecute(request)
 }
 
-func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCheckRequest) (*ClientBatchCheckResponse, error) {
-	group, ctx := errgroup.WithContext(request.ctx)
+func (request *SdkClientBatchCheckRequest) GetContext() _context.Context {
+	return request.ctx
+}
+
+func (request *SdkClientBatchCheckRequest) GetBody() *ClientBatchCheckBody {
+	return request.body
+}
+
+func (request *SdkClientBatchCheckRequest) GetOptions() *ClientBatchCheckOptions {
+    return request.options
+}
+
+func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCheckRequestInterface) (*ClientBatchCheckResponse, error) {
+	group, ctx := errgroup.WithContext(request.GetContext())
 	var maxParallelReqs int
-	if request.options == nil || request.options.MaxParallelRequests == nil {
+	if request.GetOptions() == nil || request.GetOptions().MaxParallelRequests == nil {
 		maxParallelReqs = int(DEFAULT_MAX_METHOD_PARALLEL_REQS)
 	} else {
-		maxParallelReqs = int(*request.options.MaxParallelRequests)
+		maxParallelReqs = int(*request.GetOptions().MaxParallelRequests)
 	}
 	group.SetLimit(maxParallelReqs)
-	var numOfChecks = len(*request.body)
+	var numOfChecks = len(*request.GetBody())
 	response := make(ClientBatchCheckResponse, numOfChecks)
-	for index, checkBody := range *request.body {
+	for index, checkBody := range *request.GetBody() {
 		index, checkBody := index, checkBody
 		group.Go(func() error {
-			singleResponse, err := client.CheckExecute(SdkClientCheckRequest{
+			singleResponse, err := client.CheckExecute(&SdkClientCheckRequest{
 				ctx:    ctx,
-				Client: *client,
+				Client: client,
 				body:   &checkBody,
 				options: &ClientCheckOptions{
-					AuthorizationModelId: client.getAuthorizationModelId(request.getAuthorizationModelIdOverride()),
+					AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
 				},
 			})
 
@@ -1419,10 +1727,21 @@ func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCh
 // / Expand
 type SdkClientExpandRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientExpandRequest
 	options *ClientExpandOptions
+}
+
+type SdkClientExpandRequestInterface interface {
+	Options(options ClientExpandOptions) SdkClientExpandRequestInterface
+    Body(body ClientExpandRequest) SdkClientExpandRequestInterface
+	Execute() (*ClientExpandResponse, error)
+	GetAuthorizationModelIdOverride() *string
+
+	GetContext() _context.Context
+	GetBody() *ClientExpandRequest
+	GetOptions() *ClientExpandOptions
 }
 
 type ClientExpandRequest struct {
@@ -1436,41 +1755,53 @@ type ClientExpandOptions struct {
 
 type ClientExpandResponse = {{packageName}}.ExpandResponse
 
-func (client *{{appShortName}}Client) Expand(ctx _context.Context) SdkClientExpandRequest {
-	return SdkClientExpandRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) Expand(ctx _context.Context) SdkClientExpandRequestInterface {
+	return &SdkClientExpandRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientExpandRequest) Options(options ClientExpandOptions) SdkClientExpandRequest {
+func (request *SdkClientExpandRequest) Options(options ClientExpandOptions) SdkClientExpandRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientExpandRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientExpandRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientExpandRequest) Body(body ClientExpandRequest) SdkClientExpandRequest {
+func (request *SdkClientExpandRequest) Body(body ClientExpandRequest) SdkClientExpandRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientExpandRequest) Execute() (*ClientExpandResponse, error) {
+func (request *SdkClientExpandRequest) Execute() (*ClientExpandResponse, error) {
 	return request.Client.ExpandExecute(request)
 }
 
-func (client *{{appShortName}}Client) ExpandExecute(request SdkClientExpandRequest) (*ClientExpandResponse, error) {
-	data, _, err := client.{{appShortName}}Api.Expand(request.ctx).Body({{packageName}}.ExpandRequest{
+func (request *SdkClientExpandRequest) GetContext() _context.Context {
+    return request.ctx
+}
+
+func (request *SdkClientExpandRequest) GetBody() *ClientExpandRequest {
+    return request.body
+}
+
+func (request *SdkClientExpandRequest) GetOptions() *ClientExpandOptions {
+    return request.options
+}
+
+func (client *{{appShortName}}Client) ExpandExecute(request SdkClientExpandRequestInterface) (*ClientExpandResponse, error) {
+	data, _, err := client.{{appShortName}}Api.Expand(request.GetContext()).Body({{packageName}}.ExpandRequest{
 		TupleKey: {{packageName}}.TupleKey{
-			Relation: &request.body.Relation,
-			Object:   &request.body.Object,
+			Relation: &request.GetBody().Relation,
+			Object:   &request.GetBody().Object,
 		},
-		AuthorizationModelId: client.getAuthorizationModelId(request.getAuthorizationModelIdOverride()),
+		AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
 	}).Execute()
 	if err != nil {
 		return nil, err
@@ -1481,10 +1812,21 @@ func (client *{{appShortName}}Client) ExpandExecute(request SdkClientExpandReque
 // / ListObjects
 type SdkClientListObjectsRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientListObjectsRequest
 	options *ClientListObjectsOptions
+}
+
+type SdkClientListObjectsRequestInterface interface {
+	Options(options ClientListObjectsOptions) SdkClientListObjectsRequestInterface
+	Body(body ClientListObjectsRequest) SdkClientListObjectsRequestInterface
+	Execute() (*ClientListObjectsResponse, error)
+	GetAuthorizationModelIdOverride() *string
+
+	GetContext() _context.Context
+	GetBody() *ClientListObjectsRequest
+	GetOptions() *ClientListObjectsOptions
 }
 
 type ClientListObjectsRequest struct {
@@ -1500,47 +1842,59 @@ type ClientListObjectsOptions struct {
 
 type ClientListObjectsResponse = {{packageName}}.ListObjectsResponse
 
-func (client *{{appShortName}}Client) ListObjects(ctx _context.Context) SdkClientListObjectsRequest {
-	return SdkClientListObjectsRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) ListObjects(ctx _context.Context) SdkClientListObjectsRequestInterface {
+	return &SdkClientListObjectsRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientListObjectsRequest) Options(options ClientListObjectsOptions) SdkClientListObjectsRequest {
+func (request *SdkClientListObjectsRequest) Options(options ClientListObjectsOptions) SdkClientListObjectsRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientListObjectsRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientListObjectsRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientListObjectsRequest) Body(body ClientListObjectsRequest) SdkClientListObjectsRequest {
+func (request *SdkClientListObjectsRequest) Body(body ClientListObjectsRequest) SdkClientListObjectsRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientListObjectsRequest) Execute() (*ClientListObjectsResponse, error) {
+func (request *SdkClientListObjectsRequest) Execute() (*ClientListObjectsResponse, error) {
 	return request.Client.ListObjectsExecute(request)
 }
 
-func (client *{{appShortName}}Client) ListObjectsExecute(request SdkClientListObjectsRequest) (*ClientListObjectsResponse, error) {
+func (request *SdkClientListObjectsRequest) GetContext() _context.Context {
+    return request.ctx
+}
+
+func (request *SdkClientListObjectsRequest)	GetBody() *ClientListObjectsRequest {
+    return request.body
+}
+
+func (request *SdkClientListObjectsRequest)	GetOptions() *ClientListObjectsOptions {
+    return request.options
+}
+
+func (client *{{appShortName}}Client) ListObjectsExecute(request SdkClientListObjectsRequestInterface) (*ClientListObjectsResponse, error) {
 	var contextualTuples []{{packageName}}.TupleKey
-	if request.body.ContextualTuples != nil {
-		for index := 0; index < len(*request.body.ContextualTuples); index++ {
-			contextualTuples = append(contextualTuples, (*request.body.ContextualTuples)[index].ToTupleKey())
+	if request.GetBody().ContextualTuples != nil {
+		for index := 0; index < len(*request.GetBody().ContextualTuples); index++ {
+			contextualTuples = append(contextualTuples, (*request.GetBody().ContextualTuples)[index].ToTupleKey())
 		}
 	}
-	data, _, err := client.{{appShortName}}Api.ListObjects(request.ctx).Body({{packageName}}.ListObjectsRequest{
-		User:                 request.body.User,
-		Relation:             request.body.Relation,
-		Type:                 request.body.Type,
+	data, _, err := client.{{appShortName}}Api.ListObjects(request.GetContext()).Body({{packageName}}.ListObjectsRequest{
+		User:                 request.GetBody().User,
+		Relation:             request.GetBody().Relation,
+		Type:                 request.GetBody().Type,
 		ContextualTuples:     {{packageName}}.NewContextualTupleKeys(contextualTuples),
-		AuthorizationModelId: client.getAuthorizationModelId(request.getAuthorizationModelIdOverride()),
+		AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
 	}).Execute()
 	if err != nil {
 		return nil, err
@@ -1552,10 +1906,21 @@ func (client *{{appShortName}}Client) ListObjectsExecute(request SdkClientListOb
 
 type SdkClientListRelationsRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientListRelationsRequest
 	options *ClientListRelationsOptions
+}
+
+type SdkClientListRelationsRequestInterface interface {
+	Options(options ClientListRelationsOptions) SdkClientListRelationsRequestInterface
+	Body(body ClientListRelationsRequest) SdkClientListRelationsRequestInterface
+    Execute() (*ClientListRelationsResponse, error)
+	GetAuthorizationModelIdOverride() *string
+	
+	GetContext() _context.Context
+	GetBody() *ClientListRelationsRequest
+	GetOptions() *ClientListRelationsOptions
 }
 
 type ClientListRelationsRequest struct {
@@ -1579,55 +1944,67 @@ func (o ClientListRelationsResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
-func (client *{{appShortName}}Client) ListRelations(ctx _context.Context) SdkClientListRelationsRequest {
-	return SdkClientListRelationsRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) ListRelations(ctx _context.Context) SdkClientListRelationsRequestInterface {
+	return &SdkClientListRelationsRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientListRelationsRequest) Options(options ClientListRelationsOptions) SdkClientListRelationsRequest {
+func (request *SdkClientListRelationsRequest) Options(options ClientListRelationsOptions) SdkClientListRelationsRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientListRelationsRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientListRelationsRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientListRelationsRequest) Body(body ClientListRelationsRequest) SdkClientListRelationsRequest {
+func (request *SdkClientListRelationsRequest) Body(body ClientListRelationsRequest) SdkClientListRelationsRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientListRelationsRequest) Execute() (*ClientListRelationsResponse, error) {
+func (request *SdkClientListRelationsRequest) Execute() (*ClientListRelationsResponse, error) {
 	return request.Client.ListRelationsExecute(request)
 }
 
-func (client *{{appShortName}}Client) ListRelationsExecute(request SdkClientListRelationsRequest) (*ClientListRelationsResponse, error) {
-	if len(request.body.Relations) <= 0 {
+func (request *SdkClientListRelationsRequest) GetContext() _context.Context {
+    return request.ctx
+}
+
+func (request *SdkClientListRelationsRequest) GetBody() *ClientListRelationsRequest {
+	return request.body
+}
+
+func (request *SdkClientListRelationsRequest) GetOptions() *ClientListRelationsOptions {
+	return request.options
+}
+
+func (client *{{appShortName}}Client) ListRelationsExecute(request SdkClientListRelationsRequestInterface) (*ClientListRelationsResponse, error) {
+	if len(request.GetBody().Relations) <= 0 {
 		return nil, fmt.Errorf("ListRelations - expected len(Relations) > 0")
 	}
 
 	batchRequestBody := ClientBatchCheckBody{}
-	for index := 0; index < len(request.body.Relations); index++ {
+	for index := 0; index < len(request.GetBody().Relations); index++ {
 		batchRequestBody = append(batchRequestBody, ClientCheckRequest{
-			User:             request.body.User,
-			Relation:         request.body.Relations[index],
-			Object:           request.body.Object,
-			ContextualTuples: request.body.ContextualTuples,
+			User:             request.GetBody().User,
+			Relation:         request.GetBody().Relations[index],
+			Object:           request.GetBody().Object,
+			ContextualTuples: request.GetBody().ContextualTuples,
 		})
 	}
 
-	batchResponse, err := client.BatchCheckExecute(SdkClientBatchCheckRequest{
-		ctx:    request.ctx,
-		Client: *client,
+	batchResponse, err := client.BatchCheckExecute(&SdkClientBatchCheckRequest{
+		ctx:    request.GetContext(),
+		Client: client,
 		body:   &batchRequestBody,
 		options: &ClientBatchCheckOptions{
-			AuthorizationModelId: client.getAuthorizationModelId(request.getAuthorizationModelIdOverride()),
+			AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
 		},
 	})
 
@@ -1648,9 +2025,18 @@ func (client *{{appShortName}}Client) ListRelationsExecute(request SdkClientList
 // / ReadAssertions
 type SdkClientReadAssertionsRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	options *ClientReadAssertionsOptions
+}
+
+type SdkClientReadAssertionsRequestInterface interface {
+	Options(options ClientReadAssertionsOptions) SdkClientReadAssertionsRequestInterface
+    Execute() (*ClientReadAssertionsResponse, error)
+	GetAuthorizationModelIdOverride() *string
+
+	GetContext() _context.Context
+	GetOptions() *ClientReadAssertionsOptions
 }
 
 type ClientReadAssertionsOptions struct {
@@ -1659,35 +2045,43 @@ type ClientReadAssertionsOptions struct {
 
 type ClientReadAssertionsResponse = {{packageName}}.ReadAssertionsResponse
 
-func (client *{{appShortName}}Client) ReadAssertions(ctx _context.Context) SdkClientReadAssertionsRequest {
-	return SdkClientReadAssertionsRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) ReadAssertions(ctx _context.Context) SdkClientReadAssertionsRequestInterface {
+	return &SdkClientReadAssertionsRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientReadAssertionsRequest) Options(options ClientReadAssertionsOptions) SdkClientReadAssertionsRequest {
+func (request *SdkClientReadAssertionsRequest) Options(options ClientReadAssertionsOptions) SdkClientReadAssertionsRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientReadAssertionsRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientReadAssertionsRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientReadAssertionsRequest) Execute() (*ClientReadAssertionsResponse, error) {
+func (request *SdkClientReadAssertionsRequest) Execute() (*ClientReadAssertionsResponse, error) {
 	return request.Client.ReadAssertionsExecute(request)
 }
 
-func (client *{{appShortName}}Client) ReadAssertionsExecute(request SdkClientReadAssertionsRequest) (*ClientReadAssertionsResponse, error) {
-	authorizationModelId := client.getAuthorizationModelId(request.getAuthorizationModelIdOverride())
+func (request *SdkClientReadAssertionsRequest) GetContext() _context.Context {
+    return request.ctx
+}
+
+func (request *SdkClientReadAssertionsRequest) GetOptions() *ClientReadAssertionsOptions {
+    return request.options
+}
+
+func (client *{{appShortName}}Client) ReadAssertionsExecute(request SdkClientReadAssertionsRequestInterface) (*ClientReadAssertionsResponse, error) {
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
-	data, _, err := client.{{appShortName}}Api.ReadAssertions(request.ctx, *authorizationModelId).Execute()
+	data, _, err := client.{{appShortName}}Api.ReadAssertions(request.GetContext(), *authorizationModelId).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -1697,11 +2091,23 @@ func (client *{{appShortName}}Client) ReadAssertionsExecute(request SdkClientRea
 // / WriteAssertions
 type SdkClientWriteAssertionsRequest struct {
 	ctx    _context.Context
-	Client {{appShortName}}Client
+	Client *{{appShortName}}Client
 
 	body    *ClientWriteAssertionsRequest
 	options *ClientWriteAssertionsOptions
 }
+
+type SdkClientWriteAssertionsRequestInterface interface {
+	Options(options ClientWriteAssertionsOptions) SdkClientWriteAssertionsRequestInterface
+    Body(body ClientWriteAssertionsRequest) SdkClientWriteAssertionsRequestInterface
+	Execute() (*ClientWriteAssertionsResponse, error) 
+	GetAuthorizationModelIdOverride() *string
+
+	GetContext() _context.Context
+	GetBody() *ClientWriteAssertionsRequest
+	GetOptions() *ClientWriteAssertionsOptions
+}
+
 
 type ClientAssertion struct {
 	User        string `json:"user,omitempty"`
@@ -1730,45 +2136,58 @@ type ClientWriteAssertionsOptions struct {
 type ClientWriteAssertionsResponse struct {
 }
 
-func (client *{{appShortName}}Client) WriteAssertions(ctx _context.Context) SdkClientWriteAssertionsRequest {
-	return SdkClientWriteAssertionsRequest{
-		Client: *client,
+func (client *{{appShortName}}Client) WriteAssertions(ctx _context.Context) SdkClientWriteAssertionsRequestInterface {
+	return &SdkClientWriteAssertionsRequest{
+		Client: client,
 		ctx:    ctx,
 	}
 }
 
-func (request SdkClientWriteAssertionsRequest) Options(options ClientWriteAssertionsOptions) SdkClientWriteAssertionsRequest {
+func (request *SdkClientWriteAssertionsRequest) Options(options ClientWriteAssertionsOptions) SdkClientWriteAssertionsRequestInterface {
 	request.options = &options
 	return request
 }
 
-func (request SdkClientWriteAssertionsRequest) getAuthorizationModelIdOverride() *string {
+func (request *SdkClientWriteAssertionsRequest) GetAuthorizationModelIdOverride() *string {
 	if request.options == nil {
 		return nil
 	}
 	return request.options.AuthorizationModelId
 }
 
-func (request SdkClientWriteAssertionsRequest) Body(body ClientWriteAssertionsRequest) SdkClientWriteAssertionsRequest {
+func (request *SdkClientWriteAssertionsRequest) Body(body ClientWriteAssertionsRequest) SdkClientWriteAssertionsRequestInterface {
 	request.body = &body
 	return request
 }
 
-func (request SdkClientWriteAssertionsRequest) Execute() (*ClientWriteAssertionsResponse, error) {
+func (request *SdkClientWriteAssertionsRequest) Execute() (*ClientWriteAssertionsResponse, error) {
 	return request.Client.WriteAssertionsExecute(request)
 }
 
-func (client *{{appShortName}}Client) WriteAssertionsExecute(request SdkClientWriteAssertionsRequest) (*ClientWriteAssertionsResponse, error) {
+func (request *SdkClientWriteAssertionsRequest) GetContext() _context.Context {
+    return request.ctx
+}
+
+func (request *SdkClientWriteAssertionsRequest) GetBody() *ClientWriteAssertionsRequest {
+    return request.body
+}
+
+func (request *SdkClientWriteAssertionsRequest) GetOptions() *ClientWriteAssertionsOptions {
+	return request.options
+}
+
+func (client *{{appShortName}}Client) WriteAssertionsExecute(request SdkClientWriteAssertionsRequestInterface) (*ClientWriteAssertionsResponse, error) {
 	writeAssertionsRequest := {{packageName}}.WriteAssertionsRequest{}
-	authorizationModelId := client.getAuthorizationModelId(request.getAuthorizationModelIdOverride())
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
-	for index := 0; index < len(*request.body); index++ {
-		clientAssertion := (*request.body)[index]
+	for index := 0; index < len(*request.GetBody()); index++ {
+		clientAssertion := (*request.GetBody())[index]
 		writeAssertionsRequest.Assertions = append(writeAssertionsRequest.Assertions, clientAssertion.ToAssertion())
 	}
-	_, err := client.{{appShortName}}Api.WriteAssertions(request.ctx, *authorizationModelId).Body(writeAssertionsRequest).Execute()
+	_, err := client.{{appShortName}}Api.WriteAssertions(request.GetContext(), *authorizationModelId).Body(writeAssertionsRequest).Execute()
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

## Description
Wrap some of the SDK client request (such as SdkClientReadAssertionsRequest) to have an interface version. This allows better ability to test and mock by users of the SDK

## References
Corresponding sdk generator changes for https://github.com/openfga/go-sdk/issues/23

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
