### PR TITLE
fix(go-sdk): allow setting user agent

### DIFF
--- a/config/clients/go/template/api_client.mustache
+++ b/config/clients/go/template/api_client.mustache
@@ -288,16 +288,17 @@ func (c *APIClient) prepareRequest(
 	}
 
 	// Add the user agent to the request.
-	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
+	localVarRequest.Header.Set("User-Agent", c.cfg.UserAgent)
+
+	for header, value := range c.cfg.DefaultHeaders {
+		localVarRequest.Header.Set(header, value)
+	}
 
 	if ctx != nil {
 		// add context to the request
 		localVarRequest = localVarRequest.WithContext(ctx)
 	}
 
-	for header, value := range c.cfg.DefaultHeaders {
-		localVarRequest.Header.Add(header, value)
-	}
 {{#withCustomMiddlewareFunction}}
 
 	if c.cfg.Middleware != nil {

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -58,8 +58,8 @@ func NewSdkClient(cfg *ClientConfiguration) (*{{appShortName}}Client, error) {
 		ApiHost:        cfg.ApiHost,
 		StoreId:        cfg.StoreId,
 		Credentials:    cfg.Credentials,
-		DefaultHeaders: make(map[string]string),
-		UserAgent:      {{packageName}}.GetSdkUserAgent(),
+		DefaultHeaders: cfg.DefaultHeaders,
+		UserAgent:      cfg.UserAgent,
 		Debug:          cfg.Debug,
 		RetryParams:    cfg.RetryParams,
 	})
@@ -603,7 +603,7 @@ type SdkClientDeleteStoreRequest struct {
 
 type SdkClientDeleteStoreRequestInterface interface{
 	Options(options ClientDeleteStoreOptions) SdkClientDeleteStoreRequestInterface
-	Execute() (*ClientDeleteStoreResponse, error)	
+	Execute() (*ClientDeleteStoreResponse, error)
 
     GetContext() _context.Context
     GetOptions() *ClientDeleteStoreOptions
@@ -882,7 +882,7 @@ type SdkClientReadLatestAuthorizationModelRequestInterface interface {
     Execute() (*ClientReadAuthorizationModelResponse, error)
 
     GetContext()  _context.Context
-	GetOptions() *ClientReadLatestAuthorizationModelOptions 
+	GetOptions() *ClientReadLatestAuthorizationModelOptions
 }
 
 type ClientReadLatestAuthorizationModelOptions struct {
@@ -1622,7 +1622,7 @@ type SdkClientBatchCheckRequestInterface interface {
 	Options(options ClientBatchCheckOptions) SdkClientBatchCheckRequestInterface
 	Body(body ClientBatchCheckBody) SdkClientBatchCheckRequestInterface
 	Execute() (*ClientBatchCheckResponse, error)
-	GetAuthorizationModelIdOverride() *string 
+	GetAuthorizationModelIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody() *ClientBatchCheckBody
@@ -1917,7 +1917,7 @@ type SdkClientListRelationsRequestInterface interface {
 	Body(body ClientListRelationsRequest) SdkClientListRelationsRequestInterface
     Execute() (*ClientListRelationsResponse, error)
 	GetAuthorizationModelIdOverride() *string
-	
+
 	GetContext() _context.Context
 	GetBody() *ClientListRelationsRequest
 	GetOptions() *ClientListRelationsOptions
@@ -2100,7 +2100,7 @@ type SdkClientWriteAssertionsRequest struct {
 type SdkClientWriteAssertionsRequestInterface interface {
 	Options(options ClientWriteAssertionsOptions) SdkClientWriteAssertionsRequestInterface
     Body(body ClientWriteAssertionsRequest) SdkClientWriteAssertionsRequestInterface
-	Execute() (*ClientWriteAssertionsResponse, error) 
+	Execute() (*ClientWriteAssertionsResponse, error)
 	GetAuthorizationModelIdOverride() *string
 
 	GetContext() _context.Context

--- a/config/clients/go/template/configuration.mustache
+++ b/config/clients/go/template/configuration.mustache
@@ -38,9 +38,8 @@ func DefaultRetryParams() *RetryParams {
 }
 
 func GetSdkUserAgent() string {
-	userAgent := strings.Replace("{{#userAgent}}{{{.}}}{{/userAgent}}", "{sdkId}", "{{sdkId}}", -1)
+    userAgent := strings.Replace("{{#userAgent}}{{{.}}}{{/userAgent}}", "{sdkId}", "{{sdkId}}", -1)
     userAgent = strings.Replace(userAgent, "{packageVersion}", SdkVersion, -1)
-
     return userAgent
 }
 
@@ -51,14 +50,22 @@ func NewConfiguration(config Configuration) (*Configuration, error) {
         ApiHost:        config.ApiHost,
         StoreId:        config.StoreId,
         Credentials:    config.Credentials,
-        DefaultHeaders: make(map[string]string),
-        UserAgent:      GetSdkUserAgent(),
+        DefaultHeaders: config.DefaultHeaders,
+        UserAgent:      config.UserAgent,
         Debug:          false,
         RetryParams:    config.RetryParams,
     }
 
     if cfg.ApiScheme == "" {
         cfg.ApiScheme = "https"
+    }
+
+    if cfg.UserAgent == "" {
+        cfg.UserAgent = GetSdkUserAgent()
+    }
+
+    if cfg.DefaultHeaders == nil {
+        cfg.DefaultHeaders = make(map[string]string)
     }
 
     err := cfg.ValidateConfig()


### PR DESCRIPTION
## Description

- Allows overriding `User-Agent` request header by setting it in `openfga.Configuration.DefaultHeaders`
- Allows overriding `User-Agent` request header by setting it in `openfga.Configuration.UserAgent`
- If specified, `openfga.Configuration.DefaultHeaders["User-Agent"]` is preferred over `openfga.Configuration.UserAgent`

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
