### PR TITLE
fix(go): guard against empty model id

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -408,7 +408,7 @@ type SdkClient interface {
 
 func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModelId *string) (*string, error) {
 	modelId := client.config.AuthorizationModelId
-	if authorizationModelId != nil {
+	if authorizationModelId != nil && *authorizationModelId != "" {
 		modelId = authorizationModelId
 	}
 
@@ -420,8 +420,8 @@ func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModel
 
 // helper function to validate the connection (i.e., get token)
 func (client *{{appShortName}}Client) checkValidApiConnection(ctx _context.Context, authorizationModelId *string) error {
-	if authorizationModelId != nil {
-	    _, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(ctx, *authorizationModelId).Execute()
+	if authorizationModelId != nil && *authorizationModelId != "" {
+	  _, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(ctx, *authorizationModelId).Execute()
 		return err
 	} else {
 		_, err := client.ReadAuthorizationModels(ctx).Options(ClientReadAuthorizationModelsOptions{
@@ -1746,7 +1746,7 @@ func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCh
 	response := make(ClientBatchCheckResponse, numOfChecks)
 	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
 	if err != nil {
-		return nil, err 
+		return nil, err
 	}
 
 	group.Go(func() error {


### PR DESCRIPTION
## Description

Guard against calling `ReadAuthorizationModel` with an empty string.

## References

https://github.com/openfga/cli/pull/125

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
