### PR TITLE
fix(go-sdk): ulid for auth model id and store id to be validated

### DIFF
--- a/config/clients/go/config.overrides.json
+++ b/config/clients/go/config.overrides.json
@@ -63,6 +63,14 @@
       "destinationFilename": "oauth2/token.go",
       "templateType": "SupportingFiles"
     },
-    "oauth2/token_test.go": {}
+    "oauth2/token_test.go": {},
+    "utils/utils.mustache": {
+      "destinationFilename": "utils/utils.go",
+      "templateType": "SupportingFiles"
+    },
+    "utils/utils_test.mustache": {
+      "destinationFilename": "utils/utils_test.go",
+      "templateType": "SupportingFiles"
+    }
   }
 }

--- a/config/clients/go/template/api.mustache
+++ b/config/clients/go/template/api.mustache
@@ -13,6 +13,8 @@ import (
 	"time"
 {{#imports}}	"{{import}}"
 {{/imports}}
+
+    "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/utils"
 )
 
 // Linger please
@@ -121,6 +123,9 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
         if a.client.cfg.StoreId == "" {
 		    return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("Configuration.StoreId is required and must be specified to call this method")
         }
+		if !utils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+            return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("Configuration.StoreId is invalid")
+		}
     {{/pathParams.0}}
 	localVarPath := "{{{path}}}"{{#pathParams}}
 	localVarPath = strings.Replace(localVarPath, "{"+"{{baseName}}"+"}", _neturl.PathEscape({{#-first}}a.client.cfg.StoreId{{/-first}}{{^-first}}parameterToString(r.{{paramName}}, "{{#collectionFormat}}{{collectionFormat}}{{/collectionFormat}}"){{/-first}}), -1){{/pathParams}}

--- a/config/clients/go/template/api_test.mustache
+++ b/config/clients/go/template/api_test.mustache
@@ -61,6 +61,17 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 		}
 	})
 
+	t.Run("Providing invalid storeid should result in error", func(t *testing.T) {
+		_, err := NewConfiguration(Configuration{
+            ApiHost: "api.{{sampleApiDomain}}",
+			StoreId: "invalid",
+		})
+
+		if err == nil {
+			t.Fatalf("Expect error when invalid storeid is provided")
+		}
+	})
+
 	t.Run("In ApiToken credential method, apiToken is required in the Credentials Config", func(t *testing.T) {
 		_, err := NewConfiguration(Configuration{
 			ApiHost: "https://api.{{sampleApiDomain}}",
@@ -77,7 +88,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 	t.Run("should issue a successful network call when using ApiToken credential method", func(t *testing.T) {
 		configuration, err := NewConfiguration(Configuration{
             ApiHost:         "api.{{sampleApiDomain}}",
-			StoreId:      "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -120,7 +131,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 	t.Run("In ClientCredentials method, providing no client id, secret, audience or issuer should error", func(t *testing.T) {
 		_, err := NewConfiguration(Configuration{
 			ApiHost: "https://api.{{sampleApiDomain}}",
-			StoreId: "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -135,7 +146,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 
 		_, err = NewConfiguration(Configuration{
 			ApiHost: "https://api.{{sampleApiDomain}}",
-			StoreId: "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -152,7 +163,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 
 		_, err = NewConfiguration(Configuration{
 			ApiHost: "https://api.{{sampleApiDomain}}",
-			StoreId: "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -169,7 +180,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 
 		_, err = NewConfiguration(Configuration{
 			ApiHost: "https://api.{{sampleApiDomain}}",
-			StoreId: "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodApiToken,
 				Config: &credentials.Config{
@@ -186,7 +197,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 
 		_, err = NewConfiguration(Configuration{
 			ApiHost: "api.{{sampleApiDomain}}",
-			StoreId: "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodClientCredentials,
 				Config: &credentials.Config{
@@ -206,7 +217,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 	t.Run("should issue a network call to get the token at the first request if client id is provided", func(t *testing.T) {
 		configuration, err := NewConfiguration(Configuration{
             ApiHost:         "api.{{sampleApiDomain}}",
-			StoreId:      "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodClientCredentials,
 				Config: &credentials.Config{
@@ -274,7 +285,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 	t.Run("should not issue a network call to get the token at the first request if the clientId is not provided", func(t *testing.T) {
 		configuration, err := NewConfiguration(Configuration{
             ApiHost:         "api.{{sampleApiDomain}}",
-			StoreId:      "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
 			Credentials: &credentials.Credentials{
 				Method: credentials.CredentialsMethodNone,
 				Config: &credentials.Config{ClientCredentialsApiTokenIssuer: "tokenissuer.api.example"},
@@ -382,7 +393,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 func Test{{appShortName}}Api(t *testing.T) {
 	configuration, err := NewConfiguration(Configuration{
         ApiHost:         "api.{{sampleApiDomain}}",
-        StoreId:      "6c181474-aaa1-4df7-8929-6e7b3a992754",
+        StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
 	})
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -1118,7 +1129,7 @@ func Test{{appShortName}}Api(t *testing.T) {
 
 		updatedConfiguration, err := NewConfiguration(Configuration{
             ApiHost:         "api.{{sampleApiDomain}}",
-			StoreId:      "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
 			RetryParams: &RetryParams{
 				MaxRetry:    3,
 				MinWaitInMs: 5,
@@ -1184,7 +1195,7 @@ func Test{{appShortName}}Api(t *testing.T) {
 		)
 		updatedConfiguration, err := NewConfiguration(Configuration{
             ApiHost:         "api.{{sampleApiDomain}}",
-			StoreId:      "6c181474-aaa1-4df7-8929-6e7b3a992754",
+			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
 			RetryParams: &RetryParams{
 				MaxRetry:    2,
 				MinWaitInMs: 5,

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -10,6 +10,7 @@ import (
 
 	"{{gitHost}}/{{gitUserId}}/{{gitRepoId}}"
 	"{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/credentials"
+    "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/utils"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -70,6 +71,15 @@ func NewSdkClient(cfg *ClientConfiguration) (*{{appShortName}}Client, error) {
 
 	clientConfig := newClientConfiguration(apiConfiguration)
 	clientConfig.AuthorizationModelId = cfg.AuthorizationModelId
+
+	// validate the store id and model id if they are defined
+	if cfg.StoreId != "" && !utils.IsWellFormedUlidString(cfg.StoreId) {
+		return nil, FgaInvalidUlidError{param: "StoreId"}
+    }
+
+	if cfg.AuthorizationModelId != nil && !utils.IsWellFormedUlidString(*cfg.AuthorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	}
 
 	apiClient := {{packageName}}.NewAPIClient(apiConfiguration)
 
@@ -854,6 +864,9 @@ func (client *{{appShortName}}Client) ReadAuthorizationModelExecute(request SdkC
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
+	if !utils.IsWellFormedUlidString(*authorizationModelId) {
+        return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	}
 	data, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(request.GetContext(), *authorizationModelId).Execute()
 
 	if err != nil {
@@ -1237,11 +1250,16 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 		Deletes: []ClientWriteSingleResponse{},
 	}
 
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	}
+
 	// Unless explicitly disabled, transaction mode is enabled
 	// In transaction mode, the client will send the request to the server as is
 	if request.GetOptions() == nil || request.GetOptions().Transaction == nil || !request.GetOptions().Transaction.Disable {
 		writeRequest := {{packageName}}.WriteRequest{
-			AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
+			AuthorizationModelId: authorizationModelId,
 		}
 		if request.GetBody().Writes != nil && len(*request.GetBody().Writes) > 0 {
 			writes := {{packageName}}.TupleKeys{}
@@ -1318,7 +1336,7 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 					Writes: &writeBody,
 				},
 				options: &ClientWriteOptions{
-					AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
+					AuthorizationModelId: authorizationModelId,
 				},
 			})
 
@@ -1353,7 +1371,7 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 					Deletes: &deleteBody,
 				},
 				options: &ClientWriteOptions{
-					AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
+					AuthorizationModelId: authorizationModelId,
 				},
 			})
 
@@ -1594,6 +1612,10 @@ func (client *{{appShortName}}Client) CheckExecute(request SdkClientCheckRequest
 			contextualTuples = append(contextualTuples, (*request.GetBody().ContextualTuples)[index].ToTupleKey())
 		}
 	}
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	}
 	requestBody := {{packageName}}.CheckRequest{
 		TupleKey: {{packageName}}.TupleKey{
 			User:     {{packageName}}.PtrString(request.GetBody().User),
@@ -1601,7 +1623,7 @@ func (client *{{appShortName}}Client) CheckExecute(request SdkClientCheckRequest
 			Object:   {{packageName}}.PtrString(request.GetBody().Object),
 		},
 		ContextualTuples:     {{packageName}}.NewContextualTupleKeys(contextualTuples),
-		AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
+		AuthorizationModelId: authorizationModelId,
 	}
 
 	data, httpResponse, err := client.{{appShortName}}Api.Check(request.GetContext()).Body(requestBody).Execute()
@@ -1695,6 +1717,11 @@ func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCh
 	group.SetLimit(maxParallelReqs)
 	var numOfChecks = len(*request.GetBody())
 	response := make(ClientBatchCheckResponse, numOfChecks)
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	}
+
 	for index, checkBody := range *request.GetBody() {
 		index, checkBody := index, checkBody
 		group.Go(func() error {
@@ -1703,7 +1730,7 @@ func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCh
 				Client: client,
 				body:   &checkBody,
 				options: &ClientCheckOptions{
-					AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
+					AuthorizationModelId: authorizationModelId,
 				},
 			})
 
@@ -1796,12 +1823,17 @@ func (request *SdkClientExpandRequest) GetOptions() *ClientExpandOptions {
 }
 
 func (client *{{appShortName}}Client) ExpandExecute(request SdkClientExpandRequestInterface) (*ClientExpandResponse, error) {
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	}
+
 	data, _, err := client.{{appShortName}}Api.Expand(request.GetContext()).Body({{packageName}}.ExpandRequest{
 		TupleKey: {{packageName}}.TupleKey{
 			Relation: &request.GetBody().Relation,
 			Object:   &request.GetBody().Object,
 		},
-		AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
+		AuthorizationModelId: authorizationModelId,
 	}).Execute()
 	if err != nil {
 		return nil, err
@@ -1889,12 +1921,16 @@ func (client *{{appShortName}}Client) ListObjectsExecute(request SdkClientListOb
 			contextualTuples = append(contextualTuples, (*request.GetBody().ContextualTuples)[index].ToTupleKey())
 		}
 	}
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	}
 	data, _, err := client.{{appShortName}}Api.ListObjects(request.GetContext()).Body({{packageName}}.ListObjectsRequest{
 		User:                 request.GetBody().User,
 		Relation:             request.GetBody().Relation,
 		Type:                 request.GetBody().Type,
 		ContextualTuples:     {{packageName}}.NewContextualTupleKeys(contextualTuples),
-		AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
+		AuthorizationModelId: authorizationModelId,
 	}).Execute()
 	if err != nil {
 		return nil, err
@@ -1998,13 +2034,16 @@ func (client *{{appShortName}}Client) ListRelationsExecute(request SdkClientList
 			ContextualTuples: request.GetBody().ContextualTuples,
 		})
 	}
-
+	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	}
 	batchResponse, err := client.BatchCheckExecute(&SdkClientBatchCheckRequest{
 		ctx:    request.GetContext(),
 		Client: client,
 		body:   &batchRequestBody,
 		options: &ClientBatchCheckOptions{
-			AuthorizationModelId: client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride()),
+			AuthorizationModelId: authorizationModelId,
 		},
 	})
 
@@ -2080,6 +2119,9 @@ func (client *{{appShortName}}Client) ReadAssertionsExecute(request SdkClientRea
 	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
+	}
+	if !utils.IsWellFormedUlidString(*authorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
 	}
 	data, _, err := client.{{appShortName}}Api.ReadAssertions(request.GetContext(), *authorizationModelId).Execute()
 	if err != nil {
@@ -2181,6 +2223,9 @@ func (client *{{appShortName}}Client) WriteAssertionsExecute(request SdkClientWr
 	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
+	}
+	if !utils.IsWellFormedUlidString(*authorizationModelId) {
+		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
 	}
 	for index := 0; index < len(*request.GetBody()); index++ {
 		clientAssertion := (*request.GetBody())[index]

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -72,13 +72,10 @@ func NewSdkClient(cfg *ClientConfiguration) (*{{appShortName}}Client, error) {
 	clientConfig := newClientConfiguration(apiConfiguration)
 	clientConfig.AuthorizationModelId = cfg.AuthorizationModelId
 
-	// validate the store id and model id if they are defined
-	if cfg.StoreId != "" && !utils.IsWellFormedUlidString(cfg.StoreId) {
-		return nil, FgaInvalidUlidError{param: "StoreId"}
-    }
+	// store id is already validate as part of configuraiton validation
 
 	if cfg.AuthorizationModelId != nil && !utils.IsWellFormedUlidString(*cfg.AuthorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
 	}
 
 	apiClient := {{packageName}}.NewAPIClient(apiConfiguration)
@@ -407,11 +404,16 @@ type SdkClient interface {
 	WriteAssertionsExecute(request SdkClientWriteAssertionsRequestInterface) (*ClientWriteAssertionsResponse, error)
 }
 
-func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModelId *string) *string {
+func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModelId *string) (*string, error) {
+	modelId := client.config.AuthorizationModelId
 	if authorizationModelId != nil {
-		return authorizationModelId
+		modelId = authorizationModelId
 	}
-	return client.config.AuthorizationModelId
+
+	if modelId != nil && !utils.IsWellFormedUlidString(*modelId) {
+		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+	}
+	return modelId, nil
 }
 
 /* Stores */
@@ -860,12 +862,12 @@ func (request *SdkClientReadAuthorizationModelRequest) GetContext() _context.Con
 }
 
 func (client *{{appShortName}}Client) ReadAuthorizationModelExecute(request SdkClientReadAuthorizationModelRequestInterface) (*ClientReadAuthorizationModelResponse, error) {
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
+	}
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
-	}
-	if !utils.IsWellFormedUlidString(*authorizationModelId) {
-        return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
 	}
 	data, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(request.GetContext(), *authorizationModelId).Execute()
 
@@ -1250,9 +1252,9 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 		Deletes: []ClientWriteSingleResponse{},
 	}
 
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
-	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
 	}
 
 	// Unless explicitly disabled, transaction mode is enabled
@@ -1612,9 +1614,9 @@ func (client *{{appShortName}}Client) CheckExecute(request SdkClientCheckRequest
 			contextualTuples = append(contextualTuples, (*request.GetBody().ContextualTuples)[index].ToTupleKey())
 		}
 	}
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
-	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
 	}
 	requestBody := {{packageName}}.CheckRequest{
 		TupleKey: {{packageName}}.TupleKey{
@@ -1717,9 +1719,9 @@ func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCh
 	group.SetLimit(maxParallelReqs)
 	var numOfChecks = len(*request.GetBody())
 	response := make(ClientBatchCheckResponse, numOfChecks)
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
-	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err 
 	}
 
 	for index, checkBody := range *request.GetBody() {
@@ -1823,9 +1825,9 @@ func (request *SdkClientExpandRequest) GetOptions() *ClientExpandOptions {
 }
 
 func (client *{{appShortName}}Client) ExpandExecute(request SdkClientExpandRequestInterface) (*ClientExpandResponse, error) {
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
-	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
 	}
 
 	data, _, err := client.{{appShortName}}Api.Expand(request.GetContext()).Body({{packageName}}.ExpandRequest{
@@ -1921,9 +1923,9 @@ func (client *{{appShortName}}Client) ListObjectsExecute(request SdkClientListOb
 			contextualTuples = append(contextualTuples, (*request.GetBody().ContextualTuples)[index].ToTupleKey())
 		}
 	}
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
-	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
 	}
 	data, _, err := client.{{appShortName}}Api.ListObjects(request.GetContext()).Body({{packageName}}.ListObjectsRequest{
 		User:                 request.GetBody().User,
@@ -2034,9 +2036,9 @@ func (client *{{appShortName}}Client) ListRelationsExecute(request SdkClientList
 			ContextualTuples: request.GetBody().ContextualTuples,
 		})
 	}
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
-	if authorizationModelId != nil && !utils.IsWellFormedUlidString(*authorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
 	}
 	batchResponse, err := client.BatchCheckExecute(&SdkClientBatchCheckRequest{
 		ctx:    request.GetContext(),
@@ -2116,12 +2118,12 @@ func (request *SdkClientReadAssertionsRequest) GetOptions() *ClientReadAssertion
 }
 
 func (client *{{appShortName}}Client) ReadAssertionsExecute(request SdkClientReadAssertionsRequestInterface) (*ClientReadAssertionsResponse, error) {
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
+	}
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
-	}
-	if !utils.IsWellFormedUlidString(*authorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
 	}
 	data, _, err := client.{{appShortName}}Api.ReadAssertions(request.GetContext(), *authorizationModelId).Execute()
 	if err != nil {
@@ -2220,18 +2222,18 @@ func (request *SdkClientWriteAssertionsRequest) GetOptions() *ClientWriteAsserti
 
 func (client *{{appShortName}}Client) WriteAssertionsExecute(request SdkClientWriteAssertionsRequestInterface) (*ClientWriteAssertionsResponse, error) {
 	writeAssertionsRequest := {{packageName}}.WriteAssertionsRequest{}
-	authorizationModelId := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
+	}
 	if authorizationModelId == nil {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
-	}
-	if !utils.IsWellFormedUlidString(*authorizationModelId) {
-		return nil, FgaInvalidUlidError{param: "AuthorizationModelId"}
 	}
 	for index := 0; index < len(*request.GetBody()); index++ {
 		clientAssertion := (*request.GetBody())[index]
 		writeAssertionsRequest.Assertions = append(writeAssertionsRequest.Assertions, clientAssertion.ToAssertion())
 	}
-	_, err := client.{{appShortName}}Api.WriteAssertions(request.GetContext(), *authorizationModelId).Body(writeAssertionsRequest).Execute()
+	_, err = client.{{appShortName}}Api.WriteAssertions(request.GetContext(), *authorizationModelId).Body(writeAssertionsRequest).Execute()
 
 	if err != nil {
 		return nil, err

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -72,7 +72,7 @@ func NewSdkClient(cfg *ClientConfiguration) (*{{appShortName}}Client, error) {
 	clientConfig := newClientConfiguration(apiConfiguration)
 	clientConfig.AuthorizationModelId = cfg.AuthorizationModelId
 
-	// store id is already validate as part of configuraiton validation
+	// store id is already validate as part of configuration validation
 
 	if cfg.AuthorizationModelId != nil && !utils.IsWellFormedUlidString(*cfg.AuthorizationModelId) {
 		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
@@ -414,6 +414,19 @@ func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModel
 		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
 	}
 	return modelId, nil
+}
+
+// helper function to validate the connection (i.e., get token)
+func (client *{{appShortName}}Client) checkValidApiConnection(ctx _context.Context, authorizationModelId *string) error {
+	if authorizationModelId != nil {
+	    _, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(ctx, *authorizationModelId).Execute()
+		return err
+	} else {
+		_, err := client.ReadAuthorizationModels(ctx).Options(ClientReadAuthorizationModelsOptions{
+		    PageSize: {{packageName}}.PtrInt32(1),
+	    }).Execute()
+		return err
+	}
 }
 
 /* Stores */
@@ -1326,6 +1339,11 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
     }
 
 	writeGroup, ctx := errgroup.WithContext(request.GetContext())
+	err = client.checkValidApiConnection(ctx, authorizationModelId)
+	if err != nil {
+		return nil, err
+	}
+
 	writeGroup.SetLimit(int(maxParallelReqs))
 	writeResponses := make([]ClientWriteResponse, len(writeChunks))
 	for index, writeBody := range writeChunks {
@@ -1724,6 +1742,11 @@ func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCh
 		return nil, err 
 	}
 
+	group.Go(func() error {
+		// if the connection is probelmatic, we will return error to the overall
+		// response rather than individual response
+		return client.checkValidApiConnection(ctx, authorizationModelId)
+	})
 	for index, checkBody := range *request.GetBody() {
 		index, checkBody := index, checkBody
 		group.Go(func() error {

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -1494,7 +1494,7 @@ func Test{{appShortName}}Client(t *testing.T) {
 			Options(badOptions).
 			Execute()
 		if err == nil {
-			t.Fatalf("Invalid auth model ID shoudl result in error")
+			t.Fatalf("Invalid auth model ID should result in error")
 		}
 	})
 

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -24,11 +24,41 @@ type TestDefinition struct {
 func Test{{appShortName}}Client(t *testing.T) {
 	fgaClient, err := NewSdkClient(&ClientConfiguration{
 		ApiHost: "api.fga.example",
-		StoreId: "6c181474-aaa1-4df7-8929-6e7b3a992754",
+		StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
 	})
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
+
+	t.Run("Allow client to have no store ID specified", func(t *testing.T){
+        _, err := NewSdkClient(&ClientConfiguration{
+		    ApiHost: "api.fga.example",
+	    })
+	    if err != nil {
+		    t.Fatalf("Expect no error when store id is not specified but has %v", err)
+	    }
+	})
+
+	t.Run("Validate store ID when specified", func(t *testing.T){
+        _, err := NewSdkClient(&ClientConfiguration{
+		    ApiHost: "api.fga.example",
+		    StoreId: "error",
+	    })
+	    if err == nil {
+		    t.Fatalf("Expect invalid store ID to result in error but there is none")
+	    }
+	})
+
+	t.Run("Validate auth model ID when specified", func(t *testing.T){
+        _, err := NewSdkClient(&ClientConfiguration{
+		    ApiHost: "api.fga.example",
+		    StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
+			AuthorizationModelId: {{packageName}}.PtrString("BadAuthID"),
+	    })
+	    if err == nil {
+		    t.Fatalf("Expect invalid auth mode ID to result in error but there is none")
+	    }
+	})
 
 	/* Stores */
 	t.Run("ListStores", func(t *testing.T) {
@@ -682,6 +712,36 @@ func Test{{appShortName}}Client(t *testing.T) {
 		}
 	})
 
+	t.Run("Write with invalid auth model id", func(t *testing.T) {
+		test := TestDefinition{
+			Name:           "Write",
+			JsonResponse:   `{}`,
+			ResponseStatus: http.StatusOK,
+			Method:         http.MethodPost,
+			RequestPath:    "write",
+		}
+		requestBody := ClientWriteRequest{
+			Writes: &[]ClientTupleKey{ {
+				User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+				Relation: "viewer",
+				Object:   "document:roadmap",
+			} },
+		}
+		options := ClientWriteOptions{
+			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
+		}
+
+		var expectedResponse map[string]interface{}
+		if err := json.Unmarshal([]byte(test.JsonResponse), &expectedResponse); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		_, err := fgaClient.Write(context.Background()).Body(requestBody).Options(options).Execute()
+		if err == nil {
+			t.Fatalf("Expect error due to invalid auth model ID but there is none")
+		}
+	})
+
 	t.Run("WriteNonTransaction", func(t *testing.T) {
 		test := TestDefinition{
 			Name:           "Write",
@@ -998,6 +1058,16 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// check with invalid auth model id should result in error
+		badOptions := ClientCheckOptions{
+			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.Check(context.Background()).Body(requestBody).Options(badOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad auth model id but there is none")
+		}
+
 	})
 
 	t.Run("BatchCheck", func(t *testing.T) {
@@ -1093,6 +1163,16 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+		// BatchCheck with invalid auth model ID should fail
+		badOptions := ClientBatchCheckOptions{
+			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
+			MaxParallelRequests:  {{packageName}}.PtrInt32(5),
+		}
+		_, err = fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(badOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
+
 	})
 
 	t.Run("Expand", func(t *testing.T) {
@@ -1141,6 +1221,14 @@ func Test{{appShortName}}Client(t *testing.T) {
 		_, err = fgaClient.Expand(context.Background()).Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
+		}
+		// Invalid auth model ID should result in error
+		badOptions := ClientExpandOptions{
+			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.Expand(context.Background()).Body(requestBody).Options(badOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error for invalid auth model id but there is none")
 		}
 	})
 
@@ -1207,6 +1295,17 @@ func Test{{appShortName}}Client(t *testing.T) {
 		_, err = fgaClient.ListObjects(context.Background()).Body(requestBody).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
+		}
+		// Invalid auth model id should result in error
+		badOptions := ClientListObjectsOptions{
+			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ListObjects(context.Background()).
+			Body(requestBody).
+			Options(badOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid auth model id but there is none")
 		}
 	})
 
@@ -1285,6 +1384,18 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+		// Invalid auth model ID should result in error
+		badOptions := ClientListRelationsOptions{
+			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ListRelations(context.Background()).
+			Body(requestBody).
+			Options(badOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
+
 	})
 
 	t.Run("ListRelationsNoRelationsProvided", func(t *testing.T) {
@@ -1374,6 +1485,17 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error:%v, got: %v", expectedError, err)
 		}
+
+		// Invalid auth model id should result in error
+		badOptions := ClientReadAssertionsOptions{
+			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadAssertions(context.Background()).
+			Options(badOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Invalid auth model ID shoudl result in error")
+		}
 	})
 
 	t.Run("WriteAssertions", func(t *testing.T) {
@@ -1421,6 +1543,16 @@ func Test{{appShortName}}Client(t *testing.T) {
 		expectedError := "Required parameter AuthorizationModelId was not provided"
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error:%v, got: %v", expectedError, err)
+		}
+		badOptions := ClientWriteAssertionsOptions{
+			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.WriteAssertions(context.Background()).
+			Body(requestBody).
+			Options(badOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Invalid auth model id should result in error but there is none")
 		}
 	})
 }

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -766,8 +766,9 @@ func Test{{appShortName}}Client(t *testing.T) {
 				Object:   "document:planning",
 			} },
 		}
+		const authModelId = "01GAHCE4YVKPQEKZQHT2R89MQV"
 		options := ClientWriteOptions{
-			AuthorizationModelId: {{packageName}}.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),
+			AuthorizationModelId: {{packageName}}.PtrString(authModelId),
 			Transaction: &TransactionOptions{
 				Disable:             true,
 				MaxParallelRequests: 5,
@@ -789,6 +790,11 @@ func Test{{appShortName}}Client(t *testing.T) {
 					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
 				}
 				return resp, nil
+			},
+		)
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s://%s/stores/%s/authorization-models/%s", fgaClient.GetConfig().ApiScheme, fgaClient.GetConfig().ApiHost, fgaClient.GetConfig().StoreId, authModelId),
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(http.StatusOK, ""), nil
 			},
 		)
 		data, err := fgaClient.Write(context.Background()).Body(requestBody).Options(options).Execute()
@@ -1106,8 +1112,10 @@ func Test{{appShortName}}Client(t *testing.T) {
 			Object:   "document:roadmap",
 		} }
 
+		const authModelId = "01GAHCE4YVKPQEKZQHT2R89MQV"
+
 		options := ClientBatchCheckOptions{
-			AuthorizationModelId: {{packageName}}.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),
+			AuthorizationModelId: {{packageName}}.PtrString(authModelId),
 			MaxParallelRequests:  {{packageName}}.PtrInt32(5),
 		}
 
@@ -1127,13 +1135,23 @@ func Test{{appShortName}}Client(t *testing.T) {
 				return resp, nil
 			},
 		)
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s://%s/stores/%s/authorization-models", fgaClient.GetConfig().ApiScheme, fgaClient.GetConfig().ApiHost, fgaClient.GetConfig().StoreId),
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(http.StatusOK, ""), nil
+			},
+		)
+        httpmock.RegisterResponder("GET", fmt.Sprintf("%s://%s/stores/%s/authorization-models/%s", fgaClient.GetConfig().ApiScheme, fgaClient.GetConfig().ApiHost, fgaClient.GetConfig().StoreId, authModelId),
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(http.StatusOK, ""), nil
+			},
+		)
 		got, err := fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(options).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
 
-		if httpmock.GetTotalCallCount() != 4 {
-			t.Fatalf("{{appShortName}}Client.%v() - wanted %v calls to /check, got %v", test.Name, 4, httpmock.GetTotalCallCount())
+		if httpmock.GetTotalCallCount() != 5 {
+			t.Fatalf("{{appShortName}}Client.%v() - wanted %v calls to /check + 1 call to validate auth model, got %v", test.Name, 4, httpmock.GetTotalCallCount())
 		}
 
 		if len(*got) != len(requestBody) {
@@ -1174,6 +1192,84 @@ func Test{{appShortName}}Client(t *testing.T) {
 		}
 
 	})
+
+
+	t.Run("BatchCheckConnectionProblem", func(t *testing.T) {
+		test := TestDefinition{
+			Name:           "Check",
+			JsonResponse:   `{"allowed":true, "resolution":""}`,
+			ResponseStatus: http.StatusOK,
+			Method:         http.MethodPost,
+			RequestPath:    "check",
+		}
+		requestBody := ClientBatchCheckBody{ {
+			User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+			Relation: "viewer",
+			Object:   "document:roadmap",
+			ContextualTuples: &[]ClientTupleKey{ {
+				User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+				Relation: "editor",
+				Object:   "document:roadmap",
+			} },
+		}, {
+			User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+			Relation: "admin",
+			Object:   "document:roadmap",
+			ContextualTuples: &[]ClientTupleKey{ {
+				User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+				Relation: "editor",
+				Object:   "document:roadmap",
+			} },
+		}, {
+			User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+			Relation: "creator",
+			Object:   "document:roadmap",
+		}, {
+			User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+			Relation: "deleter",
+			Object:   "document:roadmap",
+		} }
+
+		const authModelId = "01GAHCE4YVKPQEKZQHT2R89MQV"
+
+		options := ClientBatchCheckOptions{
+			AuthorizationModelId: {{packageName}}.PtrString(authModelId),
+			MaxParallelRequests:  {{packageName}}.PtrInt32(5),
+		}
+
+		var expectedResponse {{packageName}}.CheckResponse
+		if err := json.Unmarshal([]byte(test.JsonResponse), &expectedResponse); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s://%s/stores/%s/%s", fgaClient.GetConfig().ApiScheme, fgaClient.GetConfig().ApiHost, fgaClient.GetConfig().StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s://%s/stores/%s/authorization-models", fgaClient.GetConfig().ApiScheme, fgaClient.GetConfig().ApiHost, fgaClient.GetConfig().StoreId),
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(http.StatusUnauthorized, ""), nil
+			},
+		)
+        httpmock.RegisterResponder("GET", fmt.Sprintf("%s://%s/stores/%s/authorization-models/%s", fgaClient.GetConfig().ApiScheme, fgaClient.GetConfig().ApiHost, fgaClient.GetConfig().StoreId, authModelId),
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(http.StatusUnauthorized, ""), nil
+			},
+		)
+		_, err := fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(options).Execute()
+		if err == nil {
+			t.Fatalf("Expect error but there is none")
+		}
+
+	})
+
 
 	t.Run("Expand", func(t *testing.T) {
 		test := TestDefinition{
@@ -1328,8 +1424,9 @@ func Test{{appShortName}}Client(t *testing.T) {
 				Object:   "document:roadmap",
 			} },
 		}
+		const authModelId = "01GAHCE4YVKPQEKZQHT2R89MQV"
 		options := ClientListRelationsOptions{
-			AuthorizationModelId: {{packageName}}.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),
+			AuthorizationModelId: {{packageName}}.PtrString(authModelId),
 		}
 
 		var expectedResponse {{packageName}}.CheckResponse
@@ -1358,6 +1455,16 @@ func Test{{appShortName}}Client(t *testing.T) {
 				return resp, nil
 			},
 		)
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s://%s/stores/%s/authorization-models", fgaClient.GetConfig().ApiScheme, fgaClient.GetConfig().ApiHost, fgaClient.GetConfig().StoreId),
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(http.StatusOK, ""), nil
+			},
+		)
+		httpmock.RegisterResponder("GET", fmt.Sprintf("%s://%s/stores/%s/authorization-models/%s", fgaClient.GetConfig().ApiScheme, fgaClient.GetConfig().ApiHost, fgaClient.GetConfig().StoreId, authModelId),
+			func(req *http.Request) (*http.Response, error) {
+				return httpmock.NewStringResponse(http.StatusOK, ""), nil
+			},
+		)
 
 		got, err := fgaClient.ListRelations(context.Background()).
 			Body(requestBody).
@@ -1367,8 +1474,8 @@ func Test{{appShortName}}Client(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
-		if httpmock.GetTotalCallCount() != 4 {
-			t.Fatalf("{{appShortName}}Client.%v() - wanted %v calls to /check, got %v", test.Name, 4, httpmock.GetTotalCallCount())
+		if httpmock.GetTotalCallCount() != 5 {
+			t.Fatalf("{{appShortName}}Client.%v() - wanted %v calls to /check + 1 call to validate auth model, got %v", test.Name, 4, httpmock.GetTotalCallCount())
 		}
 
 		_, err = got.MarshalJSON()

--- a/config/clients/go/template/client/errors.mustache
+++ b/config/clients/go/template/client/errors.mustache
@@ -19,3 +19,22 @@ func (e FgaRequiredParamError) Error() string {
 func (e FgaRequiredParamError) Param() string {
 	return e.param
 }
+
+// FgaInvalidUlidError Provides access to the body, error and model on returned errors.
+type FgaInvalidUlidError struct {
+	error string
+	param string
+}
+
+// Error returns non-empty string if there was an error.
+func (e FgaInvalidUlidError) Error() string {
+	if e.error == "" {
+		return "Parameter " + e.Param() + " is not a valid ULID"
+	}
+	return e.error
+}
+
+// Param returns the name of the invalid parameter
+func (e FgaInvalidUlidError) Param() string {
+	return e.param
+}

--- a/config/clients/go/template/client/errors.mustache
+++ b/config/clients/go/template/client/errors.mustache
@@ -20,21 +20,22 @@ func (e FgaRequiredParamError) Param() string {
 	return e.param
 }
 
-// FgaInvalidUlidError Provides access to the body, error and model on returned errors.
-type FgaInvalidUlidError struct {
+// FgaInvalidError Provides access to the body, error and model on returned errors.
+type FgaInvalidError struct {
 	error string
 	param string
+	description string
 }
 
 // Error returns non-empty string if there was an error.
-func (e FgaInvalidUlidError) Error() string {
+func (e FgaInvalidError) Error() string {
 	if e.error == "" {
-		return "Parameter " + e.Param() + " is not a valid ULID"
+		return "Parameter " + e.Param() + " is not a valid " + e.description
 	}
 	return e.error
 }
 
 // Param returns the name of the invalid parameter
-func (e FgaInvalidUlidError) Param() string {
+func (e FgaInvalidError) Param() string {
 	return e.param
 }

--- a/config/clients/go/template/configuration.mustache
+++ b/config/clients/go/template/configuration.mustache
@@ -6,6 +6,7 @@ import (
     "strings"
 
     "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/credentials"
+    "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/utils"
 )
 
 var SdkVersion = "{{packageVersion}}"
@@ -97,6 +98,10 @@ func (c *Configuration) ValidateConfig() error {
 
     if c.RetryParams != nil && c.RetryParams.MaxRetry > {{retryMaxAllowedNumber}} {
         return reportError("Configuration.RetryParams.MaxRetry exceeds maximum allowed limit of {{retryMaxAllowedNumber}}")
+    }
+
+    if c.StoreId != "" && !utils.IsWellFormedUlidString(c.StoreId) {
+		return reportError("Configuration.StoreId is not a valid ulid")
     }
 
     return nil

--- a/config/clients/go/template/utils/utils.mustache
+++ b/config/clients/go/template/utils/utils.mustache
@@ -1,0 +1,15 @@
+{{>partial_header}}
+package utils
+
+import (
+	"regexp"
+)
+
+// cUlidRegex contains the regex for valid ULID
+const cUlidRegex = "^[0-7][0-9A-HJKMNP-TV-Z]{25}$"
+
+// IsWellFormedUlidString returns whethr the ulidString is a properly formatted ulid string
+func IsWellFormedUlidString(ulidString string) bool {
+	re := regexp.MustCompile(cUlidRegex)
+	return re.MatchString(ulidString)
+}

--- a/config/clients/go/template/utils/utils_test.mustache
+++ b/config/clients/go/template/utils/utils_test.mustache
@@ -1,0 +1,50 @@
+{{>partial_header}}
+package utils
+
+import (
+	"testing"
+)
+
+func TestIsWellFormedUlidString(t *testing.T) {
+    tests := []struct {
+		name string
+		input string
+		isValid bool
+	}{
+		{
+		    name: "valid_ulid",
+		    input: "01GRC27AM72M4SGK4VBHF3DY0F",
+            isValid: true,
+		},
+		{
+		    name: "invalid_symbols",
+		    input: "01GRC27AM72M4S$^4VBHF3DY0F",
+            isValid: false,
+		},
+		{
+		    name: "not_start_in_0-7",
+		    input: "A1GRC27AM72M4SGK4VBHF3DY0F",
+            isValid: false,
+		},
+		{
+		    name: "too_long",
+		    input: "01GRC27AM72M4SGK4VBHF3DY0FA",
+            isValid: false,
+		},
+		{
+		    name: "too_short",
+		    input: "01GRC27AM72M4SGK4VBHF3DY0",
+            isValid: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isValid := IsWellFormedUlidString(test.input)
+			if isValid != test.isValid {
+				t.Errorf("Expect %s to be valid %v actual %v", test.input, test.isValid, isValid)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Description
Go SDK should validate auth model id and store id to ensure they are valid ulid 

## References
Part of https://github.com/openfga/go-sdk/issues/19
Generated Go Code: https://github.com/openfga/go-sdk/pull/28

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
