### PR TITLE
fix(java-sdk): fix token validity check for expiry

### DIFF
--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -179,6 +179,10 @@
       "destinationFilename": "src/main/java/dev/openfga/sdk/api/auth/AccessToken.java",
       "templateType": "SupportingFiles"
     },
+    "creds-AccessTokenTest.java.mustache" : {
+      "destinationFilename": "src/test/java/dev/openfga/sdk/api/auth/AccessTokenTest.java",
+      "templateType": "SupportingFiles"
+    },    
     "creds-CredentialsFlowRequest.java.mustache" : {
       "destinationFilename": "src/main/java/dev/openfga/sdk/api/auth/CredentialsFlowRequest.java",
       "templateType": "SupportingFiles"

--- a/config/clients/java/template/creds-AccessToken.java.mustache
+++ b/config/clients/java/template/creds-AccessToken.java.mustache
@@ -18,9 +18,9 @@ class AccessToken {
     public boolean isValid() {
         return !isNullOrWhitespace(token)
                 && (expiresAt == null
-                        || expiresAt.isBefore(Instant.now()
-                                .plusSeconds(TOKEN_EXPIRY_BUFFER_THRESHOLD_IN_SEC)
-                                .plusSeconds(random.nextLong() % TOKEN_EXPIRY_JITTER_IN_SEC)));
+                        || expiresAt.isAfter(Instant.now()
+                                .minusSeconds(TOKEN_EXPIRY_BUFFER_THRESHOLD_IN_SEC)
+                                .minusSeconds(random.nextLong() % TOKEN_EXPIRY_JITTER_IN_SEC)));
     }
 
     public String getToken() {

--- a/config/clients/java/template/creds-AccessTokenTest.java.mustache
+++ b/config/clients/java/template/creds-AccessTokenTest.java.mustache
@@ -1,0 +1,34 @@
+{{>licenseInfo}}
+package {{authPackage}};
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AccessTokenTest {
+
+    private static Stream<Arguments> expTimeAndResults() {
+        return Stream.of(
+                Arguments.of(Instant.now().plus(1, ChronoUnit.HOURS), true),
+                Arguments.of(Instant.now().minus(1, ChronoUnit.HOURS), false),
+                Arguments.of(Instant.now().minus(10, ChronoUnit.MINUTES), false),
+                Arguments.of(Instant.now().plus(10, ChronoUnit.MINUTES), true),
+                Arguments.of(Instant.now(), true)
+        );
+    }
+
+    @MethodSource("expTimeAndResults")
+    @ParameterizedTest
+    public void testTokenValid(Instant exp, boolean valid) {
+        AccessToken accessToken = new AccessToken();
+        accessToken.setToken("token");
+        accessToken.setExpiresAt(exp);
+        assertEquals(valid, accessToken.isValid());
+    }
+}


### PR DESCRIPTION
Fixes bug in `AccessToken#isValid()` that caused it to return false when the token is valid, resulting in extraneous calls to fetch new tokens.

## Description

Fixes the logic used to check if the token is valid based on its expiry.

## References

https://github.com/openfga/java-sdk/issues/48

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
