### PR TITLE
fix(java-sdk): don't create a new HttpClient on every request

### DIFF
--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -175,6 +175,10 @@
       "destinationFilename": "src/test-integration/java/dev/openfga/sdk/api/client/OpenFgaClientIntegrationTest.java",
       "templateType": "SupportingFiles"
     },
+    "client-ApiClientTest.java.mustache" : {
+      "destinationFilename": "src/test/java/dev/openfga/sdk/api/client/ApiClientTest.java",
+      "templateType": "SupportingFiles"
+    },
     "creds-AccessToken.java.mustache" : {
       "destinationFilename": "src/main/java/dev/openfga/sdk/api/auth/AccessToken.java",
       "templateType": "SupportingFiles"

--- a/config/clients/java/template/client-ApiClientTest.java.mustache
+++ b/config/clients/java/template/client-ApiClientTest.java.mustache
@@ -1,0 +1,27 @@
+{{>licenseInfo}}
+package {{invokerPackage}};
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.net.http.HttpClient;
+import org.junit.jupiter.api.Test;
+
+class ApiClientTest {
+
+    @Test
+    public void returnSameHttpClient() {
+        ApiClient apiClient = new ApiClient();
+        assertEquals(apiClient.getHttpClient(), apiClient.getHttpClient());
+    }
+
+    @Test
+    public void newHttpClientWhenBuilderModified() {
+        ApiClient apiClient = new ApiClient();
+
+        HttpClient client1 = apiClient.getHttpClient();
+        apiClient.setHttpClientBuilder(HttpClient.newBuilder());
+
+        assertNotEquals(client1, apiClient.getHttpClient());
+    }
+}

--- a/config/clients/java/template/libraries/native/ApiClient.mustache
+++ b/config/clients/java/template/libraries/native/ApiClient.mustache
@@ -48,6 +48,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class ApiClient {
 
   private HttpClient.Builder builder;
+  private HttpClient client;
   private ObjectMapper mapper;
   private Consumer<HttpRequest.Builder> interceptor;
   private Consumer<HttpResponse<InputStream>> responseInterceptor;
@@ -59,6 +60,7 @@ public class ApiClient {
   public ApiClient() {
     this.builder = createDefaultHttpClientBuilder();
     this.mapper = createDefaultObjectMapper();
+    this.client = this.builder.build();
     interceptor = null;
     responseInterceptor = null;
     asyncResponseInterceptor = null;
@@ -77,6 +79,7 @@ public class ApiClient {
   public ApiClient(HttpClient.Builder builder, ObjectMapper mapper) {
     this.builder = builder;
     this.mapper = mapper;
+    this.client = this.builder.build();
     interceptor = null;
     responseInterceptor = null;
     asyncResponseInterceptor = null;
@@ -174,6 +177,7 @@ public class ApiClient {
    */
   public ApiClient setHttpClientBuilder(HttpClient.Builder builder) {
     this.builder = builder;
+    this.client = this.builder.build();
     return this;
   }
 
@@ -185,7 +189,7 @@ public class ApiClient {
    * @return The HTTP client.
    */
   public HttpClient getHttpClient() {
-    return builder.build();
+    return client;
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Fixes issue of creating a new `HttpClient` on every request.

## Description
<!-- Provide a detailed description of the changes -->

As noted in https://github.com/openfga/java-sdk/issues/46, we are currently creating a new `HttpClient` on every request. This change fixes that by building the client when the `ApiClient` is instantiated, and if the `HttpClient.Builder` is updated.

Note that this change does **not** address the retry case, in which we create a new `HttpClient` with a delayed executor. We should still be able to only create one of those, but as its tied to the `Configuration`, which is mutable, need to think a bit more about that scenario.
 
## References

* https://github.com/openfga/java-sdk/issues/46

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
