### PR TITLE
fix(build): allow clearing of unwanted files to fail

### DIFF
--- a/scripts/build_client.sh
+++ b/scripts/build_client.sh
@@ -30,7 +30,7 @@ cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/CHANGELOG.md.mustache" "${TMP_DIR}/tem
 
 # Clear existing directory
 # shellcheck disable=SC2010
-cd "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk" && ls -A | grep -Ev '.git|node_modules|.idea|venv|.gradle' | xargs rm -r || cd -
+cd "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk" && ls -A | { grep -Ev '.git|node_modules|.idea|venv|.gradle' || test $? = 1; } | xargs rm -r && cd -
 
 # Copy the generator ignore file into target directory (we need to do this before build otherwise openapi-generator ignores it)
 cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/.openapi-generator-ignore" "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk/"
@@ -48,6 +48,7 @@ docker run --rm \
   "openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_CLI_DOCKER_TAG}" generate \
   -i /docs/openapi/openfga.openapiv2.json \
   --http-user-agent="$http_user_agent" \
+  "${library[@]}" \
   -o "/clients/fga-${SDK_LANGUAGE}-sdk" \
   -c /config/config.json \
   -g "$(cat ./config/clients/"${SDK_LANGUAGE}"/generator.txt)"

--- a/scripts/build_client.sh
+++ b/scripts/build_client.sh
@@ -30,7 +30,7 @@ cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/CHANGELOG.md.mustache" "${TMP_DIR}/tem
 
 # Clear existing directory
 # shellcheck disable=SC2010
-cd "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk" && ls -A | grep -Ev '.git|node_modules|.idea|venv|.gradle' | xargs rm -r && cd -
+cd "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk" && ls -A | grep -Ev '.git|node_modules|.idea|venv|.gradle' | xargs rm -r || cd -
 
 # Copy the generator ignore file into target directory (we need to do this before build otherwise openapi-generator ignores it)
 cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/.openapi-generator-ignore" "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk/"
@@ -48,7 +48,6 @@ docker run --rm \
   "openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_CLI_DOCKER_TAG}" generate \
   -i /docs/openapi/openfga.openapiv2.json \
   --http-user-agent="$http_user_agent" \
-  "${library[@]}" \
   -o "/clients/fga-${SDK_LANGUAGE}-sdk" \
   -c /config/config.json \
   -g "$(cat ./config/clients/"${SDK_LANGUAGE}"/generator.txt)"

--- a/scripts/build_client.sh
+++ b/scripts/build_client.sh
@@ -29,7 +29,7 @@ cp -r "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/template/." "${TMP_DIR}/template/"
 cp "${CONFIG_DIR}/clients/${SDK_LANGUAGE}/CHANGELOG.md.mustache" "${TMP_DIR}/template/"
 
 # Clear existing directory
-# shellcheck disable=SC2010
+# shellcheck disable=SC2010,SC2012
 cd "${CLIENTS_OUTPUT_DIR}/fga-${SDK_LANGUAGE}-sdk" && ls -A | { grep -Ev '.git|node_modules|.idea|venv|.gradle' || test $? = 1; } | xargs rm -r && cd -
 
 # Copy the generator ignore file into target directory (we need to do this before build otherwise openapi-generator ignores it)


### PR DESCRIPTION
## Description

On a clean run, the script wouldn't find any files to remove which meant the `cd -` would never run and put the script back into the top level directory. So, use `||` to ensure that we always run that and end up back in the context of the top level directory.

## References

Closes #73

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
