### PR TITLE
feat(go-sdk): oauth2 client credentials support

### DIFF
--- a/config/clients/go/template/README_initializing.mustache
+++ b/config/clients/go/template/README_initializing.mustache
@@ -51,7 +51,7 @@ func main() {
 }
 ```
 
-#### Client Credentials
+#### Auth0 Client Credentials
 
 ```golang
 import (
@@ -72,6 +72,38 @@ func main() {
                 ClientCredentialsClientId:       os.Getenv("FGA_CLIENT_ID"),
                 ClientCredentialsClientSecret:   os.Getenv("FGA_CLIENT_SECRET"),
                 ClientCredentialsApiAudience:    os.Getenv("FGA_API_AUDIENCE"),
+                ClientCredentialsApiTokenIssuer: os.Getenv("FGA_API_TOKEN_ISSUER"),
+            },
+        },
+    })
+
+    if err != nil {
+        // .. Handle error
+    }
+}
+```
+
+#### OAuth2 Client Credentials
+
+```golang
+import (
+    {{packageName}} "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}"
+    . "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/client"
+    "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/credentials"
+    "os"
+)
+
+func main() {
+    fgaClient, err := NewSdkClient(&ClientConfiguration{
+        ApiUrl:               os.Getenv("FGA_API_URL"), // required, e.g. https://api.{{sampleApiDomain}}
+        StoreId:              os.Getenv("FGA_STORE_ID"), // not needed when calling `CreateStore` or `ListStores`
+        AuthorizationModelId: os.Getenv("FGA_AUTHORIZATION_MODEL_ID"), // optional, recommended to be set for production
+        Credentials: &credentials.Credentials{
+            Method: credentials.CredentialsMethodClientCredentials,
+            Config: &credentials.Config{
+                ClientCredentialsClientId:       os.Getenv("FGA_CLIENT_ID"),
+                ClientCredentialsClientSecret:   os.Getenv("FGA_CLIENT_SECRET"),
+                ClientCredentialsScopes:         os.Getenv("FGA_API_SCOPES"), // optional space separated scopes
                 ClientCredentialsApiTokenIssuer: os.Getenv("FGA_API_TOKEN_ISSUER"),
             },
         },

--- a/config/clients/go/template/api_test.mustache
+++ b/config/clients/go/template/api_test.mustache
@@ -128,7 +128,7 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 		}
 	})
 
