### PR TITLE
fix(go-sdk): add retry logic to oauth flow

### DIFF
--- a/config/clients/go/template/api.mustache
+++ b/config/clients/go/template/api.mustache
@@ -8,8 +8,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	_math "math"
-	_rand "math/rand"
 	"time"
 {{#imports}}	"{{import}}"
 {{/imports}}
@@ -48,12 +46,6 @@ type {{classname}} interface {
 
 // {{classname}}Service {{classname}} service
 type {{classname}}Service service
-
-func randomTime(loopCount int, minWaitInMs int) int{
-    min := int(_math.Pow(2, float64(loopCount))) * minWaitInMs;
-    max := int(_math.Pow(2, float64(loopCount + 1))) * minWaitInMs;
-    return _rand.Intn(max - min + 1) + min
-}
 
 {{#operation}}
 
@@ -423,7 +415,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 
 		if localVarHTTPResponse.StatusCode == _nethttp.StatusTooManyRequests {
 			if i < maxRetry {
-				time.Sleep(time.Duration(randomTime(i, minWaitInMs)) * time.Millisecond)
+				time.Sleep(time.Duration(internalutils.RandomTime(i, minWaitInMs)) * time.Millisecond)
 				continue
 			}
 			// maximum number of retry reached
@@ -447,7 +439,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 
 		if localVarHTTPResponse.StatusCode >= _nethttp.StatusInternalServerError {
             if localVarHTTPResponse.StatusCode != _nethttp.StatusNotImplemented && i < maxRetry {
-                time.Sleep(time.Duration(randomTime(i, minWaitInMs)) * time.Millisecond)
+                time.Sleep(time.Duration(internalutils.RandomTime(i, minWaitInMs)) * time.Millisecond)
                 continue
             }
 			newErr := FgaApiInternalError{

--- a/config/clients/go/template/internal/utils/utils.mustache
+++ b/config/clients/go/template/internal/utils/utils.mustache
@@ -2,6 +2,8 @@
 package internalutils
 
 import (
+	_math "math"
+	_rand "math/rand"
 	"regexp"
 )
 
@@ -12,4 +14,11 @@ const cUlidRegex = "^[0-7][0-9A-HJKMNP-TV-Z]{25}$"
 func IsWellFormedUlidString(ulidString string) bool {
 	re := regexp.MustCompile(cUlidRegex)
 	return re.MatchString(ulidString)
+}
+
+// RandomTime provides a randomized time
+func RandomTime(loopCount int, minWaitInMs int) int{
+    min := int(_math.Pow(2, float64(loopCount))) * minWaitInMs;
+    max := int(_math.Pow(2, float64(loopCount + 1))) * minWaitInMs;
+    return _rand.Intn(max - min + 1) + min
 }

--- a/config/clients/go/template/oauth2/internal/token.go
+++ b/config/clients/go/template/oauth2/internal/token.go
@@ -19,7 +19,12 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	internalutils "github.com/openfga/go-sdk/internal/utils"
 )
+
+const cMaxRetry = 3
+const cMinWaitInMs = 50
 
 // Token represents the credentials used to authorize
 // the requests to access protected resources on the OAuth 2.0
@@ -226,7 +231,7 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 	return token, err
 }
 
-func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
+func singleTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 	r, err := ContextClient(ctx).Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
@@ -280,6 +285,21 @@ func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 		return nil, errors.New("oauth2: server response missing access_token")
 	}
 	return token, nil
+}
+
+func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
+    var token *Token
+    var err error
+
+    for i := 0; i < cMaxRetry; i++ {
+
+        token, err = singleTokenRoundTrip(ctx, req)
+        if err == nil {
+            return token, err
+        }
+        time.Sleep(time.Duration(internalutils.RandomTime(i, cMinWaitInMs)) * time.Millisecond)
+    }
+    return nil, err
 }
 
 type RetrieveError struct {

--- a/config/clients/go/template/oauth2/internal/token_test.go
+++ b/config/clients/go/template/oauth2/internal/token_test.go
@@ -13,6 +13,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+    "github.com/jarcoal/httpmock"
 )
 
 func TestRetrieveToken_InParams(t *testing.T) {
@@ -62,6 +64,60 @@ func TestRetrieveTokenWithContexts(t *testing.T) {
 	close(retrieved)
 	if err == nil {
 		t.Errorf("RetrieveToken (with cancelled context) = nil; want error")
+	}
+}
+
+// Test the retry logic where request is successful at the end
+func TestRetrieveTokenWithContextsRetry(t *testing.T) {
+	ResetAuthCache()
+	const clientID = "client-id"
+
+    type JSONResponse struct {
+        AccessToken string `json:"access_token"`
+        TokenType string `json:"token_type"`
+    }
+    expectedResponse := JSONResponse{
+        AccessToken: "ACCESS_TOKEN",
+        TokenType: "bearer",
+    }
+
+    httpmock.Activate()
+    defer httpmock.DeactivateAndReset()
+    firstMock := httpmock.NewStringResponder(429, "")
+    secondMock, _ := httpmock.NewJsonResponder(200, expectedResponse)
+
+    const testURL = "http://testserver.com"
+    httpmock.RegisterResponder("POST", testURL,
+        firstMock.Then(firstMock).Then(firstMock).Then(secondMock),
+    )
+
+	_, err := RetrieveToken(context.Background(), clientID, "", testURL, url.Values{}, AuthStyleUnknown)
+	if err != nil {
+		t.Errorf("RetrieveToken (with background context) = %v; want no error", err)
+	}
+}
+
+func TestRetrieveTokenWithContextsFailure(t *testing.T) {
+	ResetAuthCache()
+	const clientID = "client-id"
+
+    type JSONResponse struct {
+        AccessToken string `json:"access_token"`
+        TokenType string `json:"token_type"`
+    }
+
+    httpmock.Activate()
+    defer httpmock.DeactivateAndReset()
+    firstMock := httpmock.NewStringResponder(429, "")
+
+    const testURL = "http://testserver.com"
+    httpmock.RegisterResponder("POST", testURL,
+        firstMock,
+    )
+
+	_, err := RetrieveToken(context.Background(), clientID, "", testURL, url.Values{}, AuthStyleUnknown)
+	if err == nil {
+        t.Errorf("Expect error to be returned when oauth server fails consistently")
 	}
 }
 


### PR DESCRIPTION

## Description
Add in retry logic for oauth token flow

## References
Close https://github.com/openfga/go-sdk/issues/20


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
