### PR TITLE
fix(js-sdk): make body in readChanges optional

### DIFF
--- a/config/clients/js/template/client.mustache
+++ b/config/clients/js/template/client.mustache
@@ -303,7 +303,7 @@ export class {{appShortName}}Client extends BaseAPI {
 
   /**
    * Read Changes - Read the list of historical relationship tuple writes and deletes
-   * @param {ClientReadChangesRequest} body
+   * @param {ClientReadChangesRequest} [body]
    * @param {ClientRequestOpts & PaginationOptions} [options]
    * @param {number} [options.pageSize]
    * @param {string} [options.continuationToken]
@@ -312,8 +312,8 @@ export class {{appShortName}}Client extends BaseAPI {
    * @param {number} [options.retryParams.maxRetry] - Override the max number of retries on each API request
    * @param {number} [options.retryParams.minWaitInMs] - Override the minimum wait before a retry is initiated
    */
-  async readChanges(body: ClientReadChangesRequest, options: ClientRequestOpts & PaginationOptions = {}): PromiseResult<ReadChangesResponse> {
-    return this.api.readChanges(body.type, options.pageSize, options.continuationToken, options);
+  async readChanges(body?: ClientReadChangesRequest, options: ClientRequestOpts & PaginationOptions = {}): PromiseResult<ReadChangesResponse> {
+    return this.api.readChanges(body?.type, options.pageSize, options.continuationToken, options);
   }
 
   /**

--- a/config/clients/js/template/tests/client.test.ts.mustache
+++ b/config/clients/js/template/tests/client.test.ts.mustache
@@ -193,6 +193,19 @@ describe("{{appTitleCaseName}} Client", () => {
         expect(scope.isDone()).toBe(true);
         expect(response).toMatchObject({ changes: expect.arrayContaining([]) });
       });
+
+      it("should properly call the {{appShortName}} ReadChanges API with no type", async () => {
+        const pageSize = 25;
+        const continuationToken = "eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ==";
+
+        const scope = nocks.readChanges(baseConfig.storeId!, "", pageSize, continuationToken);
+
+        expect(scope.isDone()).toBe(false);
+        const response = await fgaClient.readChanges(undefined, { pageSize, continuationToken });
+
+        expect(scope.isDone()).toBe(true);
+        expect(response).toMatchObject({ changes: expect.arrayContaining([]) });
+      });
     });
 
     describe("Read", () => {

--- a/config/clients/js/template/tests/helpers/nocks.ts.mustache
+++ b/config/clients/js/template/tests/helpers/nocks.ts.mustache
@@ -129,9 +129,9 @@ export const getNocks = ((nock: typeof Nock) => ({
     return nock(basePath)
       .get(`/stores/${storeId}/changes`)
       .query({
-        type,
         page_size: pageSize,
-        continuation_token: contToken
+        continuation_token: contToken,
+        ...(type ? { type } : { })
       })
       .reply(200, {
         changes: [{


### PR DESCRIPTION
## Description

We currently require passing an object with `type` as an empty string when calling the `OpenFgaClient.readChanges`, this is because we do not mark the `body` param as optional, when in reality it is as it is not required to pass a `type` to the api, and based on our other SDKs this seems a perfectly valid usage.

This is only really obvious when using TypeScript as it will flag the issue, developers who aren't using TypeScript won't see anything wrong until their code runs and the SDK errors when trying to access `body.type`.

```js
const response = await fgaClient.readChanges(); // Expected 1-2 arguments, but got 0. An argument for 'body' was not provided.
```

This PR proposes moving the `body` parameter to be optional, meaning that the above is now valid from a typechecking perspective and guards the property access so no runtime errors occur


## References

I'll make the JS SDK PR once this if this change gets OK'd

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
