### PR TITLE
misc(java): Rename package path of client components

### DIFF
--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -5,7 +5,7 @@
   "artifactId": "openfga-sdk",
   "groupId": "dev.openfga",
   "apiPackage": "dev.openfga.api",
-  "invokerPackage": "dev.openfga.api.invoker",
+  "invokerPackage": "dev.openfga.api.client",
   "modelPackage": "dev.openfga.api.model",
   "packageVersion": "0.0.1",
   "snapshotVersion": false,

--- a/config/clients/java/template/OpenFgaApiIntegrationTest.java.mustache
+++ b/config/clients/java/template/OpenFgaApiIntegrationTest.java.mustache
@@ -6,8 +6,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.openfga.api.invoker.*;
-import dev.openfga.api.model.*;
+import {{invokerPackage}}.*;
+import {{modelPackage}}.*;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/config/clients/java/template/OpenFgaApiTest.java.mustache
+++ b/config/clients/java/template/OpenFgaApiTest.java.mustache
@@ -8,9 +8,8 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pgssoft.httpclient.HttpClientMock;
-import dev.openfga.api.invoker.ApiClient;
-import dev.openfga.api.invoker.ApiException;
-import dev.openfga.api.model.*;
+import {{invokerPackage}}.*;
+import {{modelPackage}}.*;
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes -->

Updates the location of classes like ApiClient and Configuration to be `dev.openfga.api.client` instead of `dev.openfga.api.invoker`. This matches conventions in other OpenFGA projects

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Generates these changes: https://github.com/openfga/java-sdk/pull/4

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
