### PR TITLE
fix(go-sdk): miss path where we validate ulid

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -412,7 +412,7 @@ func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModel
 		modelId = authorizationModelId
 	}
 
-	if modelId != nil && !internalutils.IsWellFormedUlidString(*modelId) {
+	if modelId != nil && *modelId != "" && !internalutils.IsWellFormedUlidString(*modelId) {
 		return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
 	}
 	return modelId, nil


### PR DESCRIPTION
## Description
For Go-SDK, there is a path where we do not allow empty ulid

## References
Follow up on https://github.com/openfga/sdk-generator/pull/145

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
