### PR TITLE
fix: use static user agent value

### DIFF
--- a/config/clients/dotnet/template/Configuration_Configuration.mustache
+++ b/config/clients/dotnet/template/Configuration_Configuration.mustache
@@ -51,6 +51,8 @@ public class Configuration {
     /// <value>Version of the package.</value>
     public const string Version = "{{packageVersion}}";
 
+    private const string DefaultUserAgent = "{{{userAgent}}}";
+
     #endregion Constants
 
     #region Constructors
@@ -68,11 +70,10 @@ public class Configuration {
     /// </summary>
     /// <exception cref="FgaRequiredParamError"></exception>
     public Configuration() {
-        UserAgent = "{{#userAgent}}{{{.}}}{{/userAgent}}".Replace("{sdkId}", "{{sdkId}}").Replace("{packageVersion}", Version);
         DefaultHeaders ??= new Dictionary<string, string>();
 
         if (!DefaultHeaders.ContainsKey("User-Agent")) {
-            DefaultHeaders.Add("User-Agent", UserAgent);
+            DefaultHeaders.Add("User-Agent", DefaultUserAgent);
         }
     }
 

--- a/config/clients/go/template/configuration.mustache
+++ b/config/clients/go/template/configuration.mustache
@@ -3,12 +3,15 @@ package {{packageName}}
 
 import (
     "net/http"
-    "strings"
 
     "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/credentials"
 )
 
-var SdkVersion = "{{packageVersion}}"
+const (
+    SdkVersion = "{{packageVersion}}"
+
+    defaultUserAgent = "{{{userAgent}}}"
+)
 
 // RetryParams configures configuration for retry in case of HTTP too many request
 type RetryParams struct {
@@ -38,10 +41,7 @@ func DefaultRetryParams() *RetryParams {
 }
 
 func GetSdkUserAgent() string {
-	userAgent := strings.Replace("{{#userAgent}}{{{.}}}{{/userAgent}}", "{sdkId}", "{{sdkId}}", -1)
-    userAgent = strings.Replace(userAgent, "{packageVersion}", SdkVersion, -1)
-
-    return userAgent
+    return defaultUserAgent
 }
 
 // NewConfiguration returns a new Configuration object

--- a/config/clients/js/template/configuration.mustache
+++ b/config/clients/js/template/configuration.mustache
@@ -8,8 +8,11 @@ import { assertParamExists, isWellFormedUlidString, isWellFormedUriString } from
 
 // default maximum number of retry
 const DEFAULT_MAX_RETRY = {{{defaultMaxRetry}}};
+
 // default minimum wait period in retry - but will backoff exponentially
 const DEFAULT_MIN_WAIT_MS = {{{defaultMinWaitInMs}}};
+
+const DEFAULT_USER_AGENT = "{{{userAgent}}}";
 
 export interface RetryParams {
   maxRetry?: number;
@@ -142,7 +145,7 @@ export class Configuration {
     baseOptions.headers = baseOptions.headers || {};
 
     if (typeof process === "object" && process.title === "node" && !baseOptions.headers["User-Agent"]) {
-      baseOptions.headers["User-Agent"] = "{{#userAgent}}{{{.}}}{{/userAgent}}".replace("{sdkId}", "{{sdkId}}").replace("{packageVersion}", Configuration.sdkVersion);
+      baseOptions.headers["User-Agent"] = DEFAULT_USER_AGENT;
     }
 
     this.baseOptions = baseOptions;

--- a/config/clients/python/template/api_client.mustache
+++ b/config/clients/python/template/api_client.mustache
@@ -29,6 +29,9 @@ from {{packageName}} import rest
 from {{packageName}}.exceptions import ApiValueError, ApiException, FgaValidationException, RateLimitExceededError
 
 
+DEFAULT_USER_AGENT = '{{{userAgent}}}'
+
+
 def random_time(loop_count, min_wait_in_ms):
     """
     Helper function to return the time (in s) to wait before retry
@@ -86,7 +89,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = '{{userAgent}}'.replace('{sdkId}', '{{sdkId}}').replace('{packageVersion}', '{{packageVersion}}')
+        self.user_agent = DEFAULT_USER_AGENT
         self.client_side_validation = configuration.client_side_validation
 
     {{#asyncio}}

--- a/config/common/config.base.json
+++ b/config/common/config.base.json
@@ -12,7 +12,7 @@
   "author": "OpenFGA",
   "gitHost": "github.com",
   "gitUserId": "openfga",
-  "userAgent": "openfga-sdk {sdkId}/{packageVersion}",
+  "userAgent": "openfga-sdk $sdk_language/$package_version",
   "supportInfo": "https://discord.gg/8naAwJfWN6",
   "docsUrl": "https://openfga.dev/docs",
   "apiDocsUrl": "https://openfga.dev/api/service",

--- a/scripts/build_client.sh
+++ b/scripts/build_client.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Build a config from common + overrides
+package_version=$(jq -r '.packageVersion' "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/config.overrides.json")
+
+# shellcheck disable=SC2016
+http_user_agent="$(package_version=$package_version envsubst '$sdk_language,$package_version' < ./config/common/config.base.json | jq -r '.userAgent')"
+
+jq -rs --arg ua "$http_user_agent" 'reduce .[] as $item ({}; . * $item) | .userAgent = $ua' \
+  "${CONFIG_DIR}/common/config.base.json" "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/config.overrides.json" \
+    > "${TMP_DIR}/config.json"
+
+mkdir -p "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk"
+
+# Initialize the temporary template directory
+mkdir "${TMP_DIR}/template"
+
+# Copy the shared files into temp template
+cp -r "${CONFIG_DIR}/common/files/." "${TMP_DIR}/template/"
+
+# Copy the template files into temp template
+cp -r "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/template/." "${TMP_DIR}/template/"
+
+# Copy the CHANGELOG.md file into temp template
+cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/CHANGELOG.md.mustache" "${TMP_DIR}/template/"
+
+# Clear existing directory
+find "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk" -type f \
+  -not \( -name '.git' -or -name 'node_modules' -or -name '.idea' -or -name 'venv' \) -delete
+
+# Copy the generator ignore file into target directory (we need to do this before build otherwise openapi-generator ignores it)
+cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/.openapi-generator-ignore" "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk/"
+
+library=()
+[[ -n "$LIBRARY_TEMPLATE" ]] && library=(--library "$LIBRARY_TEMPLATE")
+
+# Generate the SDK
+docker run --rm \
+  -u "${CURRENT_UID}:${CURRENT_GID}" \
+  -v "${PWD}/docs:/docs" \
+  -v "${CLIENTS_OUTPUT_DIR}:/clients" \
+  -v "${TMP_DIR}:/config" \
+  --name openapi-generator \
+  "openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_CLI_DOCKER_TAG}" generate \
+  -i /docs/openapi/openfga.openapiv2.json \
+  --http-user-agent="$http_user_agent" \
+  "${library[@]}" \
+  -o "/clients/fga-${SDK_LANGUAGE}-sdk" \
+  -c /config/config.json \
+  -g "$(cat ./config/clients/"${SDK_LANGUAGE}"/generator.txt)"


### PR DESCRIPTION
## Description

Prevent string manipulation for user agent by rendering appropriate value during builds.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
