### PR TITLE
chore(python-sdk): enable PyPI trusted publishing

### DIFF
--- a/config/clients/python/template/.github/workflows/main.yaml
+++ b/config/clients/python/template/.github/workflows/main.yaml
@@ -42,6 +42,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [test]
 
+    permissions:
+      # Required for PyPI trusted publishing
+      id-token: write
+
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -67,9 +71,6 @@ jobs:
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This PR updates the Python SDK's GitHub publishing workflow to enable [trusted publishing](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) with the Python Package Index.

## References

- Generated change for SDK repository: https://github.com/openfga/python-sdk/pull/64

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
