### PR TITLE
fix(dotnet): allow case with empty read body

### DIFF
--- a/config/clients/dotnet/template/Client/Client.mustache
+++ b/config/clients/dotnet/template/Client/Client.mustache
@@ -138,11 +138,16 @@ public class {{appShortName}}Client : IDisposable {
      * Read - Read tuples previously written to the store (does not evaluate)
      */
     public async Task<ReadResponse> Read(ClientReadRequest body, IClientReadOptions? options = default,
-        CancellationToken cancellationToken = default) =>
-        await api.Read(
+        CancellationToken cancellationToken = default) {
+        TupleKey tupleKey = null;
+        if (body != null && (body.User != null || body.Relation != null || body.Object != null)) {
+            tupleKey = body;
+        }
+        return await api.Read(
             new ReadRequest {
-                TupleKey = body, PageSize = options?.PageSize, ContinuationToken = options?.ContinuationToken
+                TupleKey = tupleKey, PageSize = options?.PageSize, ContinuationToken = options?.ContinuationToken
             }, cancellationToken);
+    }
 
     /**
      * Write - Create or delete relationship tuples

--- a/config/clients/dotnet/template/OpenFgaClientTests.mustache
+++ b/config/clients/dotnet/template/OpenFgaClientTests.mustache
@@ -593,7 +593,8 @@ public class {{appShortName}}ClientTests {
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/read") &&
-                    req.Method == HttpMethod.Post),
+                    req.Method == HttpMethod.Post &&
+                    req.Content.ReadAsStringAsync().Result.Contains("tuple")),
                 ItExpr.IsAny<CancellationToken>()
             )
             .ReturnsAsync(new HttpResponseMessage() {
@@ -616,7 +617,55 @@ public class {{appShortName}}ClientTests {
             Times.Exactly(1),
             ItExpr.Is<HttpRequestMessage>(req =>
                 req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/read") &&
-                req.Method == HttpMethod.Post),
+                req.Method == HttpMethod.Post &&
+                req.Content.ReadAsStringAsync().Result.Contains("tuple")),
+            ItExpr.IsAny<CancellationToken>()
+        );
+
+        Assert.IsType<ReadResponse>(response);
+        Assert.Single(response.Tuples);
+        Assert.Equal(response, expectedResponse);
+    }
+
+    /// <summary>
+    /// Test Read with Empty Body
+    /// </summary>
+    [Fact]
+    public async Task ReadEmptyTest() {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var expectedResponse = new ReadResponse() {
+            Tuples = new List<Model.Tuple>() {
+                new(new TupleKey("document:roadmap", "viewer", "user:81684243-9356-4421-8fbf-a4f8d36aa31b"),
+                    DateTime.Now)
+            }
+        };
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/read") &&
+                    req.Method == HttpMethod.Post &&
+                    !req.Content.ReadAsStringAsync().Result.Contains("tuple")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage() {
+                StatusCode = HttpStatusCode.OK, Content = Utils.CreateJsonStringContent(expectedResponse),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var fgaClient = new {{appShortName}}Client(_config, httpClient);
+
+        var body = new ClientReadRequest() { };
+        var options = new ClientReadOptions { };
+        var response = await fgaClient.Read(body, options);
+
+        mockHandler.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/read") &&
+                req.Method == HttpMethod.Post &&
+                !req.Content.ReadAsStringAsync().Result.Contains("tuple")),
             ItExpr.IsAny<CancellationToken>()
         );
 

--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -1360,6 +1360,50 @@ namespace {{testPackageName}}.Api {
         }
 
         /// <summary>
+        /// Test Read With Empty Parameters
+        /// </summary>
+        [Fact]
+        public async Task ReadEmptyTest() {
+            var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var expectedResponse = new ReadResponse() {
+                            Tuples = new List<{{packageName}}.Model.Tuple>() {
+                                new(new TupleKey("document:roadmap", "viewer", "user:81684243-9356-4421-8fbf-a4f8d36aa31b"), DateTime.Now)
+                            }
+                        };
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/read") &&
+                        req.Method == HttpMethod.Post),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = Utils.CreateJsonStringContent(expectedResponse),
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var {{appCamelCaseName}}Api = new {{classname}}(_config, httpClient);
+
+            var body = new ReadRequest{};
+            var response = await {{appCamelCaseName}}Api.Read(body);
+
+            mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/read") &&
+                    req.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>()
+            );
+
+            Assert.IsType<ReadResponse>(response);
+            Assert.Single(response.Tuples);
+            Assert.Equal(response, expectedResponse);
+        }
+
+        /// <summary>
         /// Test ReadChanges
         /// </summary>
         [Fact]

--- a/config/clients/dotnet/template/modelGeneric.mustache
+++ b/config/clients/dotnet/template/modelGeneric.mustache
@@ -205,6 +205,7 @@
         {{^conditionalSerialization}}
         [DataMember(Name = "{{baseName}}"{{#required}}, IsRequired = true{{/required}}, EmitDefaultValue = {{#vendorExtensions.x-emit-default-value}}true{{/vendorExtensions.x-emit-default-value}}{{^vendorExtensions.x-emit-default-value}}{{#isBoolean}}true{{/isBoolean}}{{^isBoolean}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/isBoolean}}{{/vendorExtensions.x-emit-default-value}})]
         [JsonPropertyName("{{baseName}}")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         {{#isDate}}
         [JsonConverter(typeof(OpenAPIDateConverter))]
         {{/isDate}}


### PR DESCRIPTION


## Description
Do not serialize default value.  As such, if read request is provided without any body, it will not serialize tuple_key field.

## References
Close https://github.com/openfga/dotnet-sdk/issues/31


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