-	t.Run("In ClientCredentials method, providing no client id, secret, audience or issuer should error", func(t *testing.T) {
+	t.Run("In ClientCredentials method, providing no client id, secret or issuer should error", func(t *testing.T) {
 		_, err := NewConfiguration(Configuration{
 			ApiHost: "https://api.{{sampleApiDomain}}",
 			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
@@ -159,23 +159,6 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 
 		if err == nil {
 			t.Fatalf("Expected an error: client secret is required")
-		}
-
-		_, err = NewConfiguration(Configuration{
-			ApiHost: "https://api.{{sampleApiDomain}}",
-			StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
-			Credentials: &credentials.Credentials{
-				Method: credentials.CredentialsMethodApiToken,
-				Config: &credentials.Config{
-					ClientCredentialsClientId:       "some-id",
-					ClientCredentialsClientSecret:   "some-secret",
-					ClientCredentialsApiTokenIssuer: "some-issuer",
-				},
-			},
-		})
-
-		if err == nil {
-			t.Fatalf("Expected an error: api audience is required")
 		}
 
 		_, err = NewConfiguration(Configuration{
@@ -252,20 +235,8 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 		}
 	})
 
-	t.Run("should issue a network call to get the token at the first request if client id is provided", func(t *testing.T) {
-		configuration, err := NewConfiguration(Configuration{
-            ApiHost:         "api.{{sampleApiDomain}}",
-			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
-			Credentials: &credentials.Credentials{
-				Method: credentials.CredentialsMethodClientCredentials,
-				Config: &credentials.Config{
-					ClientCredentialsClientId:       "some-id",
-					ClientCredentialsClientSecret:   "some-secret",
-					ClientCredentialsApiAudience:    "some-audience",
-					ClientCredentialsApiTokenIssuer: "tokenissuer.{{sampleApiDomain}}",
-				},
-			},
-		})
+    clientCredentialsFirstRequestTest := func(t *testing.T, config Configuration) {
+		configuration, err := NewConfiguration(config)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -318,6 +289,34 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 		if numCalls != 1 {
 			t.Fatalf("Expected call to get authorization models to be made exactly once, saw: %d", numCalls)
 		}
+    }
+	t.Run("should issue a network call to get the token at the first request if client id is provided", func(t *testing.T) {
+		t.Run("with Auth0 configuration", func(t *testing.T) {
+			clientCredentialsFirstRequestTest(t, Configuration{
+            ApiHost:         "api.{{sampleApiDomain}}",
+			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
+			Credentials: &credentials.Credentials{
+				Method: credentials.CredentialsMethodClientCredentials,
+				Config: &credentials.Config{
+					ClientCredentialsClientId:       "some-id",
+					ClientCredentialsClientSecret:   "some-secret",
+					ClientCredentialsApiAudience:    "some-audience",
+					ClientCredentialsApiTokenIssuer: "tokenissuer.{{sampleApiDomain}}",
+			})
+		})
+		t.Run("with OAuth2 configuration", func(t *testing.T) {
+			clientCredentialsFirstRequestTest(t, Configuration{
+            ApiHost:         "api.{{sampleApiDomain}}",
+			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
+			Credentials: &credentials.Credentials{
+				Method: credentials.CredentialsMethodClientCredentials,
+				Config: &credentials.Config{
+					ClientCredentialsClientId:       "some-id",
+					ClientCredentialsClientSecret:   "some-secret",
+                    ClientCredentialsScopes:         "scope1 scope2",
+					ClientCredentialsApiTokenIssuer: "tokenissuer.{{sampleApiDomain}}",
+			})
+		})
 	})
 
 	t.Run("should not issue a network call to get the token at the first request if the clientId is not provided", func(t *testing.T) {

--- a/config/clients/go/template/api_test.mustache
+++ b/config/clients/go/template/api_test.mustache
@@ -290,34 +290,39 @@ func Test{{appShortName}}ApiConfiguration(t *testing.T) {
 			t.Fatalf("Expected call to get authorization models to be made exactly once, saw: %d", numCalls)
 		}
     }
-	t.Run("should issue a network call to get the token at the first request if client id is provided", func(t *testing.T) {
-		t.Run("with Auth0 configuration", func(t *testing.T) {
-			clientCredentialsFirstRequestTest(t, Configuration{
-            ApiHost:         "api.{{sampleApiDomain}}",
-			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
-			Credentials: &credentials.Credentials{
-				Method: credentials.CredentialsMethodClientCredentials,
-				Config: &credentials.Config{
-					ClientCredentialsClientId:       "some-id",
-					ClientCredentialsClientSecret:   "some-secret",
-					ClientCredentialsApiAudience:    "some-audience",
-					ClientCredentialsApiTokenIssuer: "tokenissuer.{{sampleApiDomain}}",
-			})
-		})
-		t.Run("with OAuth2 configuration", func(t *testing.T) {
-			clientCredentialsFirstRequestTest(t, Configuration{
-            ApiHost:         "api.{{sampleApiDomain}}",
-			StoreId:      "01GXSB9YR785C4FYS3C0RTG7B2",
-			Credentials: &credentials.Credentials{
-				Method: credentials.CredentialsMethodClientCredentials,
-				Config: &credentials.Config{
-					ClientCredentialsClientId:       "some-id",
-					ClientCredentialsClientSecret:   "some-secret",
-                    ClientCredentialsScopes:         "scope1 scope2",
-					ClientCredentialsApiTokenIssuer: "tokenissuer.{{sampleApiDomain}}",
-			})
-		})
-	})
+
+    t.Run("should issue a network call to get the token at the first request if client id is provided", func(t *testing.T) {
+        t.Run("with Auth0 configuration", func(t *testing.T) {
+            clientCredentialsFirstRequestTest(t, Configuration{
+                ApiHost: "api.{{sampleApiDomain}}",
+                StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
+                Credentials: &credentials.Credentials{
+                    Method: credentials.CredentialsMethodClientCredentials,
+                    Config: &credentials.Config{
+                        ClientCredentialsClientId:       "some-id",
+                        ClientCredentialsClientSecret:   "some-secret",
+                        ClientCredentialsApiAudience:    "some-audience",
+                        ClientCredentialsApiTokenIssuer: "tokenissuer.{{sampleApiDomain}}",
+                    },
+                },
+            })
+        })
+        t.Run("with OAuth2 configuration", func(t *testing.T) {
+            clientCredentialsFirstRequestTest(t, Configuration{
+                ApiHost: "api.{{sampleApiDomain}}",
+                StoreId: "01GXSB9YR785C4FYS3C0RTG7B2",
+                Credentials: &credentials.Credentials{
+                    Method: credentials.CredentialsMethodClientCredentials,
+                    Config: &credentials.Config{
+                        ClientCredentialsClientId:       "some-id",
+                        ClientCredentialsClientSecret:   "some-secret",
+                        ClientCredentialsScopes:         "scope1 scope2",
+                        ClientCredentialsApiTokenIssuer: "tokenissuer.{{sampleApiDomain}}",
+                    },
+                },
+            })
+        })
+    })
 
 	t.Run("should not issue a network call to get the token at the first request if the clientId is not provided", func(t *testing.T) {
 		configuration, err := NewConfiguration(Configuration{

--- a/config/clients/go/template/credentials.mustache
+++ b/config/clients/go/template/credentials.mustache
@@ -5,6 +5,7 @@ import (
     "fmt"
     "net/http"
 	"net/url"
+    "strings"
 
     "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/oauth2/clientcredentials"
 )
@@ -30,6 +31,7 @@ type Config struct {
     ClientCredentialsApiAudience    string `json:"apiAudience,omitempty"`
     ClientCredentialsClientId       string `json:"clientId,omitempty"`
     ClientCredentialsClientSecret   string `json:"clientSecret,omitempty"`
+    ClientCredentialsScopes         string `json:"scopes,omitempty"`
 }
 
 type Credentials struct {
@@ -74,9 +76,8 @@ func (c *Credentials) ValidateCredentialsConfig() error {
         if conf == nil ||
             conf.ClientCredentialsClientId == "" ||
             conf.ClientCredentialsClientSecret == "" ||
-            conf.ClientCredentialsApiTokenIssuer == "" ||
-            conf.ClientCredentialsApiAudience == "" {
-            return fmt.Errorf("all of CredentialsConfig.ClientId, CredentialsConfig.ClientSecret, CredentialsConfig.ApiAudience and CredentialsConfig.ApiTokenIssuer are required when CredentialsMethod is CredentialsMethodClientCredentials (%s)", c.Method)
+            conf.ClientCredentialsApiTokenIssuer == "" {
+            return fmt.Errorf("all of CredentialsConfig.ClientId, CredentialsConfig.ClientSecret and CredentialsConfig.ApiTokenIssuer are required when CredentialsMethod is CredentialsMethodClientCredentials (%s)", c.Method)
         }
         if !isWellFormedUri("https://" + conf.ClientCredentialsApiTokenIssuer) {
             return fmt.Errorf("CredentialsConfig.ApiTokenIssuer (%s) is in an invalid format", "https://"+conf.ClientCredentialsApiTokenIssuer)
@@ -114,9 +115,17 @@ func (c *Credentials) GetHttpClientAndHeaderOverrides() (*http.Client, []*Header
 			ClientID:     c.Config.ClientCredentialsClientId,
 			ClientSecret: c.Config.ClientCredentialsClientSecret,
 			TokenURL:     fmt.Sprintf("https://%s/oauth/token", c.Config.ClientCredentialsApiTokenIssuer),
-			EndpointParams: map[string][]string{
+		}
+		if c.Config.ClientCredentialsApiAudience != "" {
+			ccConfig.EndpointParams = map[string][]string{
 				"audience": {c.Config.ClientCredentialsApiAudience},
-			},
+			}
+		}
+		if c.Config.ClientCredentialsScopes != "" {
+			scopes := strings.Split(strings.TrimSpace(c.Config.ClientCredentialsScopes), " ")
+			for _, scope := range scopes {
+				ccConfig.Scopes = append(ccConfig.Scopes, scope)
+			}
 		}
 		client = ccConfig.Client(context.Background())
 	case CredentialsMethodApiToken:

--- a/config/clients/go/template/credentials.mustache
+++ b/config/clients/go/template/credentials.mustache
@@ -123,9 +123,7 @@ func (c *Credentials) GetHttpClientAndHeaderOverrides() (*http.Client, []*Header
 		}
 		if c.Config.ClientCredentialsScopes != "" {
 			scopes := strings.Split(strings.TrimSpace(c.Config.ClientCredentialsScopes), " ")
-			for _, scope := range scopes {
-				ccConfig.Scopes = append(ccConfig.Scopes, scope)
-			}
+			ccConfig.Scopes = append(ccConfig.Scopes, scopes...)
 		}
 		client = ccConfig.Client(context.Background())
 	case CredentialsMethodApiToken:


### PR DESCRIPTION
Add OAuth2 client credentials support to go SDK.

## Description
Add an optional scope parameter and make the audience parameter optional. 

## References
#255 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
