### PR TITLE
fix: use correct content type for token request

### DIFF
--- a/config/clients/dotnet/template/Client_OAuth2Client.mustache
+++ b/config/clients/dotnet/template/Client_OAuth2Client.mustache
@@ -18,13 +18,6 @@ public class OAuth2Client {
 
     private static readonly Random _random = new();
 
-    private class AuthRequestBody {
-        [JsonPropertyName("audience")] public string? Audience { get; set; }
-        [JsonPropertyName("client_id")] public string? ClientId { get; set; }
-        [JsonPropertyName("client_secret")] public string? ClientSecret { get; set; }
-        [JsonPropertyName("grant_type")] public string? GrantType { get; set; }
-    }
-
     /// <summary>
     /// Credentials Flow Response
     ///
@@ -68,7 +61,7 @@ public class OAuth2Client {
 
     private readonly BaseClient _httpClient;
     private AuthToken _authToken = new();
-    private AuthRequestBody _authRequest { get; set; }
+    private IDictionary<string, string> _authRequest { get; set; }
     private string _apiTokenIssuer { get; set; }
 
     #endregion
@@ -92,11 +85,11 @@ public class OAuth2Client {
 
         this._httpClient = httpClient;
         this._apiTokenIssuer = credentialsConfig.Config.ApiTokenIssuer;
-        this._authRequest = new AuthRequestBody() {
-            ClientId = credentialsConfig.Config.ClientId,
-            ClientSecret = credentialsConfig.Config.ClientSecret,
-            Audience = credentialsConfig.Config.ApiAudience,
-            GrantType = "client_credentials"
+        this._authRequest = new Dictionary<string, string>() {
+            { "client_id", credentialsConfig.Config.ClientId },
+            { "client_secret", credentialsConfig.Config.ClientSecret },
+            { "audience", credentialsConfig.Config.ApiAudience },
+            { "grant_type", "client_credentials" }
         };
     }
 
@@ -110,7 +103,7 @@ public class OAuth2Client {
             Method = HttpMethod.Post,
             BasePath = $"https://{this._apiTokenIssuer}",
             PathTemplate = "/oauth/token",
-            Body = Utils.CreateJsonStringContent(this._authRequest)
+            Body = Utils.CreateFormEncodedConent(this._authRequest),
         };
 
         var accessTokenResponse = await _httpClient.SendRequestAsync<AccessTokenResponse>(

--- a/config/clients/dotnet/template/Client_Utils.mustache
+++ b/config/clients/dotnet/template/Client_Utils.mustache
@@ -15,6 +15,11 @@ public static class Utils {
         return new StringContent(json, Encoding.UTF8, "application/json");
     }
 
+    public static HttpContent CreateFormEncodedConent(IDictionary<string, string> parameters) {
+        return new FormUrlEncodedContent(parameters.Select(p =>
+            new KeyValuePair<string, string>(p.Key, p.Value ?? "")));
+    }
+
     public static string BuildQueryParams(IDictionary<string, string> parameters) {
         var query = "";
         foreach (var parameter in parameters) {

--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -296,7 +296,8 @@ namespace {{testPackageName}}.Api {
                     "SendAsync",
                     ItExpr.Is<HttpRequestMessage>(req =>
                         req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
-                        req.Method == HttpMethod.Post),
+                        req.Method == HttpMethod.Post &&
+                        req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                     ItExpr.IsAny<CancellationToken>()
                 )
                 .ReturnsAsync(new HttpResponseMessage() {
@@ -350,7 +351,8 @@ namespace {{testPackageName}}.Api {
                 Times.Exactly(1),
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
-                    req.Method == HttpMethod.Post),
+                    req.Method == HttpMethod.Post &&
+                    req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                 ItExpr.IsAny<CancellationToken>()
             );
             mockHandler.Protected().Verify(
@@ -393,7 +395,8 @@ namespace {{testPackageName}}.Api {
                     "SendAsync",
                     ItExpr.Is<HttpRequestMessage>(req =>
                         req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
-                        req.Method == HttpMethod.Post),
+                        req.Method == HttpMethod.Post &&
+                        req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                     ItExpr.IsAny<CancellationToken>()
                 )
                 .ReturnsAsync(new HttpResponseMessage() {
@@ -447,7 +450,8 @@ namespace {{testPackageName}}.Api {
                 Times.Exactly(2),
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
-                    req.Method == HttpMethod.Post),
+                    req.Method == HttpMethod.Post &&
+                    req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                 ItExpr.IsAny<CancellationToken>()
             );
             mockHandler.Protected().Verify(

--- a/config/clients/js/template/credentials/credentials.ts.mustache
+++ b/config/clients/js/template/credentials/credentials.ts.mustache
@@ -133,6 +133,9 @@ export class Credentials {
           client_secret: clientCredentials.clientSecret,
           audience: clientCredentials.apiAudience,
           grant_type: "client_credentials",
+        },
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
         }
       }, {
         maxRetry: 3,

--- a/config/clients/js/template/tests/helpers/nocks.ts.mustache
+++ b/config/clients/js/template/tests/helpers/nocks.ts.mustache
@@ -29,10 +29,12 @@ export const getNocks = ((nock: typeof Nock) => ({
     expiresIn = 300,
     statusCode = 200,
   ) => {
-    return nock(`https://${apiTokenIssuer}`).post("/oauth/token").reply(statusCode, {
-      access_token: accessToken,
-      expires_in: expiresIn,
-    });
+    return nock(`https://${apiTokenIssuer}`, { reqheaders: { "Content-Type": "application/x-www-form-urlencoded"} })
+      .post("/oauth/token")
+      .reply(statusCode, {
+        access_token: accessToken,
+        expires_in: expiresIn,
+      });
   },
   listStores: (
     basePath = defaultConfiguration.getBasePath(),

--- a/config/clients/python/template/oauth2.mustache
+++ b/config/clients/python/template/oauth2.mustache
@@ -36,14 +36,14 @@ class OAuth2Client:
         """
         configuration = self._credentials.configuration
         token_url = 'https://{}/oauth/token'.format(configuration.api_issuer)
-        body = {
+        post_params = {
             'client_id': configuration.client_id,
             'client_secret': configuration.client_secret,
             'audience': configuration.api_audience,
             'grant_type': "client_credentials",
         }
-        headers = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
-        raw_response = await client.POST(token_url, headers=headers, body=body);
+        headers = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
+        raw_response = await client.POST(token_url, headers=headers, post_params=post_params);
         if 200 <= raw_response.status <= 299:
             try:
                 api_response = json.loads(raw_response.data)

--- a/config/clients/python/template/oauth2_sync.mustache
+++ b/config/clients/python/template/oauth2_sync.mustache
@@ -36,14 +36,14 @@ class OAuth2Client:
         """
         configuration = self._credentials.configuration
         token_url = 'https://{}/oauth/token'.format(configuration.api_issuer)
-        body = {
+        post_params = {
             'client_id': configuration.client_id,
             'client_secret': configuration.client_secret,
             'audience': configuration.api_audience,
             'grant_type': "client_credentials",
         }
-        headers = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
-        raw_response = client.POST(token_url, headers=headers, body=body);
+        headers = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
+        raw_response = client.POST(token_url, headers=headers, post_params=post_params);
         if 200 <= raw_response.status <= 299:
             try:
                 api_response = json.loads(raw_response.data)

--- a/config/clients/python/template/oauth2_test.mustache
+++ b/config/clients/python/template/oauth2_test.mustache
@@ -69,13 +69,13 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         self.assertEqual(auth_header, {'Authorization': 'Bearer AABBCCDD'})
         self.assertEqual(client._access_token, 'AABBCCDD')
         self.assertGreaterEqual(client._access_expiry_time, current_time + timedelta(seconds=int(120)))
-        expected_header = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
+        expected_header = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
         mock_request.assert_called_once_with(
             'POST',
             'https://www.testme.com/oauth/token',
             headers=expected_header,
-            query_params=None, post_params=None, _preload_content=True, _request_timeout=None,
-            body={"client_id": "myclientid", "client_secret": "mysecret", "audience": "myaudience", "grant_type": "client_credentials"}
+            query_params=None, body=None, _preload_content=True, _request_timeout=None,
+            post_params={"client_id": "myclientid", "client_secret": "mysecret", "audience": "myaudience", "grant_type": "client_credentials"}
         )
         await rest_client.close()
 

--- a/config/clients/python/template/oauth2_test_sync.mustache
+++ b/config/clients/python/template/oauth2_test_sync.mustache
@@ -70,13 +70,13 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         self.assertEqual(auth_header, {'Authorization': 'Bearer AABBCCDD'})
         self.assertEqual(client._access_token, 'AABBCCDD')
         self.assertGreaterEqual(client._access_expiry_time, current_time + timedelta(seconds=int(120)))
-        expected_header = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/json', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
+        expected_header = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
         mock_request.assert_called_once_with(
             'POST',
             'https://www.testme.com/oauth/token',
             headers=expected_header,
-            query_params=None, post_params=None, _preload_content=True, _request_timeout=None,
-            body={"client_id": "myclientid", "client_secret": "mysecret", "audience": "myaudience", "grant_type": "client_credentials"}
+            query_params=None, body=None, _preload_content=True, _request_timeout=None,
+            post_params={"client_id": "myclientid", "client_secret": "mysecret", "audience": "myaudience", "grant_type": "client_credentials"}
         )
         rest_client.close()
 


### PR DESCRIPTION
## Description

Updates the remaining SDKs to use the correct content type when making a token request.

* .net - Needed to move to using `FormUrlEncodedContent` as the body and then the runtime will handle setting the `Content-Type` for us
* Go - no work needed as this is done by the `oauth2` package we included
* JS - Set the header on the request and axios will serialize for us
* Python - Set the header and pass `post_params` instead of body

This has been verified by running all 4 examples and providing credentials, where possible tests have been amended to assert we're passing the right header/body.

## References

Closes #284
Language PRs to follow

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
