### PR TITLE
fix(python-sdk): fix incorrect double slash comments in python-sdk

### DIFF
--- a/config/clients/python/template/README_calling_api.mustache
+++ b/config/clients/python/template/README_calling_api.mustache
@@ -488,7 +488,7 @@ body = ClientListRelationsRequest(
 )
 var response = await fga_client.list_relations(body, options);
 
-// response.relations = ["can_view", "can_edit"]
+# response.relations = ["can_view", "can_edit"]
 ```
 
 #### Assertions


### PR DESCRIPTION
## Description
- Fix incorrect double slash comment in `python/template/README_calling_api.mustache`

## References
Related to #126 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
