### PR TITLE
chore: add test to cover not sending empty array when other has data

### DIFF
--- a/config/clients/dotnet/template/OpenFgaClientTests.mustache
+++ b/config/clients/dotnet/template/OpenFgaClientTests.mustache
@@ -786,6 +786,7 @@ public class {{appShortName}}ClientTests {
                     Object = "document:roadmap",
                 }
             },
+            Deletes = new List<ClientTupleKeyWithoutCondition>(), // should not get passed
         };
         var response = await fgaClient.Write(body, new ClientWriteOptions {
             AuthorizationModelId = "01GXSA8YR785C4FYS3C0RTG7B1",

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -961,6 +961,7 @@ func Test{{appShortName}}Client(t *testing.T) {
 				Relation: "viewer",
 				Object:   "document:roadmap",
 			} },
+			Deletes: []ClientTupleKeyWithoutCondition{},
 		}
 		options := ClientWriteOptions{
 			AuthorizationModelId: {{packageName}}.PtrString("01GAHCE4YVKPQEKZQHT2R89MQV"),

--- a/config/clients/js/template/tests/client.test.ts.mustache
+++ b/config/clients/js/template/tests/client.test.ts.mustache
@@ -353,6 +353,27 @@ describe("{{appTitleCaseName}} Client", () => {
           expect(scope1.isDone()).toBe(true);
         }
       });
+
+      it("should properly call the {{appShortName}} Write API when providing one empty array", async () => {
+        const tuple = {
+          user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+          relation: "admin",
+          object: "workspace:1",
+        };
+        const scope = nocks.write(baseConfig.storeId!);
+
+        expect(scope.isDone()).toBe(false);
+        const data = await fgaClient.write({
+          writes: [tuple],
+          deletes: []
+        }, {
+          authorizationModelId: "01GXSA8YR785C4FYS3C0RTG7B1",
+        });
+
+        expect(scope.isDone()).toBe(true);
+        expect(data.writes.length).toBe(1);
+        expect(data.deletes.length).toBe(0);
+      });
     });
 
     describe("WriteTuples", () => {

--- a/config/clients/python/template/client/test_client.mustache
+++ b/config/clients/python/template/client/test_client.mustache
@@ -1316,6 +1316,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                             user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
                         )
                     ],
+                writes=[],
             )
             transaction = WriteTransactionOpts(disabled=True, max_per_chunk=1, max_parallel_requests=10)
             {{#asyncio}}await {{/asyncio}}api_client.write(

--- a/config/clients/python/template/client/test_client_sync.mustache
+++ b/config/clients/python/template/client/test_client_sync.mustache
@@ -1316,6 +1316,7 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                             user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
                         )
                     ],
+                writes=[],
             )
             transaction = WriteTransactionOpts(disabled=True, max_per_chunk=1, max_parallel_requests=10)
             api_client.write(


### PR DESCRIPTION
## Description

For the Go, JS, and Python SDKs make passing no deletes or writes to the `write` command perform a no-op and just return an empty response

## References

Part of #299
SDK PRs to come shortly

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
