### PR TITLE
fix(go-sdk): allow empty string for ulid

### DIFF
--- a/config/clients/go/template/api.mustache
+++ b/config/clients/go/template/api.mustache
@@ -115,7 +115,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
         if a.client.cfg.StoreId == "" {
 		    return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("Configuration.StoreId is required and must be specified to call this method")
         }
-		if !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
+		if a.client.cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(a.client.cfg.StoreId) {
             return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("Configuration.StoreId is invalid")
 		}
     {{/pathParams.0}}

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -76,7 +76,7 @@ func NewSdkClient(cfg *ClientConfiguration) (*{{appShortName}}Client, error) {
 
 	// store id is already validate as part of configuration validation
 
-	if cfg.AuthorizationModelId != nil && !internalutils.IsWellFormedUlidString(*cfg.AuthorizationModelId) {
+	if cfg.AuthorizationModelId != nil && *cfg.AuthorizationModelId != "" && !internalutils.IsWellFormedUlidString(*cfg.AuthorizationModelId) {
 		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
 	}
 

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -39,6 +39,16 @@ func Test{{appShortName}}Client(t *testing.T) {
 	    }
 	})
 
+	t.Run("Allow client to have empty store ID specified", func(t *testing.T){
+        _, err := NewSdkClient(&ClientConfiguration{
+		    ApiHost: "api.fga.example",
+			StoreId: "",
+	    })
+	    if err != nil {
+		    t.Fatalf("Expect no error when store id is empty but has %v", err)
+	    }
+	})
+
 	t.Run("Validate store ID when specified", func(t *testing.T){
         _, err := NewSdkClient(&ClientConfiguration{
 		    ApiHost: "api.fga.example",
@@ -59,6 +69,18 @@ func Test{{appShortName}}Client(t *testing.T) {
 		    t.Fatalf("Expect invalid auth mode ID to result in error but there is none")
 	    }
 	})
+
+	t.Run("Allow auth model ID to be empty when specified", func(t *testing.T){
+        _, err := NewSdkClient(&ClientConfiguration{
+		    ApiHost: "api.fga.example",
+		    StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
+			AuthorizationModelId: {{packageName}}.PtrString(""),
+	    })
+	    if err != nil {
+		    t.Fatalf("Expect no error when auth model id is empty but has %v", err)
+	    }
+	})
+
 
 	/* Stores */
 	t.Run("ListStores", func(t *testing.T) {


### PR DESCRIPTION
## Description
For Go-SDK, allow empty string for ulid

## References
Close https://github.com/openfga/go-sdk/issues/36
Corresponding Go-SDK change: https://github.com/openfga/go-sdk/pull/37

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
