### PR TITLE
refactor(java): Async

### DIFF
--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -22,6 +22,7 @@
   "scmDeveloperConnection": "scm:git:git@github.com:openfga/java-sdk.git",
   "scmUrl": "https://github.com/openfga/java-sdk",
   "library": "native",
+  "asyncNative": true,
   "disallowAdditionalPropertiesIfNotPresent": false,
   "enumUnknownDefaultCase": true,
   "allowUnicodeIdentifiers": true,

--- a/config/clients/java/template/OpenFgaApiIntegrationTest.java.mustache
+++ b/config/clients/java/template/OpenFgaApiIntegrationTest.java.mustache
@@ -33,20 +33,20 @@ public class OpenFgaApiIntegrationTest {
     }
 
     @Test
-    public void createStore() throws ApiException {
+    public void createStore() throws Exception {
         // Given
         String storeName = thisTestName();
         CreateStoreRequest createStoreRequest = new CreateStoreRequest().name(storeName);
 
         // When
-        CreateStoreResponse response = api.createStore(createStoreRequest);
+        CreateStoreResponse response = api.createStore(createStoreRequest).get();
 
         // Then
         assertEquals("OpenFgaApiIntegrationTest.createStore", response.getName());
     }
 
     @Test
-    public void deleteStore() throws ApiException {
+    public void deleteStore() throws Exception {
         // Given
         String storeName = thisTestName();
         String storeId = createStore(storeName);
@@ -55,26 +55,26 @@ public class OpenFgaApiIntegrationTest {
         api.deleteStore(storeId);
 
         // Then
-        ListStoresResponse response = api.listStores(100, null);
+        ListStoresResponse response = api.listStores(100, null).get();
         boolean itWasDeleted = response.getStores().stream().map(Store::getId).noneMatch(storeId::equals);
         assertTrue(itWasDeleted, String.format("No stores should remain with the id %s.", storeId));
     }
 
     @Test
-    public void getStore() throws ApiException {
+    public void getStore() throws Exception {
         // Given
         String storeName = thisTestName();
         String storeId = createStore(storeName);
 
         // When
-        GetStoreResponse response = api.getStore(storeId);
+        GetStoreResponse response = api.getStore(storeId).get();
 
         // Then
         assertEquals(storeName, response.getName());
     }
 
     @Test
-    public void listStores() throws ApiException {
+    public void listStores() throws Exception {
         // Given
         String testName = thisTestName();
         String store1 = testName + "-store1";
@@ -86,7 +86,7 @@ public class OpenFgaApiIntegrationTest {
         }
 
         // When
-        ListStoresResponse response = api.listStores(100, null);
+        ListStoresResponse response = api.listStores(100, null).get();
 
         // Then
         for (String store : stores) {
@@ -103,7 +103,7 @@ public class OpenFgaApiIntegrationTest {
         String authModelId = writeAuthModel(storeId);
 
         // When
-        ReadAuthorizationModelResponse response = api.readAuthorizationModel(storeId, authModelId);
+        ReadAuthorizationModelResponse response = api.readAuthorizationModel(storeId, authModelId).get();
 
         // Then
         AuthorizationModel authModel = response.getAuthorizationModel();
@@ -122,7 +122,7 @@ public class OpenFgaApiIntegrationTest {
         String authModelId = writeAuthModel(storeId);
 
         // When
-        ReadAuthorizationModelsResponse response = api.readAuthorizationModels(storeId, 100, null);
+        ReadAuthorizationModelsResponse response = api.readAuthorizationModels(storeId, 100, null).get();
 
         // Then
         response.getAuthorizationModels().stream()
@@ -142,7 +142,7 @@ public class OpenFgaApiIntegrationTest {
     }
 
     @Test
-    public void writeAuthModel() throws ApiException, JsonProcessingException {
+    public void writeAuthModel() throws Exception {
         // Given
         String storeName = thisTestName();
         String storeId = createStore(storeName);
@@ -150,7 +150,7 @@ public class OpenFgaApiIntegrationTest {
                 mapper.readValue(DEFAULT_AUTH_MODEL, WriteAuthorizationModelRequest.class);
 
         // When
-        WriteAuthorizationModelResponse response = api.writeAuthorizationModel(storeId, request);
+        WriteAuthorizationModelResponse response = api.writeAuthorizationModel(storeId, request).get();
 
         // Then
         assertNotNull(response);
@@ -170,7 +170,7 @@ public class OpenFgaApiIntegrationTest {
 
         // When
         api.write(storeId, writeRequest);
-        ReadResponse response = api.read(storeId, readRequest);
+        ReadResponse response = api.read(storeId, readRequest).get();
 
         // Then
         TupleKey key = response.getTuples().get(0).getKey();
@@ -191,7 +191,7 @@ public class OpenFgaApiIntegrationTest {
 
         // When
         api.write(storeId, writeRequest);
-        CheckResponse response = api.check(storeId, checkRequest);
+        CheckResponse response = api.check(storeId, checkRequest).get();
 
         // Then
         assertTrue(response.getAllowed());
@@ -209,7 +209,7 @@ public class OpenFgaApiIntegrationTest {
 
         // When
         api.write(storeId, writeRequest);
-        ExpandResponse response = api.expand(storeId, expandRequest);
+        ExpandResponse response = api.expand(storeId, expandRequest).get();
 
         // Then
         assertNotNull(response.getTree());
@@ -231,7 +231,7 @@ public class OpenFgaApiIntegrationTest {
 
         // When
         api.write(storeId, writeRequest);
-        ListObjectsResponse response = api.listObjects(storeId, listObjectsRequest);
+        ListObjectsResponse response = api.listObjects(storeId, listObjectsRequest).get();
 
         // Then
         assertEquals(1, response.getObjects().size());
@@ -248,12 +248,15 @@ public class OpenFgaApiIntegrationTest {
 
         // When
         api.write(storeId, writeRequest);
-        ReadChangesResponse response = api.readChanges(storeId, null, null, null);
+        ReadChangesResponse response = api.readChanges(storeId, null, null, null).get();
 
         // Then
         assertEquals(1, response.getChanges().size());
-        String firstTupleKeyJson = mapper.writeValueAsString(response.getChanges().get(0).getTupleKey());
-        assertEquals("{\"object\":\"document:2021-budget\",\"relation\":\"reader\",\"user\":\"user:81684243-9356-4421-8fbf-a4f8d36aa31b\"}", firstTupleKeyJson);
+        String firstTupleKeyJson =
+                mapper.writeValueAsString(response.getChanges().get(0).getTupleKey());
+        assertEquals(
+                "{\"object\":\"document:2021-budget\",\"relation\":\"reader\",\"user\":\"user:81684243-9356-4421-8fbf-a4f8d36aa31b\"}",
+                firstTupleKeyJson);
     }
 
     @Test
@@ -267,7 +270,7 @@ public class OpenFgaApiIntegrationTest {
 
         // When
         api.writeAssertions(storeId, authModelId, writeRequest);
-        ReadAssertionsResponse response = api.readAssertions(storeId, authModelId);
+        ReadAssertionsResponse response = api.readAssertions(storeId, authModelId).get();
 
         // Then
         String responseJson = mapper.writeValueAsString(response.getAssertions());
@@ -281,8 +284,8 @@ public class OpenFgaApiIntegrationTest {
      * test method createStore().
      * @return The created Store ID
      */
-    private String createStore(String storeName) throws ApiException {
-        CreateStoreResponse response = api.createStore(new CreateStoreRequest().name(storeName));
+    private String createStore(String storeName) throws Exception {
+        CreateStoreResponse response = api.createStore(new CreateStoreRequest().name(storeName)).get();
         return response.getId();
     }
 
@@ -291,10 +294,10 @@ public class OpenFgaApiIntegrationTest {
      * no-arguments @Test writeAuthModel() method.
      * @return The created Authorization Model ID
      */
-    private String writeAuthModel(String storeId) throws ApiException, JsonProcessingException {
+    private String writeAuthModel(String storeId) throws Exception {
         WriteAuthorizationModelRequest request =
                 mapper.readValue(DEFAULT_AUTH_MODEL, WriteAuthorizationModelRequest.class);
-        WriteAuthorizationModelResponse response = api.writeAuthorizationModel(storeId, request);
+        WriteAuthorizationModelResponse response = api.writeAuthorizationModel(storeId, request).get();
         return response.getAuthorizationModelId();
     }
 

--- a/config/clients/java/template/OpenFgaApiTest.java.mustache
+++ b/config/clients/java/template/OpenFgaApiTest.java.mustache
@@ -13,6 +13,7 @@ import {{modelPackage}}.*;
 import dev.openfga.sdk.errors.*;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +56,7 @@ public class OpenFgaApiTest {
      * List all stores.
      */
     @Test
-    public void listStoresTest() throws ApiException {
+    public void listStoresTest() throws Exception {
         // Given
         String responseBody =
                 String.format("{\"stores\":[{\"id\":\"%s\",\"name\":\"%s\"}]}", DEFAULT_STORE_ID, DEFAULT_STORE_NAME);
@@ -64,7 +65,8 @@ public class OpenFgaApiTest {
         String continuationToken = null; // Input is optional
 
         // When
-        ListStoresResponse response = fga.listStores(pageSize, continuationToken);
+        ListStoresResponse response =
+                fga.listStores(pageSize, continuationToken).get();
 
         // Then
         mockHttpClient.verify().get("https://localhost/stores").called(1);
@@ -75,69 +77,95 @@ public class OpenFgaApiTest {
     }
 
     @Test
-    public void listStores_400() throws ApiException {
+    public void listStores_400() {
         // Given
-        mockHttpClient.onGet("https://localhost/stores").doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onGet("https://localhost/stores")
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.listStores(pageSize, continuationToken));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.listStores(pageSize, continuationToken)
+                        .get());
 
         // Then
         mockHttpClient.verify().get("https://localhost/stores").called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void listStores_404() throws ApiException {
+    public void listStores_404() throws Exception {
         // Given
-        mockHttpClient.onGet("https://localhost/stores").doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onGet("https://localhost/stores")
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.listStores(pageSize, continuationToken));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.listStores(pageSize, continuationToken)
+                        .get());
 
         // Then
         mockHttpClient.verify().get("https://localhost/stores").called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void listStores_500() throws ApiException {
+    public void listStores_500() throws Exception {
         // Given
-        mockHttpClient.onGet("https://localhost/stores").doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onGet("https://localhost/stores")
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.listStores(pageSize, continuationToken));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.listStores(pageSize, continuationToken)
+                        .get());
 
         // Then
         mockHttpClient.verify().get("https://localhost/stores").called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Create a store.
      */
     @Test
-    public void createStoreTest() throws ApiException {
+    public void createStoreTest() throws Exception {
         // Given
         String expectedBody = String.format("{\"name\":\"%s\"}", DEFAULT_STORE_NAME);
         String requestBody = String.format("{\"id\":\"%s\",\"name\":\"%s\"}", DEFAULT_STORE_ID, DEFAULT_STORE_NAME);
-        mockHttpClient.onPost("https://localhost/stores").withBody(is(expectedBody)).doReturn(201, requestBody);
+        mockHttpClient
+                .onPost("https://localhost/stores")
+                .withBody(is(expectedBody))
+                .doReturn(201, requestBody);
         CreateStoreRequest request = new CreateStoreRequest().name(DEFAULT_STORE_NAME);
 
         // When
-        CreateStoreResponse response = fga.createStore(request);
+        CreateStoreResponse response = fga.createStore(request).get();
 
         // Then
-        mockHttpClient.verify().post("https://localhost/stores").withBody(is(expectedBody)).called(1);
+        mockHttpClient
+                .verify()
+                .post("https://localhost/stores")
+                .withBody(is(expectedBody))
+                .called(1);
         assertEquals(DEFAULT_STORE_ID, response.getId());
         assertEquals(DEFAULT_STORE_NAME, response.getName());
     }
@@ -145,66 +173,87 @@ public class OpenFgaApiTest {
     @Test
     public void createStore_bodyRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.createStore(null));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.createStore(null).get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'body' when calling createStore", exception.getMessage());
     }
 
     @Test
-    public void createStore_400() throws ApiException {
+    public void createStore_400() throws Exception {
         // Given
-        mockHttpClient.onPost("https://localhost/stores").doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onPost("https://localhost/stores")
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.createStore(new CreateStoreRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.createStore(new CreateStoreRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post("https://localhost/stores").called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void createStore_404() throws ApiException {
+    public void createStore_404() throws Exception {
         // Given
-        mockHttpClient.onPost("https://localhost/stores").doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onPost("https://localhost/stores")
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.createStore(new CreateStoreRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.createStore(new CreateStoreRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post("https://localhost/stores").called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void createStore_500() throws ApiException {
+    public void createStore_500() throws Exception {
         // Given
-        mockHttpClient.onPost("https://localhost/stores").doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onPost("https://localhost/stores")
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.createStore(new CreateStoreRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.createStore(new CreateStoreRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post("https://localhost/stores").called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Get a store.
      */
     @Test
-    public void getStoreTest() throws ApiException {
+    public void getStoreTest() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X";
         String responseBody = String.format("{\"id\":\"%s\",\"name\":\"%s\"}", DEFAULT_STORE_ID, DEFAULT_STORE_NAME);
         mockHttpClient.onGet(getUrl).doReturn(200, responseBody);
 
         // When
-        GetStoreResponse response = fga.getStore(DEFAULT_STORE_ID);
+        GetStoreResponse response = fga.getStore(DEFAULT_STORE_ID).get();
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
@@ -215,62 +264,80 @@ public class OpenFgaApiTest {
     @Test
     public void getStore_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.getStore(null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.getStore(null).get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling getStore", exception.getMessage());
     }
 
     @Test
-    public void getStore_400() throws ApiException {
+    public void getStore_400() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X";
-        mockHttpClient.onGet(getUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.getStore(DEFAULT_STORE_ID));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.getStore(DEFAULT_STORE_ID).get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void getStore_404() throws ApiException {
+    public void getStore_404() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X";
-        mockHttpClient.onGet(getUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.getStore(DEFAULT_STORE_ID));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.getStore(DEFAULT_STORE_ID).get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void getStore_500() throws ApiException {
+    public void getStore_500() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X";
-        mockHttpClient.onGet(getUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.getStore(DEFAULT_STORE_ID));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.getStore(DEFAULT_STORE_ID).get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Delete a store.
      */
     @Test
-    public void deleteStoreTest() throws ApiException {
+    public void deleteStoreTest() throws Exception {
         // Given
         String deleteUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X";
         mockHttpClient.onDelete(deleteUrl).doReturn(204, EMPTY_RESPONSE_BODY);
@@ -285,62 +352,83 @@ public class OpenFgaApiTest {
     @Test
     public void deleteStore_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.deleteStore(null));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.deleteStore(null).get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling deleteStore", exception.getMessage());
     }
 
     @Test
-    public void deleteStore_400() throws ApiException {
+    public void deleteStore_400() throws Exception {
         // Given
         String deleteUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X";
-        mockHttpClient.onDelete(deleteUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onDelete(deleteUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.deleteStore(DEFAULT_STORE_ID));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.deleteStore(DEFAULT_STORE_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().delete(deleteUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void deleteStore_404() throws ApiException {
+    public void deleteStore_404() throws Exception {
         // Given
         String deleteUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X";
-        mockHttpClient.onDelete(deleteUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onDelete(deleteUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.deleteStore(DEFAULT_STORE_ID));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.deleteStore(DEFAULT_STORE_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().delete(deleteUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void deleteStore_500() throws ApiException {
+    public void deleteStore_500() throws Exception {
         // Given
         String deleteUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X";
-        mockHttpClient.onDelete(deleteUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onDelete(deleteUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.deleteStore(DEFAULT_STORE_ID));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.deleteStore(DEFAULT_STORE_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().delete(deleteUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Return all the authorization models for a particular store.
      */
     @Test
-    public void readAuthorizationModelsTest() throws ApiException {
+    public void readAuthorizationModelsTest() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models";
         String responseBody = String.format(
@@ -351,8 +439,9 @@ public class OpenFgaApiTest {
         String continuationToken = null; // Input is optional
 
         // When
-        ReadAuthorizationModelsResponse response =
-                fga.readAuthorizationModels(DEFAULT_STORE_ID, pageSize, continuationToken);
+        ReadAuthorizationModelsResponse response = fga.readAuthorizationModels(
+                        DEFAULT_STORE_ID, pageSize, continuationToken)
+                .get();
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
@@ -366,70 +455,92 @@ public class OpenFgaApiTest {
     @Test
     public void readAuthorizationModels_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAuthorizationModels(null, null, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readAuthorizationModels(null, null, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(
                 "Missing the required parameter 'storeId' when calling readAuthorizationModels",
                 exception.getMessage());
     }
 
     @Test
-    public void readAuthorizationModels_400() throws ApiException {
+    public void readAuthorizationModels_400() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models";
-        mockHttpClient.onGet(getUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAuthorizationModels(DEFAULT_STORE_ID, pageSize, continuationToken));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.readAuthorizationModels(
+                        DEFAULT_STORE_ID, pageSize, continuationToken)
+                .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void readAuthorizationModels_404() throws ApiException {
+    public void readAuthorizationModels_404() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models";
-        mockHttpClient.onGet(getUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAuthorizationModels(DEFAULT_STORE_ID, pageSize, continuationToken));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.readAuthorizationModels(
+                        DEFAULT_STORE_ID, pageSize, continuationToken)
+                .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void readAuthorizationModels_500() throws ApiException {
+    public void readAuthorizationModels_500() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models";
-        mockHttpClient.onGet(getUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAuthorizationModels(DEFAULT_STORE_ID, pageSize, continuationToken));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.readAuthorizationModels(
+                        DEFAULT_STORE_ID, pageSize, continuationToken)
+                .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Create a new authorization model.
      */
     @Test
-    public void writeAuthorizationModelTest() throws ApiException {
+    public void writeAuthorizationModelTest() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models";
         String expectedBody =
@@ -441,7 +552,8 @@ public class OpenFgaApiTest {
                 .typeDefinitions(List.of(new TypeDefinition().type(DEFAULT_TYPE)));
 
         // When
-        WriteAuthorizationModelResponse response = fga.writeAuthorizationModel(DEFAULT_STORE_ID, request);
+        WriteAuthorizationModelResponse response =
+                fga.writeAuthorizationModel(DEFAULT_STORE_ID, request).get();
 
         // Then
         mockHttpClient.verify().post(postUrl).withBody(is(expectedBody)).called(1);
@@ -451,10 +563,12 @@ public class OpenFgaApiTest {
     @Test
     public void writeAuthorizationModel_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(
-                ApiException.class, () -> fga.writeAuthorizationModel(null, new WriteAuthorizationModelRequest()));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.writeAuthorizationModel(null, new WriteAuthorizationModelRequest())
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(
                 "Missing the required parameter 'storeId' when calling writeAuthorizationModel",
                 exception.getMessage());
@@ -463,64 +577,85 @@ public class OpenFgaApiTest {
     @Test
     public void writeAuthorizationModel_bodyRequired() {
         // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> fga.writeAuthorizationModel(DEFAULT_STORE_ID, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.writeAuthorizationModel(DEFAULT_STORE_ID, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(
                 "Missing the required parameter 'body' when calling writeAuthorizationModel", exception.getMessage());
     }
 
     @Test
-    public void writeAuthorizationModel_400() throws ApiException {
+    public void writeAuthorizationModel_400() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models";
-        mockHttpClient.onPost(postUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.writeAuthorizationModel(DEFAULT_STORE_ID, new WriteAuthorizationModelRequest()));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.writeAuthorizationModel(
+                        DEFAULT_STORE_ID, new WriteAuthorizationModelRequest())
+                .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void writeAuthorizationModel_404() throws ApiException {
+    public void writeAuthorizationModel_404() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models";
-        mockHttpClient.onPost(postUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.writeAuthorizationModel(DEFAULT_STORE_ID, new WriteAuthorizationModelRequest()));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.writeAuthorizationModel(
+                        DEFAULT_STORE_ID, new WriteAuthorizationModelRequest())
+                .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void writeAuthorizationModel_500() throws ApiException {
+    public void writeAuthorizationModel_500() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models";
-        mockHttpClient.onPost(postUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.writeAuthorizationModel(DEFAULT_STORE_ID, new WriteAuthorizationModelRequest()));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.writeAuthorizationModel(
+                        DEFAULT_STORE_ID, new WriteAuthorizationModelRequest())
+                .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Return a particular version of an authorization model.
      */
     @Test
-    public void readAuthorizationModelTest() throws ApiException {
+    public void readAuthorizationModelTest() throws Exception {
         // Given
         String getUrl =
                 "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J";
@@ -530,7 +665,8 @@ public class OpenFgaApiTest {
         mockHttpClient.onGet(getUrl).doReturn(200, getResponse);
 
         // When
-        ReadAuthorizationModelResponse response = fga.readAuthorizationModel(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID);
+        ReadAuthorizationModelResponse response = fga.readAuthorizationModel(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID)
+                .get();
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
@@ -542,10 +678,12 @@ public class OpenFgaApiTest {
     @Test
     public void readAuthorizationModel_storeIdRequired() {
         // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> fga.readAuthorizationModel(null, DEFAULT_AUTH_MODEL_ID));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readAuthorizationModel(null, DEFAULT_AUTH_MODEL_ID)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(
                 "Missing the required parameter 'storeId' when calling readAuthorizationModel", exception.getMessage());
     }
@@ -553,66 +691,87 @@ public class OpenFgaApiTest {
     @Test
     public void readAuthorizationModel_idRequired() {
         // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> fga.readAuthorizationModel(DEFAULT_STORE_ID, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readAuthorizationModel(DEFAULT_STORE_ID, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'id' when calling readAuthorizationModel", exception.getMessage());
     }
 
     @Test
-    public void readAuthorizationModel_400() throws ApiException {
+    public void readAuthorizationModel_400() throws Exception {
         // Given
         String getUrl =
                 "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onGet(getUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAuthorizationModel(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.readAuthorizationModel(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void readAuthorizationModel_404() throws ApiException {
+    public void readAuthorizationModel_404() throws Exception {
         // Given
         String getUrl =
                 "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onGet(getUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAuthorizationModel(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.readAuthorizationModel(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void readAuthorizationModel_500() throws ApiException {
+    public void readAuthorizationModel_500() throws Exception {
         // Given
         String getUrl =
                 "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onGet(getUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAuthorizationModel(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.readAuthorizationModel(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Return a list of all the tuple changes.
      */
     @Test
-    public void readChangesTest() throws ApiException {
+    public void readChangesTest() throws Exception {
         // Given
         String getPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/changes";
         String responseBody = String.format(
@@ -624,7 +783,8 @@ public class OpenFgaApiTest {
         String continuationToken = null; // Input is optional
 
         // When
-        ReadChangesResponse response = fga.readChanges(DEFAULT_STORE_ID, type, pageSize, continuationToken);
+        ReadChangesResponse response = fga.readChanges(DEFAULT_STORE_ID, type, pageSize, continuationToken)
+                .get();
 
         // Then
         mockHttpClient.verify().get(getPath).called(1);
@@ -638,73 +798,95 @@ public class OpenFgaApiTest {
     }
 
     @Test
-    public void readChanges_storeIdRequired() throws ApiException {
+    public void readChanges_storeIdRequired() throws Exception {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readChanges(null, null, null, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readChanges(null, null, null, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling readChanges", exception.getMessage());
     }
 
     @Test
-    public void readChanges_400() throws ApiException {
+    public void readChanges_400() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/changes";
-        mockHttpClient.onGet(getUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
         String type = null; // Input is optional
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readChanges(DEFAULT_STORE_ID, type, pageSize, continuationToken));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.readChanges(DEFAULT_STORE_ID, type, pageSize, continuationToken)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void readChanges_404() throws ApiException {
+    public void readChanges_404() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/changes";
-        mockHttpClient.onGet(getUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
         String type = null; // Input is optional
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readChanges(DEFAULT_STORE_ID, type, pageSize, continuationToken));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.readChanges(DEFAULT_STORE_ID, type, pageSize, continuationToken)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void readChanges_500() throws ApiException {
+    public void readChanges_500() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/changes";
-        mockHttpClient.onGet(getUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
         String type = null; // Input is optional
         Integer pageSize = null; // Input is optional
         String continuationToken = null; // Input is optional
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readChanges(DEFAULT_STORE_ID, type, pageSize, continuationToken));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.readChanges(DEFAULT_STORE_ID, type, pageSize, continuationToken)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Get tuples from the store that matches a query, without following userset rewrite rules.
      */
     @Test
-    public void readTest() throws ApiException {
+    public void readTest() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/read";
         String expectedBody = String.format(
@@ -721,7 +903,7 @@ public class OpenFgaApiTest {
                         .user(DEFAULT_USER));
 
         // When
-        ReadResponse response = fga.read(DEFAULT_STORE_ID, request);
+        ReadResponse response = fga.read(DEFAULT_STORE_ID, request).get();
 
         // Then
         mockHttpClient.verify().post(postUrl).withBody(is(expectedBody)).called(1);
@@ -737,71 +919,95 @@ public class OpenFgaApiTest {
     @Test
     public void read_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.read(null, new ReadRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.read(null, new ReadRequest())
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling read", exception.getMessage());
     }
 
     @Test
     public void read_bodyRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.read(DEFAULT_STORE_ID, null));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.read(DEFAULT_STORE_ID, null).get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'body' when calling read", exception.getMessage());
     }
 
     @Test
-    public void read_400() throws ApiException {
+    public void read_400() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/read";
-        mockHttpClient.onPost(postUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.read(DEFAULT_STORE_ID, new ReadRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.read(DEFAULT_STORE_ID, new ReadRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void read_404() throws ApiException {
+    public void read_404() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/read";
-        mockHttpClient.onPost(postUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.read(DEFAULT_STORE_ID, new ReadRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.read(DEFAULT_STORE_ID, new ReadRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void read_500() throws ApiException {
+    public void read_500() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/read";
-        mockHttpClient.onPost(postUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.read(DEFAULT_STORE_ID, new ReadRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.read(DEFAULT_STORE_ID, new ReadRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Add or delete tuples from the store.
      */
     @Test
-    public void writeTest_writes() throws ApiException {
+    public void writeTest_writes() throws Exception {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
         String expectedBody = String.format(
@@ -827,7 +1033,7 @@ public class OpenFgaApiTest {
      * Add or delete tuples from the store.
      */
     @Test
-    public void writeTest_deletes() throws ApiException {
+    public void writeTest_deletes() throws Exception {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
         String expectedBody = String.format(
@@ -852,64 +1058,89 @@ public class OpenFgaApiTest {
     @Test
     public void write_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.write(null, new WriteRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.write(null, new WriteRequest())
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling write", exception.getMessage());
     }
 
     @Test
     public void write_bodyRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.write(DEFAULT_STORE_ID, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.write(DEFAULT_STORE_ID, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'body' when calling write", exception.getMessage());
     }
 
     @Test
-    public void write_400() throws ApiException {
+    public void write_400() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
-        mockHttpClient.onPost(postUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.write(DEFAULT_STORE_ID, new WriteRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.write(DEFAULT_STORE_ID, new WriteRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void write_404() throws ApiException {
+    public void write_404() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
-        mockHttpClient.onPost(postUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.write(DEFAULT_STORE_ID, new WriteRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.write(DEFAULT_STORE_ID, new WriteRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void write_500() throws ApiException {
+    public void write_500() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/write";
-        mockHttpClient.onPost(postUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.write(DEFAULT_STORE_ID, new WriteRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.write(DEFAULT_STORE_ID, new WriteRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
@@ -932,7 +1163,7 @@ public class OpenFgaApiTest {
                 .authorizationModelId(DEFAULT_AUTH_MODEL_ID);
 
         // When
-        CheckResponse response = fga.check(DEFAULT_STORE_ID, request);
+        CheckResponse response = fga.check(DEFAULT_STORE_ID, request).get();
 
         // Then
         verify(mockConfiguration).getApiUrl();
@@ -944,71 +1175,96 @@ public class OpenFgaApiTest {
     @Test
     public void check_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.check(null, new CheckRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.check(null, new CheckRequest())
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling check", exception.getMessage());
     }
 
     @Test
     public void check_bodyRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.check(DEFAULT_STORE_ID, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.check(DEFAULT_STORE_ID, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'body' when calling check", exception.getMessage());
     }
 
     @Test
-    public void check_400() throws ApiException {
+    public void check_400() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check";
-        mockHttpClient.onPost(postUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.check(DEFAULT_STORE_ID, new CheckRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.check(DEFAULT_STORE_ID, new CheckRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void check_404() throws ApiException {
+    public void check_404() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check";
-        mockHttpClient.onPost(postUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.check(DEFAULT_STORE_ID, new CheckRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.check(DEFAULT_STORE_ID, new CheckRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void check_500() throws ApiException {
+    public void check_500() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/check";
-        mockHttpClient.onPost(postUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.check(DEFAULT_STORE_ID, new CheckRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.check(DEFAULT_STORE_ID, new CheckRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Expand all relationships in userset tree format, and following userset rewrite rules.  Useful to reason about and debug a certain relationship.
      */
     @Test
-    public void expandTest() throws ApiException {
+    public void expandTest() throws Exception {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/expand";
         String expectedBody = String.format(
@@ -1026,7 +1282,7 @@ public class OpenFgaApiTest {
                         .user(DEFAULT_USER));
 
         // When
-        ExpandResponse response = fga.expand(DEFAULT_STORE_ID, request);
+        ExpandResponse response = fga.expand(DEFAULT_STORE_ID, request).get();
 
         // Then
         mockHttpClient.verify().post(postPath).withBody(is(expectedBody)).called(1);
@@ -1047,71 +1303,96 @@ public class OpenFgaApiTest {
     @Test
     public void expand_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.expand(null, new ExpandRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.expand(null, new ExpandRequest())
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling expand", exception.getMessage());
     }
 
     @Test
     public void expand_bodyRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.expand(DEFAULT_STORE_ID, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.expand(DEFAULT_STORE_ID, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'body' when calling expand", exception.getMessage());
     }
 
     @Test
-    public void expand_400() throws ApiException {
+    public void expand_400() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/expand";
-        mockHttpClient.onPost(postUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.expand(DEFAULT_STORE_ID, new ExpandRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.expand(DEFAULT_STORE_ID, new ExpandRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void expand_404() throws ApiException {
+    public void expand_404() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/expand";
-        mockHttpClient.onPost(postUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.expand(DEFAULT_STORE_ID, new ExpandRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.expand(DEFAULT_STORE_ID, new ExpandRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void expand_500() throws ApiException {
+    public void expand_500() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/expand";
-        mockHttpClient.onPost(postUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.expand(DEFAULT_STORE_ID, new ExpandRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.expand(DEFAULT_STORE_ID, new ExpandRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * List all objects of the given type that the user has a relation with.
      */
     @Test
-    public void listObjectsTest() throws ApiException {
+    public void listObjectsTest() throws Exception {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/list-objects";
         String expectedBody = String.format(
@@ -1127,7 +1408,8 @@ public class OpenFgaApiTest {
                 .user(DEFAULT_USER);
 
         // When
-        ListObjectsResponse response = fga.listObjects(DEFAULT_STORE_ID, request);
+        ListObjectsResponse response =
+                fga.listObjects(DEFAULT_STORE_ID, request).get();
 
         // Then
         mockHttpClient.verify().post(postPath).withBody(is(expectedBody)).called(1);
@@ -1137,72 +1419,96 @@ public class OpenFgaApiTest {
     @Test
     public void listObjects_storeIdRequired() {
         // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> fga.listObjects(null, new ListObjectsRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.listObjects(null, new ListObjectsRequest())
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling listObjects", exception.getMessage());
     }
 
     @Test
     public void listObjects_bodyRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.listObjects(DEFAULT_STORE_ID, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.listObjects(DEFAULT_STORE_ID, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'body' when calling listObjects", exception.getMessage());
     }
 
     @Test
-    public void listObjects_400() throws ApiException {
+    public void listObjects_400() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/list-objects";
-        mockHttpClient.onPost(postUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.listObjects(DEFAULT_STORE_ID, new ListObjectsRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.listObjects(DEFAULT_STORE_ID, new ListObjectsRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void listObjects_404() throws ApiException {
+    public void listObjects_404() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/list-objects";
-        mockHttpClient.onPost(postUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.listObjects(DEFAULT_STORE_ID, new ListObjectsRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.listObjects(DEFAULT_STORE_ID, new ListObjectsRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void listObjects_500() throws ApiException {
+    public void listObjects_500() throws Exception {
         // Given
         String postUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/list-objects";
-        mockHttpClient.onPost(postUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.listObjects(DEFAULT_STORE_ID, new ListObjectsRequest()));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.listObjects(DEFAULT_STORE_ID, new ListObjectsRequest())
+                        .get());
 
         // Then
         mockHttpClient.verify().post(postUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Read assertions for an authorization model ID.
      */
     @Test
-    public void readAssertionsTest() throws ApiException {
+    public void readAssertionsTest() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/assertions/01G5JAVJ41T49E9TT3SKVS7X1J";
         String responseBody = String.format(
@@ -1211,7 +1517,8 @@ public class OpenFgaApiTest {
         mockHttpClient.onGet(getUrl).doReturn(200, responseBody);
 
         // When
-        ReadAssertionsResponse response = fga.readAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID);
+        ReadAssertionsResponse response =
+                fga.readAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID).get();
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
@@ -1228,74 +1535,98 @@ public class OpenFgaApiTest {
     @Test
     public void readAssertions_storeIdRequired() {
         // When
-        ApiException exception =
-                assertThrows(ApiException.class, () -> fga.readAssertions(null, DEFAULT_AUTH_MODEL_ID));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readAssertions(null, DEFAULT_AUTH_MODEL_ID)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling readAssertions", exception.getMessage());
     }
 
     @Test
     public void readAssertions_authModelIdRequired() {
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAssertions(DEFAULT_STORE_ID, null));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readAssertions(DEFAULT_STORE_ID, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(
                 "Missing the required parameter 'authorizationModelId' when calling readAssertions",
                 exception.getMessage());
     }
 
     @Test
-    public void readAssertions_400() throws ApiException {
+    public void readAssertions_400() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/assertions/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onGet(getUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void readAssertions_404() throws ApiException {
+    public void readAssertions_404() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/assertions/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onGet(getUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void readAssertions_500() throws ApiException {
+    public void readAssertions_500() throws Exception {
         // Given
         String getUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/assertions/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onGet(getUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onGet(getUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.readAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID));
+        ExecutionException execException =
+                assertThrows(ExecutionException.class, () -> fga.readAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID)
+                        .get());
 
         // Then
         mockHttpClient.verify().get(getUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 
     /**
      * Upsert assertions for an authorization model ID.
      */
     @Test
-    public void writeAssertionsTest() throws ApiException {
+    public void writeAssertionsTest() throws Exception {
         // Given
         String putUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/assertions/01G5JAVJ41T49E9TT3SKVS7X1J";
         String expectedBody = String.format(
@@ -1320,21 +1651,24 @@ public class OpenFgaApiTest {
     @Test
     public void writeAssertions_storeIdRequired() {
         // When
-        ApiException exception = assertThrows(
-                ApiException.class,
-                () -> fga.writeAssertions(null, DEFAULT_AUTH_MODEL_ID, new WriteAssertionsRequest()));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.writeAssertions(
+                        null, DEFAULT_AUTH_MODEL_ID, new WriteAssertionsRequest())
+                .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'storeId' when calling writeAssertions", exception.getMessage());
     }
 
     @Test
     public void writeAssertions_authModelIdRequired() {
         // When
-        ApiException exception = assertThrows(
-                ApiException.class, () -> fga.writeAssertions(DEFAULT_STORE_ID, null, new WriteAssertionsRequest()));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.writeAssertions(
+                        DEFAULT_STORE_ID, null, new WriteAssertionsRequest())
+                .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(
                 "Missing the required parameter 'authorizationModelId' when calling writeAssertions",
                 exception.getMessage());
@@ -1343,55 +1677,76 @@ public class OpenFgaApiTest {
     @Test
     public void writeAssertions_bodyRequired() {
         // When
-        ApiException exception = assertThrows(
-                ApiException.class, () -> fga.writeAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID, null));
+        ExecutionException execException = assertThrows(
+                ExecutionException.class, () -> fga.writeAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID, null)
+                        .get());
 
         // Then
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals("Missing the required parameter 'body' when calling writeAssertions", exception.getMessage());
     }
 
     @Test
-    public void writeAssertions_400() throws ApiException {
+    public void writeAssertions_400() throws Exception {
         // Given
         String putUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/assertions/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onPut(putUrl).doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
+        mockHttpClient
+                .onPut(putUrl)
+                .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.writeAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID, new WriteAssertionsRequest()));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.writeAssertions(
+                        DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID, new WriteAssertionsRequest())
+                .get());
 
         // Then
         mockHttpClient.verify().put(putUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(400, exception.getCode());
-        assertEquals("{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}",
+                exception.getResponseBody());
     }
 
     @Test
-    public void writeAssertions_404() throws ApiException {
+    public void writeAssertions_404() throws Exception {
         // Given
         String putUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/assertions/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onPut(putUrl).doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
+        mockHttpClient
+                .onPut(putUrl)
+                .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.writeAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID, new WriteAssertionsRequest()));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.writeAssertions(
+                        DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID, new WriteAssertionsRequest())
+                .get());
 
         // Then
         mockHttpClient.verify().put(putUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(404, exception.getCode());
-        assertEquals("{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}", exception.getResponseBody());
     }
 
     @Test
-    public void writeAssertions_500() throws ApiException {
+    public void writeAssertions_500() throws Exception {
         // Given
         String putUrl = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/assertions/01G5JAVJ41T49E9TT3SKVS7X1J";
-        mockHttpClient.onPut(putUrl).doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
+        mockHttpClient
+                .onPut(putUrl)
+                .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        ApiException exception = assertThrows(ApiException.class, () -> fga.writeAssertions(DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID, new WriteAssertionsRequest()));
+        ExecutionException execException = assertThrows(ExecutionException.class, () -> fga.writeAssertions(
+                        DEFAULT_STORE_ID, DEFAULT_AUTH_MODEL_ID, new WriteAssertionsRequest())
+                .get());
 
         // Then
         mockHttpClient.verify().put(putUrl).called(1);
+        ApiException exception = assertInstanceOf(ApiException.class, execException.getCause());
         assertEquals(500, exception.getCode());
-        assertEquals("{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
+        assertEquals(
+                "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseBody());
     }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Switches to async style Java.

The core of async is in HttpClient, and the ability to configure things like thread pools is in [HttpClient.Builder.executor(Executor)](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.Builder.html#executor%28java.util.concurrent.Executor%29)

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->



## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
