### PR TITLE
fix(go-sdk): OpenFgaClient should satisfy SdkClient interface

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -16,6 +16,8 @@ import (
 
 var (
 	_ _context.Context
+	// Ensure the SdkClient fits OpenFgaClient interface
+	_ SdkClient = (*OpenFgaClient)(nil)
 )
 
 var DEFAULT_MAX_METHOD_PARALLEL_REQS = int32({{clientMaxMethodParallelRequests}})
@@ -218,28 +220,28 @@ type SdkClient interface {
 	/*
 	 * ReadAuthorizationModel Read a particular authorization model.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientReadAuthorizationModelRequest
+	 * @return SdkClientReadAuthorizationModelRequestInterface
 	 */
-	ReadAuthorizationModel(ctx _context.Context) SdkClientReadAuthorizationModelRequest
+	ReadAuthorizationModel(ctx _context.Context) SdkClientReadAuthorizationModelRequestInterface
 
 	/*
 	 * ReadAuthorizationModelExecute executes the ReadAuthorizationModel request
 	 * @return *ClientReadAuthorizationModelResponse
 	 */
-	ReadAuthorizationModelExecute(request SdkClientReadAuthorizationModelRequest) (*ClientReadAuthorizationModelResponse, error)
+	ReadAuthorizationModelExecute(request SdkClientReadAuthorizationModelRequestInterface) (*ClientReadAuthorizationModelResponse, error)
 
 	/*
 	 * ReadLatestAuthorizationModel Reads the latest authorization model (note: this ignores the model id in configuration).
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return SdkClientReadLatestAuthorizationModelRequest
+	 * @return SdkClientReadLatestAuthorizationModelRequestInterface
 	 */
-	ReadLatestAuthorizationModel(ctx _context.Context) SdkClientReadLatestAuthorizationModelRequest
+	ReadLatestAuthorizationModel(ctx _context.Context) SdkClientReadLatestAuthorizationModelRequestInterface
 
 	/*
 	 * ReadLatestAuthorizationModelExecute executes the ReadLatestAuthorizationModel request
 	 * @return *ClientReadAuthorizationModelResponse
 	 */
-	ReadLatestAuthorizationModelExecute(request SdkClientReadLatestAuthorizationModelRequest) (*ClientReadAuthorizationModelResponse, error)
+	ReadLatestAuthorizationModelExecute(request SdkClientReadLatestAuthorizationModelRequestInterface) (*ClientReadAuthorizationModelResponse, error)
 
 	/* Relationship Tuples */
 


### PR DESCRIPTION


## Description
OpenFgaClient did not satisfy SdkClient interface as there are discrepancy in ReadAuthorizationModel and ReadLatestAuthorizationModel method

## References
Close https://github.com/openfga/go-sdk/issues/34
Corresponding go-sdk changes https://github.com/openfga/go-sdk/pull/35

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
