### PR TITLE
fix(go-sdk): client option + body not respected

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -476,11 +476,11 @@ func (client *{{appShortName}}Client) ListStoresExecute(request SdkClientListSto
 	req := client.{{appShortName}}Api.ListStores(request.GetContext())
 	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
-		req.PageSize(*pageSize)
+		req = req.PageSize(*pageSize)
 	}
 	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
-		req.ContinuationToken(*continuationToken)
+		req = req.ContinuationToken(*continuationToken)
 	}
 	data, _, err := req.Execute()
 	if err != nil {
@@ -720,11 +720,11 @@ func (client *{{appShortName}}Client) ReadAuthorizationModelsExecute(request Sdk
 	req := client.{{appShortName}}Api.ReadAuthorizationModels(request.GetContext())
 	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
-		req.PageSize(*pageSize)
+		req = req.PageSize(*pageSize)
 	}
 	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
-		req.ContinuationToken(*continuationToken)
+		req = req.ContinuationToken(*continuationToken)
 	}
 	data, _, err := req.Execute()
 	if err != nil {
@@ -881,7 +881,7 @@ func (client *{{appShortName}}Client) ReadAuthorizationModelExecute(request SdkC
 	if err != nil {
 		return nil, err
 	}
-	if authorizationModelId == nil {
+	if authorizationModelId == nil || *authorizationModelId == "" {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
 	data, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(request.GetContext(), *authorizationModelId).Execute()
@@ -1031,12 +1031,17 @@ func (client *{{appShortName}}Client) ReadChangesExecute(request SdkClientReadCh
 	req := client.{{appShortName}}Api.ReadChanges(request.GetContext())
 	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
-		req.PageSize(*pageSize)
+		req = req.PageSize(*pageSize)
 	}
 	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if continuationToken != nil {
-		req.ContinuationToken(*continuationToken)
+		req = req.ContinuationToken(*continuationToken)
 	}
+	requestBody := request.GetBody()
+	if requestBody != nil {
+		req = req.Type_(requestBody.Type)
+	}
+
 	data, _, err := req.Execute()
 	if err != nil {
 		return nil, err
@@ -1479,7 +1484,7 @@ func (client *{{appShortName}}Client) WriteTuplesExecute(request SdkClientWriteT
 		Writes: request.GetBody(),
 	})
 	if request.GetOptions() != nil {
-		baseReq.Options(*request.GetOptions())
+		baseReq = baseReq.Options(*request.GetOptions())
 	}
 	return baseReq.Execute()
 }
@@ -1543,7 +1548,7 @@ func (client *{{appShortName}}Client) DeleteTuplesExecute(request SdkClientDelet
 		Deletes: request.GetBody(),
 	})
 	if request.GetOptions() != nil {
-		baseReq.Options(*request.GetOptions())
+		baseReq = baseReq.Options(*request.GetOptions())
 	}
 	return baseReq.Execute()
 }
@@ -2147,7 +2152,7 @@ func (client *{{appShortName}}Client) ReadAssertionsExecute(request SdkClientRea
 	if err != nil {
 		return nil, err
 	}
-	if authorizationModelId == nil {
+	if authorizationModelId == nil || *authorizationModelId == "" {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
 	data, _, err := client.{{appShortName}}Api.ReadAssertions(request.GetContext(), *authorizationModelId).Execute()
@@ -2251,7 +2256,7 @@ func (client *{{appShortName}}Client) WriteAssertionsExecute(request SdkClientWr
 	if err != nil {
 		return nil, err
 	}
-	if authorizationModelId == nil {
+	if authorizationModelId == nil || *authorizationModelId == ""  {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
 	for index := 0; index < len(*request.GetBody()); index++ {

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -489,9 +489,17 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if *(*got.AuthorizationModel).Id != modelId {
 			t.Fatalf("{{appShortName}}Client.%v() = %v, want %v", test.Name, string(responseJson), test.JsonResponse)
 		}
-		// ReadAuthorizationModel without options should work
+		// ReadAuthorizationModel without options should not work
 		_, err = fgaClient.ReadAuthorizationModel(context.Background()).Execute()
 		expectedError := "Required parameter AuthorizationModelId was not provided"
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error:%v, got: %v", expectedError, err)
+		}
+		// ReadAuthorizationModel with options of empty string should not work
+		badOptions := ClientReadAuthorizationModelOptions{
+			AuthorizationModelId: {{packageName}}.PtrString(""),
+		}
+		_, err = fgaClient.ReadAuthorizationModel(context.Background()).Options(badOptions).Execute()
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error:%v, got: %v", expectedError, err)
 		}


### PR DESCRIPTION

## Description
Client not taking in details for option and body in list stores/read changes etc. In addition, read auth model does not check and error when auth model is id string is empty

## References
Close https://github.com/openfga/go-sdk/issues/41
Close https://github.com/openfga/go-sdk/issues/42

Corresponding Go SDK changes: https://github.com/openfga/go-sdk/pull/43

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
