### PR TITLE
fix(java-sdk): fix clone of object mapper

### DIFF
--- a/config/clients/java/template/libraries/native/ApiClient.mustache
+++ b/config/clients/java/template/libraries/native/ApiClient.mustache
@@ -231,12 +231,12 @@ public class ApiClient {
   }
 
   /**
-   * Get a copy of the current {@link ObjectMapper}.
+   * Get current {@link ObjectMapper}.
    *
-   * @return A copy of the current object mapper.
+   * @return the current object mapper.
    */
   public ObjectMapper getObjectMapper() {
-    return mapper.copy();
+    return mapper;
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Fixes https://github.com/openfga/java-sdk/issues/65. The intention is to avoid unnecessary clones of the object mapper for less overhead. Tests are expected to pass, given that this is an internal change with untouched contracts.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
