### PR TITLE
style(python-sdk): fix import order in client and configuration file templates

### DIFF
--- a/config/clients/python/template/client/client.mustache
+++ b/config/clients/python/template/client/client.mustache
@@ -1,6 +1,15 @@
 # coding: utf-8
 {{>partial_header}}
 
+{{#asyncio}}
+import asyncio
+{{/asyncio}}
+{{^asyncio}}
+import time
+{{/asyncio}}
+import uuid
+from typing import List
+
 from {{packageName}}.api_client import ApiClient
 from {{packageName}}.api.open_fga_api import OpenFgaApi
 from {{packageName}}.client.configuration import ClientConfiguration
@@ -29,15 +38,6 @@ from {{packageName}}.models.write_assertions_request import WriteAssertionsReque
 from {{packageName}}.models.write_authorization_model_request import WriteAuthorizationModelRequest
 from {{packageName}}.models.write_request import WriteRequest
 from {{packageName}}.validation import is_well_formed_ulid_string
-
-{{#asyncio}}
-import asyncio
-{{/asyncio}}
-{{^asyncio}}
-import time
-{{/asyncio}}
-import uuid
-from typing import List
 
 CLIENT_METHOD_HEADER = "X-OpenFGA-Client-Method"
 CLIENT_BULK_REQUEST_ID_HEADER = "X-OpenFGA-Client-Bulk-Request-Id"

--- a/config/clients/python/template/configuration.mustache
+++ b/config/clients/python/template/configuration.mustache
@@ -8,11 +8,12 @@ import logging
 import multiprocessing
 {{/asyncio}}
 import sys
-import urllib3
+from urllib.parse import urlparse
 
+import urllib3
 import six
 from six.moves import http_client as httplib
-from urllib.parse import urlparse
+
 from {{packageName}}.exceptions import FgaValidationException, ApiValueError
 from {{packageName}}.validation import is_well_formed_ulid_string
 


### PR DESCRIPTION
## Description
- Fix import order in `python/template/client/client.mustache`
- Fix import order in `python/template/configuration.mustache`

## References
Related to #126 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
