### PR TITLE
java-sdk calling the server without content when submitting empty deletes and writes

### DIFF
--- a/config/clients/java/template/client-ClientWriteResponse.java.mustache
+++ b/config/clients/java/template/client-ClientWriteResponse.java.mustache
@@ -2,6 +2,7 @@
 package {{clientPackage}}.model;
 
 import {{clientPackage}}.ApiResponse;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -10,10 +11,18 @@ public class ClientWriteResponse {
     private final Map<String, List<String>> headers;
     private final String rawResponse;
 
+    public static ClientWriteResponse EMPTY = new ClientWriteResponse();
+
     public ClientWriteResponse(ApiResponse<Object> apiResponse) {
         this.statusCode = apiResponse.getStatusCode();
         this.headers = apiResponse.getHeaders();
         this.rawResponse = apiResponse.getRawResponse();
+    }
+
+    private ClientWriteResponse() {
+        this.statusCode = 0;
+        this.headers = Collections.emptyMap();
+        this.rawResponse = "";
     }
 
     public int getStatusCode() {

--- a/config/clients/java/template/client-ClientWriteResponse.java.mustache
+++ b/config/clients/java/template/client-ClientWriteResponse.java.mustache
@@ -2,7 +2,6 @@
 package {{clientPackage}}.model;
 
 import {{clientPackage}}.ApiResponse;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -11,19 +10,10 @@ public class ClientWriteResponse {
     private final Map<String, List<String>> headers;
     private final String rawResponse;
 
-    // how to better express no call has been made?
-    public static ClientWriteResponse EMPTY = new ClientWriteResponse();
-
     public ClientWriteResponse(ApiResponse<Object> apiResponse) {
         this.statusCode = apiResponse.getStatusCode();
         this.headers = apiResponse.getHeaders();
         this.rawResponse = apiResponse.getRawResponse();
-    }
-
-    private ClientWriteResponse() {
-        this.statusCode = 200; // from openapi-spec, success status code
-        this.headers = Collections.emptyMap();
-        this.rawResponse = "";
     }
 
     public int getStatusCode() {

--- a/config/clients/java/template/client-ClientWriteResponse.java.mustache
+++ b/config/clients/java/template/client-ClientWriteResponse.java.mustache
@@ -11,6 +11,7 @@ public class ClientWriteResponse {
     private final Map<String, List<String>> headers;
     private final String rawResponse;
 
+    // how to better express no call has been made?
     public static ClientWriteResponse EMPTY = new ClientWriteResponse();
 
     public ClientWriteResponse(ApiResponse<Object> apiResponse) {
@@ -20,7 +21,7 @@ public class ClientWriteResponse {
     }
 
     private ClientWriteResponse() {
-        this.statusCode = 0;
+        this.statusCode = 200; // from openapi-spec, success status code
         this.headers = Collections.emptyMap();
         this.rawResponse = "";
     }

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -1,6 +1,7 @@
 {{>licenseInfo}}
 package {{clientPackage}};
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
 import static {{utilPackage}}.StringUtil.isNullOrWhitespace;
 import static java.util.UUID.randomUUID;
 
@@ -357,13 +358,19 @@ public class OpenFgaClient {
         WriteRequest body = new WriteRequest();
 
         var writeTuples = request.getWrites();
-        if (writeTuples != null && !writeTuples.isEmpty()) {
+        var writesRequested = writeTuples != null && !writeTuples.isEmpty();
+        if (writesRequested) {
             body.writes(ClientTupleKey.asWriteRequestWrites(writeTuples));
         }
 
         var deleteTuples = request.getDeletes();
-        if (deleteTuples != null && !deleteTuples.isEmpty()) {
+        var deletesRequested = deleteTuples != null && !deleteTuples.isEmpty();
+        if (deletesRequested) {
             body.deletes(ClientTupleKeyWithoutCondition.asWriteRequestDeletes(deleteTuples));
+        }
+
+        if (!writesRequested && !deletesRequested) {
+            return completedFuture(ClientWriteResponse.EMPTY);
         }
 
         if (options != null && !isNullOrWhitespace(options.getAuthorizationModelId())) {

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -370,6 +370,7 @@ public class OpenFgaClient {
         }
 
         if (!writesRequested && !deletesRequested) {
+            // no call executed -> return empty response
             return completedFuture(ClientWriteResponse.EMPTY);
         }
 

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -1,7 +1,6 @@
 {{>licenseInfo}}
 package {{clientPackage}};
 
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static {{utilPackage}}.StringUtil.isNullOrWhitespace;
 import static java.util.UUID.randomUUID;
 
@@ -358,20 +357,13 @@ public class OpenFgaClient {
         WriteRequest body = new WriteRequest();
 
         var writeTuples = request.getWrites();
-        var writesRequested = writeTuples != null && !writeTuples.isEmpty();
-        if (writesRequested) {
+        if (writeTuples != null && !writeTuples.isEmpty()) {
             body.writes(ClientTupleKey.asWriteRequestWrites(writeTuples));
         }
 
         var deleteTuples = request.getDeletes();
-        var deletesRequested = deleteTuples != null && !deleteTuples.isEmpty();
-        if (deletesRequested) {
+        if (deleteTuples != null && !deleteTuples.isEmpty()) {
             body.deletes(ClientTupleKeyWithoutCondition.asWriteRequestDeletes(deleteTuples));
-        }
-
-        if (!writesRequested && !deletesRequested) {
-            // no call executed -> return empty response
-            return completedFuture(ClientWriteResponse.EMPTY);
         }
 
         if (options != null && !isNullOrWhitespace(options.getAuthorizationModelId())) {
@@ -405,6 +397,12 @@ public class OpenFgaClient {
         var deleteTransactions = chunksOf(chunkSize, request.getDeletes()).map(ClientWriteRequest::ofDeletes);
 
         var transactions = Stream.concat(writeTransactions, deleteTransactions).collect(Collectors.toList());
+
+        if(transactions.isEmpty()) {
+            var emptyTransaction = new ClientWriteRequest().writes(null).deletes(null);
+            return this.writeNonTransaction(storeId, emptyTransaction, writeOptions);
+        }
+
         var futureResponse = this.writeNonTransaction(storeId, transactions.get(0), options);
 
         for (int i = 1; i < transactions.size(); i++) {

--- a/config/clients/java/template/client-OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClientTest.java.mustache
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pgssoft.httpclient.HttpClientMock;
 import {{clientPackage}}.model.*;
@@ -16,6 +15,7 @@ import {{invokerPackage}}.*;
 import {{modelPackage}}.*;
 import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -1358,6 +1358,23 @@ public class OpenFgaClientTest {
 
         // Then
         mockHttpClient.verify().post(postPath).withBody(is(expectedBody)).called(1);
+        assertEquals(200, response.getStatusCode());
+    }
+
+    @Test
+    public void write_nothingSentWhenWritesAndDeletesAreEmpty() throws FgaInvalidParameterException, ExecutionException, InterruptedException {
+        // Given
+        String postPath = String.format("https://localhost/stores/%s/write", DEFAULT_STORE_ID);
+        String expectedBody = String.format(
+        "{\"writes\":null,\"deletes\":null,\"authorization_model_id\":\"%s\"}", DEFAULT_AUTH_MODEL_ID);
+        mockHttpClient.onPost(postPath).withBody(is(expectedBody)).doReturn(200, EMPTY_RESPONSE_BODY);
+
+        // When
+        var clientWriteRequest = new ClientWriteRequest().writes(Collections.emptyList()).deletes(Collections.emptyList());
+        var response = fga.write(clientWriteRequest).get();
+
+        // Then
+        mockHttpClient.verify().post(postPath).called(1);
         assertEquals(200, response.getStatusCode());
     }
 


### PR DESCRIPTION
## Open for this PR:

- [x]  discuss the Java changes
- [x] add a test for the Java changes

## Description
For the Java SDK make passing empty deletes and empty writes to the write command perform a server call without content

## References
Part of https://github.com/openfga/sdk-generator/issues/299 and https://github.com/openfga/sdk-generator/issues/306
SDK PRs to come shortly

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
