### PR TITLE
chore(docs): correctly attribute the python changelog to python

### DIFF
--- a/config/clients/dotnet/CHANGELOG.md.mustache
+++ b/config/clients/dotnet/CHANGELOG.md.mustache
@@ -3,7 +3,7 @@
 ## v0.3.0
 
 ### [0.3.0](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.2.5...v0.3.0) (2023-12-20)
-- feat!: initial support for conditions
+- feat!: initial support for [conditions](https://openfga.dev/blog/conditional-tuples-announcement)
 - feat!: allow overriding storeId per request (#33)
 - feat: support specifying a port and path for the API (You can now set the `ApiUrl` to something like: `https://api.fga.exampleL8080/some_path`)
 - feat: validate that store id and auth model id in ulid format (#23)
@@ -12,6 +12,7 @@
 - fix: `OpenFgaClient.Read` and `OpenFgaClient.ReadChanges` now allow a null body
 - chore!: use latest API interfaces
 - chore: dependency updates
+- chore: add [example project](./example)
 
 BREAKING CHANGES:
 Note: This release comes with substantial breaking changes, especially to the interfaces due to the protobuf changes in the last release.

--- a/config/clients/go/CHANGELOG.md.mustache
+++ b/config/clients/go/CHANGELOG.md.mustache
@@ -1,20 +1,11 @@
 # Changelog
 
-## v0.3.4
-
-### [0.3.4](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.3.3...v0.3.4) (2023-12-21)
-
-- feat: support for conditions
-- chore: use latest API interfaces for type info
-- chore: add [example project](./example)
-- chore: dependency updates
-
 ## v0.3.3
 
 ### [0.3.3](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.3.2...v0.3.3) (2023-12-21)
 
 - fix: WriteAuthorizationModel was not passing conditions to API
-- chore: add example project
+- chore: add [example project](./example)
 
 ## v0.3.2
 
@@ -34,7 +25,7 @@
 
 ### [0.3.0](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.2.3...v0.3.0) (2023-12-11)
 
-- feat!: initial support for conditions
+- feat!: initial support for [conditions](https://openfga.dev/blog/conditional-tuples-announcement)
 - feat: support specifying a port and path for the API (You can now set the `ApiUrl` to something like: `https://api.fga.exampleL8080/some_path`)
 - fix: resolve a bug in `NewCredentials` (#60) - thanks @harper
 - chore!: use latest API interfaces

--- a/config/clients/java/CHANGELOG.md.mustache
+++ b/config/clients/java/CHANGELOG.md.mustache
@@ -4,12 +4,12 @@
 
 ### [0.3.0](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.2.3...v0.3.0) (2023-12-13)
 
-- feat: support for Conditions
+- feat: support for [conditions](https://openfga.dev/blog/conditional-tuples-announcement)
 - feat: standard OpenFGA headers have been added to Write, BatchCheck, and ListRelations calls
 - feat: apiTokenIssuer has been expanded to support arbitrary http and https URLs. previously it supported
   only configuring a hostname - thanks @le-yams
 - feat: allow setting and overriding http headers
-- [BREAKING] chore: use latest API interfaces
+- [BREAKING] chore!: use latest API interfaces
 - chore: dependency updates
 - refactor: abstract common functionality; update validation and exception types
 

--- a/config/clients/js/CHANGELOG.md.mustache
+++ b/config/clients/js/CHANGELOG.md.mustache
@@ -4,7 +4,7 @@
 
 ### [0.3.0](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.2.10...v0.3.0) (2023-12-11)
 
-- feat: support for conditions
+- feat: support for [conditions](https://openfga.dev/blog/conditional-tuples-announcement)
 - chore: use latest API interfaces
 - chore: dependency updates
 

--- a/config/clients/python/CHANGELOG.md.mustache
+++ b/config/clients/python/CHANGELOG.md.mustache
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.3.4
+
+### [0.3.4](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.3.3...v0.3.4) (2024-01-09)
+
+- feat: support for [conditions](https://openfga.dev/blog/conditional-tuples-announcement)
+- chore: use latest API interfaces for type info
+- chore: add [example project](./example)
+- chore: dependency updates
+
 ## v0.3.3
 
 ### [0.3.3](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.3.2...v0.3.3) (2024-01-02)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- JS audit failure resolved in #272 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
