### PR TITLE
fix(java-sdk): fix incorrect check for whether transactionChunkSize is not set

### DIFF
--- a/config/clients/java/template/config-ClientWriteOptions.java.mustache
+++ b/config/clients/java/template/config-ClientWriteOptions.java.mustache
@@ -43,6 +43,6 @@ public class ClientWriteOptions implements AdditionalHeadersSupplier {
     }
 
     public int getTransactionChunkSize() {
-        return transactionChunkSize >= 0 ? transactionChunkSize : 1;
+        return transactionChunkSize > 0 ? transactionChunkSize : 1;
     }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

If `write` is called without setting a `transactionChunkSize` on `ClientWriteOptions` then it will currently cause an infinite loop as when we calculate the [number of chunks](https://github.com/openfga/java-sdk/blob/7c82547c8a00a3b299283a8d959749e15981c0eb/src/main/java/dev/openfga/sdk/api/client/OpenFgaClient.java#L432) it will be set to the max int due to dividing by 0 (`chunkSize`).

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
