### PR TITLE
chore(deps): update gradle-build-action

### DIFF
--- a/config/clients/java/template/.github/workflows/main.yml.mustache
+++ b/config/clients/java/template/.github/workflows/main.yml.mustache
@@ -49,7 +49,7 @@ jobs:
       uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1.1.0
 
     - name: Publish package
-      uses: gradle/gradle-build-action@87a9a15658c426a54dd469d4fc7dc1a73ca9d4a6 # v2.10.0
+      uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2.11.1
       with:
         # Tasks created by https://github.com/gradle-nexus/publish-plugin
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
@@ -80,7 +80,7 @@ jobs:
       uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1.1.0
 
     - name: Publish package
-      uses: gradle/gradle-build-action@87a9a15658c426a54dd469d4fc7dc1a73ca9d4a6 # v2.10.0
+      uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2.11.1
       with:
         # Tasks created by https://docs.gradle.org/current/userguide/publishing_maven.html
         arguments: publishAllPublicationsToGitHubPackagesRepository


### PR DESCRIPTION
## Description

Port dependabot `gradle-build-action` version bump back to generator.

## References

https://github.com/openfga/java-sdk/pull/42/

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
