### PR TITLE
fix(go-sdk): dont escape HTML characters in conditions

### DIFF
--- a/config/clients/go/template/model.mustache
+++ b/config/clients/go/template/model.mustache
@@ -3,6 +3,12 @@ package {{packageName}}
 
 {{#models}}
 import (
+{{#model}}
+{{^isEnum}}
+	"bytes"
+{{/isEnum}}
+{{/model}}
+
 	"encoding/json"
 {{#imports}}
 	"{{import}}"

--- a/config/clients/go/template/model_simple.mustache
+++ b/config/clients/go/template/model_simple.mustache
@@ -277,7 +277,14 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	}
 
 	{{/isAdditionalPropertiesTrue}}
-	return json.Marshal(toSerialize)
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(toSerialize)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 {{#isAdditionalPropertiesTrue}}


### PR DESCRIPTION
## Description

The behaviour of json.Marshal is to escape any HTML characters in a string, by using json.Encoder we are able to disable the escaping of these characters

## References

openfga/cli/issues/188

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
