### PR TITLE
Adjust logic on handlebars to avoid 'if true' statement on models

### DIFF
--- a/config/clients/go/template/model_simple.mustache
+++ b/config/clients/go/template/model_simple.mustache
@@ -260,9 +260,14 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	{{/isNullable}}
 	{{! if argument is not nullable, don't set it if it is nil}}
 	{{^isNullable}}
-	if {{#required}}true{{/required}}{{^required}}o.{{name}} != nil{{/required}} {
+    {{#required}}
+    toSerialize["{{baseName}}"] = o.{{name}}
+    {{/required}}
+    {{^required}}
+    if o.{{name}} != nil {
 		toSerialize["{{baseName}}"] = o.{{name}}
 	}
+    {{/required}}
 	{{/isNullable}}
 	{{/vars}}
 	{{#isAdditionalPropertiesTrue}}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

There was a small logic on handlebars causing to create if true statements on the golang sdk as we can see [here](https://github.com/openfga/go-sdk/blob/main/model_authorization_model.go#L137)

## Description
with this new implementation the code is now like this:
*before*
```go
func (o ListObjectsRequest) MarshalJSON() ([]byte, error) {
	toSerialize := map[string]interface{}{}
	if o.AuthorizationModelId != nil {
		toSerialize["authorization_model_id"] = o.AuthorizationModelId
	}
	if true {
		toSerialize["type"] = o.Type
	}
	if true {
		toSerialize["relation"] = o.Relation
	}
	if true {
		toSerialize["user"] = o.User
	}
	if o.ContextualTuples != nil {
		toSerialize["contextual_tuples"] = o.ContextualTuples
	}
	return json.Marshal(toSerialize)
}
```
*after*
```go
func (o ListObjectsRequest) MarshalJSON() ([]byte, error) {
	toSerialize := map[string]interface{}{}
	if o.AuthorizationModelId != nil {
		toSerialize["authorization_model_id"] = o.AuthorizationModelId
	}
	toSerialize["type"] = o.Type
	toSerialize["relation"] = o.Relation
	toSerialize["user"] = o.User
	if o.ContextualTuples != nil {
		toSerialize["contextual_tuples"] = o.ContextualTuples
	}
	return json.Marshal(toSerialize)
}
```
## References
#close https://github.com/openfga/go-sdk/issues/11

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
