### PR TITLE
fix(java-sdk): don't send tuple key on empty read request

### DIFF
--- a/config/clients/java/CHANGELOG.md.mustache
+++ b/config/clients/java/CHANGELOG.md.mustache
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.2
+
+### [0.2.2](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.2.1...v0.2.2) (2023-10-31)
+
+- fix(client): an empty read request will no longer send an empty tuple
+- fix(client): an unused "user" field, and related methods, was removed from ClientExpandRequest
+
 ## v0.2.1
 
 ### [0.2.1](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.2.0...v0.2.1) (2023-10-13)

--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -3,7 +3,7 @@
   "gitRepoId": "java-sdk",
   "artifactId": "openfga-sdk",
   "groupId": "dev.openfga",
-  "packageVersion": "0.2.1",
+  "packageVersion": "0.2.2",
   "apiPackage": "dev.openfga.sdk.api",
   "authPackage": "dev.openfga.sdk.api.auth",
   "clientPackage": "dev.openfga.sdk.api.client",

--- a/config/clients/java/template/client-ClientExpandRequest.java.mustache
+++ b/config/clients/java/template/client-ClientExpandRequest.java.mustache
@@ -2,7 +2,6 @@
 package {{invokerPackage}};
 
 public class ClientExpandRequest {
-    private String user;
     private String relation;
     private String _object;
 
@@ -30,18 +29,5 @@ public class ClientExpandRequest {
      **/
     public String getRelation() {
         return relation;
-    }
-
-    public ClientExpandRequest user(String user) {
-        this.user = user;
-        return this;
-    }
-
-    /**
-     * Get user
-     * @return user
-     **/
-    public String getUser() {
-        return user;
     }
 }

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -227,17 +227,16 @@ public class OpenFgaClient {
         String storeId = configuration.getStoreIdChecked();
 
         ReadRequest body = new ReadRequest();
-        TupleKey tupleKey = new TupleKey();
 
-        if (request != null) {
+        if (request != null && (request.getUser() != null || request.getRelation() != null || request.getObject() != null)) {
+            TupleKey tupleKey = new TupleKey();
             tupleKey.user(request.getUser()).relation(request.getRelation())._object(request.getObject());
+            body.tupleKey(tupleKey);
         }
 
         if (options != null) {
             body.pageSize(options.getPageSize()).continuationToken(options.getContinuationToken());
         }
-
-        body.tupleKey(tupleKey);
 
         return call(() -> api.read(storeId, body)).thenApply(ClientReadResponse::new);
     }

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -397,7 +397,6 @@ public class OpenFgaClient {
 
         if (request != null) {
             body.tupleKey(new TupleKey()
-                    .user(request.getUser())
                     .relation(request.getRelation())
                     ._object(request.getObject()));
         }

--- a/config/clients/java/template/client-OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClientTest.java.mustache
@@ -936,6 +936,21 @@ public class OpenFgaClientTest {
     }
 
     @Test
+    public void read_emptyRequestSendsNoTupleKey() throws Exception {
+        // Given
+        String postUrl = String.format("https://localhost/stores/%s/read", DEFAULT_STORE_ID);
+        String expectedBody = "{\"tuple_key\":null,\"page_size\":null,\"continuation_token\":null}";
+        mockHttpClient.onPost(postUrl).withBody(is(expectedBody)).doReturn(200, EMPTY_RESPONSE_BODY);
+        ClientReadRequest request = new ClientReadRequest();
+
+        // When
+        ClientReadResponse response = fga.read(request).get();
+
+        // Then
+        mockHttpClient.verify().post(postUrl).withBody(is(expectedBody)).called(1);
+    }
+
+    @Test
     public void read_storeIdRequired() {
         // Given
         clientConfiguration.storeId(null);

--- a/config/clients/java/template/client-OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClientTest.java.mustache
@@ -1309,14 +1309,13 @@ public class OpenFgaClientTest {
         // Given
         String postPath = "https://localhost/stores/01YCP46JKYM8FJCQ37NMBYHE5X/expand";
         String expectedBody = String.format(
-                "{\"tuple_key\":{\"object\":\"%s\",\"relation\":\"%s\",\"user\":\"%s\"},\"authorization_model_id\":\"%s\"}",
-                DEFAULT_OBJECT, DEFAULT_RELATION, DEFAULT_USER, DEFAULT_AUTH_MODEL_ID);
+                "{\"tuple_key\":{\"object\":\"%s\",\"relation\":\"%s\",\"user\":null},\"authorization_model_id\":\"%s\"}",
+                DEFAULT_OBJECT, DEFAULT_RELATION, DEFAULT_AUTH_MODEL_ID);
         String responseBody = String.format(
                 "{\"tree\":{\"root\":{\"union\":{\"nodes\":[{\"leaf\":{\"users\":{\"users\":[\"%s\"]}}}]}}}}",
                 DEFAULT_USER);
         mockHttpClient.onPost(postPath).withBody(is(expectedBody)).doReturn(200, responseBody);
         ClientExpandRequest request = new ClientExpandRequest()
-                .user(DEFAULT_USER)
                 .relation(DEFAULT_RELATION)
                 ._object(DEFAULT_OBJECT);
         ClientExpandOptions options = new ClientExpandOptions().authorizationModelId(DEFAULT_AUTH_MODEL_ID);


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

- fix(client): don't send tuple key on empty read request
- fix(client): remove unnecessary parameter from ClientExpandRequest
- chore: bump version to 0.3.0

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

generates https://github.com/openfga/java-sdk/pull/31
closes https://github.com/openfga/java-sdk/issues/30


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
