### PR TITLE
fix(python-sdk): fix crash in ClientCheck w/ ctx tuples

### DIFF
--- a/config/clients/python/template/client/client.mustache
+++ b/config/clients/python/template/client/client.mustache
@@ -486,7 +486,9 @@ class OpenFgaClient():
             authorization_model_id=self._get_authorization_model_id(options),
         )
         if body.contextual_tuples:
-            req_body.contextual_tuples(body.contextual_tuples)
+            req_body.contextual_tuples = ContextualTupleKeys(
+                tuple_keys=convert_tuple_keys(body.contextual_tuples)
+            )
         api_response = await self._api.check(
             body=req_body,
             **kwargs

--- a/config/clients/python/template/client/test_client.mustache
+++ b/config/clients/python/template/client/test_client.mustache
@@ -1426,9 +1426,16 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         response_body = '{"allowed": true, "resolution": "1234"}'
         mock_request.return_value = mock_response(response_body, 200)
         body = ClientCheckRequest(
-                    object="document:2021-budget",
-                    relation="reader",
+            user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+            relation="reader",
+            object="document:budget",
+            contextual_tuples=[
+                ClientTuple(
                     user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                    relation="writer",
+                    object="document:budget",
+                ),
+            ],
             )
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1446,8 +1453,9 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                 headers=ANY,
                 query_params=[],
                 post_params=[],
-                body={"tuple_key": {"object": "document:2021-budget",
-                                    "relation": "reader", "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b"}, "authorization_model_id": "01GXSA8YR785C4FYS3C0RTG7B1"},
+                body={"tuple_key": {"user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b", "relation": "reader", "object": "document:budget"},
+                                    "contextual_tuples": {"tuple_keys": [{"user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b", "relation": "writer", "object": "document:budget"}]},
+                                    "authorization_model_id": "01GXSA8YR785C4FYS3C0RTG7B1"},
                 _preload_content=ANY,
                 _request_timeout=None
             )


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- Generates: https://github.com/openfga/python-sdk/pull/36
- Issue: https://github.com/openfga/python-sdk/issues/35

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
