### PR TITLE
fix(python): correct path for sync client in README

### DIFF
--- a/config/clients/python/template/README_initializing.mustache
+++ b/config/clients/python/template/README_initializing.mustache
@@ -90,7 +90,7 @@ without requiring async/await.
 
 ```python
 import {{packageName}}
-from {{packageName}}.sync.client import OpenFgaClient
+from {{packageName}}.sync import OpenFgaClient
 
 
 def main():


### PR DESCRIPTION


## Description
Correct path for sync client import for python SDK

## References
Implement changes for https://github.com/openfga/python-sdk/pull/44


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
