### PR TITLE
fix(go-sdk, dotnet): fix example makefile to run openfga

### DIFF
--- a/config/clients/dotnet/template/example/Makefile
+++ b/config/clients/dotnet/template/example/Makefile
@@ -14,4 +14,4 @@ run:
 
 run-openfga:
 	docker pull docker.io/openfga/openfga:${openfga_version} && \
-		docker run -p 8080:8080 docker.io/openfga/openfga:${openfga_version}
+		docker run -p 8080:8080 docker.io/openfga/openfga:${openfga_version} run

--- a/config/clients/go/template/example/Makefile
+++ b/config/clients/go/template/example/Makefile
@@ -11,4 +11,4 @@ run: restore
 
 run-openfga:
 	docker pull docker.io/openfga/openfga:${openfga_version} && \
-		docker run -p 8080:8080 docker.io/openfga/openfga:${openfga_version}
+		docker run -p 8080:8080 docker.io/openfga/openfga:${openfga_version} run


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

## Description

Noticed that a couple of our SDK examples don't have the docker command configured to start the OpenFGA server; this PR fixes that for repositories where this was missing (dotnet and go)

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
