### PR TITLE
fix(python): Convert tabs to spaces

### DIFF
--- a/config/clients/python/template/api_test.mustache
+++ b/config/clients/python/template/api_test.mustache
@@ -545,10 +545,10 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
                                 ],
                             ),
                         ),
-					    writer=Userset(
+                            writer=Userset(
                             this=dict(),
                         ),
-		            )
+                    )
                 )
             ]
             authorization_model = AuthorizationModel(id='01G5JAVJ41T49E9TT3SKVS7X1J', schema_version = "1.1",
@@ -768,7 +768,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
                     TypeDefinition(
                         type="document",
                         relations=dict(
-			        		writer=Userset(
+                                writer=Userset(
                                 this=dict(),
                             ),
                             reader=Userset(
@@ -782,7 +782,7 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
                                     ],
                                 ),
                             ),
-		                )
+                        )
                     ),
                 ],
             )

--- a/config/clients/python/template/client/models/list_objects_request.mustache
+++ b/config/clients/python/template/client/models/list_objects_request.mustache
@@ -11,10 +11,10 @@ class ClientListObjectsRequest():
     """
 
     def __init__(self, user: str, relation: str, type: str, contextual_tuples: List[ClientTuple]=None):
-        self._user = user	
+        self._user = user
         self._relation = relation
         self._type = type
-		self._contextual_tuples = contextual_tuples
+        self._contextual_tuples = contextual_tuples
 
     @property
     def user(self):

--- a/config/clients/python/template/client/models/list_relations_request.mustache
+++ b/config/clients/python/template/client/models/list_relations_request.mustache
@@ -11,10 +11,10 @@ class ClientListRelationsRequest():
     """
 
     def __init__(self, user: str, relations: List[str], object: str, contextual_tuples: List[ClientTuple]=None):
-        self._user = user	
+        self._user = user
         self._relations = relations
         self._object = object
-		self._contextual_tuples = contextual_tuples
+        self._contextual_tuples = contextual_tuples
 
     @property
     def user(self):

--- a/config/clients/python/template/client/models/tuple.mustache
+++ b/config/clients/python/template/client/models/tuple.mustache
@@ -61,11 +61,11 @@ class ClientTuple():
         self._object = value
 
     @property
-	def tuple_key(self):
-	    """
-		Return the tuple as tuple_key
+    def tuple_key(self):
         """
-		return TupleKey(
+        Return the tuple as tuple_key
+        """
+        return TupleKey(
             object=self.object,
             relation=self.relation,
             user=self.user,

--- a/config/clients/python/template/client/models/write_single_response.mustache
+++ b/config/clients/python/template/client/models/write_single_response.mustache
@@ -14,10 +14,10 @@ class ClientWriteSingleResponse():
     ClientWriteSingleResponse encapsulates the response of a single write
     """
 
-	def __init__(self, tuple_key: ClientTuple, success: bool, error: Exception=None):
-	    self._tuple_key = tuple_key
-	    self._success = success
-	    self._error = error
+    def __init__(self, tuple_key: ClientTuple, success: bool, error: Exception=None):
+        self._tuple_key = tuple_key
+        self._success = success
+        self._error = error
     
     def __eq__(self, other):
         return self.tuple_key == other.tuple_key and self.success == other.success and self.error == other.error


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Converting a few stray tabs to spaces to address failures in Python SDK unit tests.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

* https://github.com/openfga/sdk-generator/actions/runs/5730559134/job/15529575715?pr=158

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
