### PR TITLE
fix(js-sdk): raw response in client check

### DIFF
--- a/config/clients/js/template/client.mustache
+++ b/config/clients/js/template/client.mustache
@@ -483,10 +483,7 @@ export class {{appShortName}}Client extends BaseAPI {
       },
       contextual_tuples: { tuple_keys: body.contextualTuples || [] },
       authorization_model_id: this.getAuthorizationModelId(options)
-    }, options).then(response => ({
-      ...response,
-      allowed: response.allowed || false,
-    }));
+    }, options);
   }
 
   /**
@@ -512,20 +509,16 @@ export class {{appShortName}}Client extends BaseAPI {
 
         const responses: ClientBatchCheckSingleResponse[] = [];
         for await (const singleCheckResponse of asyncPool(maxParallelRequests, body, (tuple) => this.check(tuple, { ...options, headers })
-          .then(({ allowed, $response: response }) => {
-            const result = {
-              allowed: allowed || false,
-              _request: tuple,
-            };
-            setNotEnumerableProperty(result, "$response", response);
-            return result as ClientBatchCheckSingleResponse;
+          .then(response => {
+            (response as ClientBatchCheckSingleResponse)._request = tuple;
+            return response as ClientBatchCheckSingleResponse;
           })
           .catch(err => {
             return {
-              allowed: false,
+              allowed: undefined,
               error: err,
               _request: tuple,
-            } as unknown as ClientBatchCheckSingleResponse;
+            };
           })
         )) {
           responses.push(singleCheckResponse);

--- a/config/clients/js/template/tests/client.test.ts.mustache
+++ b/config/clients/js/template/tests/client.test.ts.mustache
@@ -423,7 +423,7 @@ describe("{{appTitleCaseName}} Client", () => {
           .toMatchObject(expect.arrayContaining([
             { _request: tuples[0], allowed: true, },
             { _request: tuples[1], allowed: false },
-            { _request: tuples[2], allowed: false, error: expect.any(Error) },
+            { _request: tuples[2], error: expect.any(Error) },
           ]));
       });
     });


### PR DESCRIPTION
NOTE: BatchCheck does not have the raw response yet

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- SDK PR: https://github.com/openfga/js-sdk/pull/31

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
