### PR TITLE
fix: exclude files when clearing output dirs

### DIFF
--- a/scripts/build_client.sh
+++ b/scripts/build_client.sh
@@ -29,8 +29,8 @@ cp -r "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/template/." "${TMP_DIR}/template/"
 cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/CHANGELOG.md.mustache" "${TMP_DIR}/template/"
 
 # Clear existing directory
-find "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk" -type f \
-  -not \( -name '.git' -or -name 'node_modules' -or -name '.idea' -or -name 'venv' \) -delete
+# shellcheck disable=SC2010
+cd "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk" && ls -A | grep -Ev '.git|node_modules|.idea|venv' | xargs rm -r && cd -
 
 # Copy the generator ignore file into target directory (we need to do this before build otherwise openapi-generator ignores it)
 cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/.openapi-generator-ignore" "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk/"


### PR DESCRIPTION
## Description

follow up to #136 to prevent deleting .git directory and other files when clearing out output directories.

## References

https://github.com/openfga/sdk-generator/pull/136

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
