### PR TITLE
fix(python): correct initialization instruction in README

### DIFF
--- a/config/clients/python/template/README_initializing.mustache
+++ b/config/clients/python/template/README_initializing.mustache
@@ -6,7 +6,7 @@ The documentation below refers to the `{{appShortName}}Client`, to read the docu
 
 ```python
 import {{packageName}}
-from {{packageName}}.client import OpenFgaClient
+from {{packageName}}.client.client import OpenFgaClient
 
 
 async def main():
@@ -27,7 +27,7 @@ async def main():
 
 ```python
 import {{packageName}}
-from {{packageName}}.client import OpenFgaClient
+from {{packageName}}.client.client import OpenFgaClient
 from {{packageName}}.credentials import Credentials, CredentialConfiguration
 
 
@@ -55,7 +55,7 @@ async def main():
 
 ```python
 import {{packageName}}
-from {{packageName}}.client import OpenFgaClient
+from {{packageName}}.client.client import OpenFgaClient
 from {{packageName}}.credentials import Credentials, CredentialConfiguration
 
 
@@ -90,7 +90,7 @@ without requiring async/await.
 
 ```python
 import {{packageName}}
-from {{packageName}}.sync.client import OpenFgaClient
+from {{packageName}}.sync.client.client import OpenFgaClient
 
 
 def main():


### PR DESCRIPTION
## Description
Correct initialization of python SDK in README.  Should use client.client instead of client 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
