### PR TITLE
docs: include retry information in the readme for SDKs

### DIFF
--- a/config/clients/dotnet/template/Client_ApiClient.mustache
+++ b/config/clients/dotnet/template/Client_ApiClient.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using {{packageName}}.Client.Model;
 using {{packageName}}.Configuration;
 using {{packageName}}.Exceptions;
 
@@ -34,7 +35,7 @@ public class ApiClient : IDisposable {
                 _baseClient = new BaseClient(_configuration, userHttpClient);
                 break;
             case CredentialsMethod.ClientCredentials:
-                _oauth2Client = new OAuth2Client(_configuration.Credentials, _baseClient);
+                _oauth2Client = new OAuth2Client(_configuration.Credentials, _baseClient,  new RetryParams { MaxRetry = _configuration.MaxRetry, MinWaitInMs = _configuration.MinWaitInMs});
                 break;
             case CredentialsMethod.None:
             default:

--- a/config/clients/dotnet/template/Client_OAuth2Client.mustache
+++ b/config/clients/dotnet/template/Client_OAuth2Client.mustache
@@ -2,6 +2,7 @@
 
 using System.Text.Json.Serialization;
 
+using {{packageName}}.Client.Model;
 using {{packageName}}.Configuration;
 using {{packageName}}.Exceptions;
 
@@ -63,6 +64,7 @@ public class OAuth2Client {
     private AuthToken _authToken = new();
     private IDictionary<string, string> _authRequest { get; set; }
     private string _apiTokenIssuer { get; set; }
+    private RetryParams _retryParams;
 
     #endregion
 
@@ -74,7 +76,7 @@ public class OAuth2Client {
     /// <param name="credentialsConfig"></param>
     /// <param name="httpClient"></param>
     /// <exception cref="NullReferenceException"></exception>
-    public OAuth2Client(Credentials credentialsConfig, BaseClient httpClient) {
+    public OAuth2Client(Credentials credentialsConfig, BaseClient httpClient, RetryParams retryParams) {
         if (string.IsNullOrWhiteSpace(credentialsConfig.Config!.ClientId)) {
             throw new FgaRequiredParamError("OAuth2Client", "config.ClientId");
         }
@@ -91,6 +93,8 @@ public class OAuth2Client {
             { "audience", credentialsConfig.Config.ApiAudience },
             { "grant_type", "client_credentials" }
         };
+
+        this._retryParams = retryParams;
     }
 
     /// <summary>
@@ -106,16 +110,45 @@ public class OAuth2Client {
             Body = Utils.CreateFormEncodedConent(this._authRequest),
         };
 
-        var accessTokenResponse = await _httpClient.SendRequestAsync<AccessTokenResponse>(
+        var accessTokenResponse = await Retry(async () => await _httpClient.SendRequestAsync<AccessTokenResponse>(
             requestBuilder,
             null,
             "ExchangeTokenAsync",
-            cancellationToken);
+            cancellationToken));
 
         _authToken = new AuthToken() {
             AccessToken = accessTokenResponse.AccessToken,
             ExpiresAt = DateTime.Now + TimeSpan.FromSeconds(accessTokenResponse.ExpiresIn)
         };
+    }
+
+    private async Task<TResult> Retry<TResult>(Func<Task<TResult>> retryable) {
+        var numRetries = 0;
+        while (true) {
+            try {
+                numRetries++;
+
+                return await retryable();
+            }
+            catch (FgaApiRateLimitExceededError err) {
+                if (numRetries > _retryParams.MaxRetry) {
+                    throw;
+                }
+                var waitInMs = (int)((err.ResetInMs == null || err.ResetInMs < _retryParams.MinWaitInMs)
+                    ? _retryParams.MinWaitInMs
+                    : err.ResetInMs);
+
+                await Task.Delay(waitInMs);
+            }
+            catch (FgaApiError err) {
+                if (!err.ShouldRetry || numRetries > _retryParams.MaxRetry) {
+                    throw;
+                }
+                var waitInMs = _retryParams.MinWaitInMs;
+
+                await Task.Delay(waitInMs);
+            }
+        }
     }
 
     /// <summary>

--- a/config/clients/dotnet/template/README_retries.mustache
+++ b/config/clients/dotnet/template/README_retries.mustache
@@ -1,0 +1,31 @@
+By default API requests are retried up to 15 times on 429 and 5xx errors and credential requests are retried up to 15 times on 429 and 5xx errors. In both instances they will wait a minimum of 100 milliseconds between requests.
+
+In order to change the behavior for API requests, pass a `RetryParams` property to `ClientConfiguration` constructor to a `RetryParams` instance like below with a `MaxRetry` property to control the amount of retries and a `MinWaitInMs` to control the minimum wait time between retried requests.
+
+```csharp
+using OpenFga.Sdk.Client;
+using OpenFga.Sdk.Client.Model;
+using OpenFga.Sdk.Model;
+
+namespace Example {
+    public class Example {
+        public static async Task Main() {
+            try {
+                var configuration = new ClientConfiguration() {
+                    ApiUrl = Environment.GetEnvironmentVariable("FGA_API_URL") ?? "http://localhost:8080", // required, e.g. https://api.fga.example
+                    StoreId = Environment.GetEnvironmentVariable("FGA_STORE_ID"), // not needed when calling `CreateStore` or `ListStores`
+                    AuthorizationModelId = Environment.GetEnvironmentVariable("FGA_AUTHORIZATION_MODEL_ID"), // Optional, can be overridden per request
+                    RetryParams = new RetryParams() {
+                        MaxRetry = 3, // retry up to 3 times on API requests
+                        MinWaitInMs = 250 // wait a minimum of 250 milliseconds between requests
+                    }
+                };
+                var fgaClient = new OpenFgaClient(configuration);
+                var response = await fgaClient.ReadAuthorizationModels();
+            } catch (ApiException e) {
+                 Debug.Print("Error: "+ e);
+            }
+        }
+    }
+}
+```

--- a/config/clients/dotnet/template/README_retries.mustache
+++ b/config/clients/dotnet/template/README_retries.mustache
@@ -1,6 +1,8 @@
-By default API requests are retried up to 15 times on 429 and 5xx errors and credential requests are retried up to 15 times on 429 and 5xx errors. In both instances they will wait a minimum of 100 milliseconds between requests.
+If a network request fails with a 429 or 5xx error from the server, the SDK will automatically retry the request up to {{defaultMaxRetry}} times with a minimum wait time of {{defaultMinWaitInMs}} milliseconds between each attempt.
 
-In order to change the behavior for API requests, pass a `RetryParams` property to `ClientConfiguration` constructor to a `RetryParams` instance like below with a `MaxRetry` property to control the amount of retries and a `MinWaitInMs` to control the minimum wait time between retried requests.
+To customize this behavior, create a `RetryParams` instance and assign values to the `MaxRetry` and `MinWaitInMs` constructor parameters. `MaxRetry` determines the maximum number of retries (up to {{retryMaxAllowedNumber}}), while `MinWaitInMs` sets the minimum wait time between retries in milliseconds.
+
+Apply your custom retry values by passing the object to the `ClientConfiguration` constructor's `RetryParams` parameter.
 
 ```csharp
 using OpenFga.Sdk.Client;

--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -470,6 +470,102 @@ namespace {{testPackageName}}.Api {
             );
         }
 
+        /// <summary>
+        /// Test that a network calls to get credentials are retried
+        /// </summary>
+        [Fact]
+        public async Task ExchangeCredentialsRetriesTest() {
+            var config = new Configuration.Configuration() {
+                ApiHost = _host,
+                Credentials = new Credentials() {
+                    Method = CredentialsMethod.ClientCredentials,
+                    Config = new CredentialsConfig() {
+                        ClientId = "some-id",
+                        ClientSecret = "some-secret",
+                        ApiTokenIssuer = "tokenissuer.{{sampleApiDomain}}",
+                        ApiAudience = "some-audience",
+                    }
+                }
+            };
+
+            var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            mockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
+                        req.Method == HttpMethod.Post &&
+                        req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.TooManyRequests
+                })
+                    .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.InternalServerError
+                })
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = Utils.CreateJsonStringContent(new OAuth2Client.AccessTokenResponse() {
+                        AccessToken = "some-token",
+                        ExpiresIn = 86400,
+                        TokenType = "Bearer"
+                    }),
+                });
+
+            var readAuthorizationModelsMockExpression = ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri.ToString()
+                    .StartsWith($"{config.BasePath}/stores/{_storeId}/authorization-models") &&
+                req.Method == HttpMethod.Get &&
+                req.Headers.Contains("Authorization") &&
+                req.Headers.Authorization.Equals(new AuthenticationHeaderValue("Bearer", "some-token")));
+            mockHandler.Protected()
+                .SetupSequence<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    readAuthorizationModelsMockExpression,
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = Utils.CreateJsonStringContent(
+                            new ReadAuthorizationModelsResponse() { AuthorizationModels = { } }),
+                })
+                .ReturnsAsync(new HttpResponseMessage() {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = Utils.CreateJsonStringContent(
+                            new ReadAuthorizationModelsResponse() { AuthorizationModels = { } }),
+                });
+
+            var httpClient = new HttpClient(mockHandler.Object);
+            var {{appCamelCaseName}}Api = new {{classname}}(config, httpClient);
+
+            var response = await {{appCamelCaseName}}Api.ReadAuthorizationModels(_storeId, null, null);
+
+            mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(3),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
+                    req.Method == HttpMethod.Post &&
+                    req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
+                ItExpr.IsAny<CancellationToken>()
+            );
+            mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                readAuthorizationModelsMockExpression,
+                ItExpr.IsAny<CancellationToken>()
+            );
+            mockHandler.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(0),
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri == new Uri($"{config.BasePath}/stores/{_storeId}/check") &&
+                    req.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
         /**
          * Errors
          */

--- a/config/clients/go/template/README_retries.mustache
+++ b/config/clients/go/template/README_retries.mustache
@@ -1,0 +1,26 @@
+By default API requests are retried up to 15 times on 429 and 5xx errors with a minimum wait time of 100 milliseconds and credential requests are retried up to 3 times on 429 and 5xx errors with a minimum wait time of 50 milliseconds.
+
+In order to change the behavior for API requests, pass a `RetryParams` property in the `ClientConfiguration` struct, with a `MaxRetry` property to control the amount of retries and a `MinWaitInMs` to control the minimum wait time between retried requests.
+
+```golang
+import (
+    . "github.com/openfga/go-sdk/client"
+    "os"
+)
+
+func main() {
+    fgaClient, err := NewSdkClient(&ClientConfiguration{
+        ApiUrl:  os.Getenv("FGA_API_URL"), // required, e.g. https://api.fga.example
+        StoreId: os.Getenv("FGA_STORE_ID"), // not needed when calling `CreateStore` or `ListStores`
+        AuthorizationModelId: os.Getenv("FGA_AUTHORIZATION_MODEL_ID"), // optional, recommended to be set for production
+        RetryParams: &openfga.RetryParams{
+            MaxRetry:    3, // retry up to 3 times on API requests
+            MinWaitInMs: 250, // wait a minimum of 250 milliseconds between requests
+        },
+    })
+
+    if err != nil {
+        // .. Handle error
+    }
+}
+```

--- a/config/clients/go/template/README_retries.mustache
+++ b/config/clients/go/template/README_retries.mustache
@@ -1,6 +1,8 @@
-By default API requests are retried up to 15 times on 429 and 5xx errors with a minimum wait time of 100 milliseconds and credential requests are retried up to 3 times on 429 and 5xx errors with a minimum wait time of 50 milliseconds.
+If a network request fails with a 429 or 5xx error from the server, the SDK will automatically retry the request up to {{defaultMaxRetry}} times with a minimum wait time of {{defaultMinWaitInMs}} milliseconds between each attempt.
 
-In order to change the behavior for API requests, pass a `RetryParams` property in the `ClientConfiguration` struct, with a `MaxRetry` property to control the amount of retries and a `MinWaitInMs` to control the minimum wait time between retried requests.
+To customize this behavior, create an `openfga.RetryParams` struct and assign values to the `MaxRetry` and `MinWaitInMs` fields. `MaxRetry` determines the maximum number of retries (up to {{retryMaxAllowedNumber}}), while `MinWaitInMs` sets the minimum wait time between retries in milliseconds.
+
+Apply your custom retry values by passing this struct to the `ClientConfiguration` struct's `RetryParams` parameter.
 
 ```golang
 import (

--- a/config/clients/java/template/README_initializing.mustache
+++ b/config/clients/java/template/README_initializing.mustache
@@ -13,7 +13,7 @@ import java.net.http.HttpClient;
 public class Example {
     public static void main(String[] args) throws Exception {
         var config = new ClientConfiguration()
-                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "https://localhost:8080"
+                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "http://localhost:8080"
                 .storeId(System.getenv("FGA_STORE_ID")) // Not required when calling createStore() or listStores()
                 .authorizationModelId(System.getenv("FGA_AUTHORIZATION_MODEL_ID")); // Optional, can be overridden per request
 
@@ -36,7 +36,7 @@ import java.net.http.HttpClient;
 public class Example {
     public static void main(String[] args) throws Exception {
         var config = new ClientConfiguration()
-                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "https://localhost:8080"
+                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "http://localhost:8080"
                 .storeId(System.getenv("FGA_STORE_ID")) // Not required when calling createStore() or listStores()
                 .authorizationModelId(System.getenv("FGA_AUTHORIZATION_MODEL_ID")) // Optional, can be overridden per request
                 .credentials(new Credentials(
@@ -62,7 +62,7 @@ import java.net.http.HttpClient;
 public class Example {
     public static void main(String[] args) throws Exception {
         var config = new ClientConfiguration()
-                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "https://localhost:8080"
+                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "http://localhost:8080"
                 .storeId(System.getenv("FGA_STORE_ID")) // Not required when calling createStore() or listStores()
                 .authorizationModelId(System.getenv("FGA_AUTHORIZATION_MODEL_ID")) // Optional, can be overridden per request
                 .credentials(new Credentials(
@@ -92,7 +92,7 @@ import java.net.http.HttpClient;
 public class Example {
     public static void main(String[] args) throws Exception {
         var config = new ClientConfiguration()
-                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "https://localhost:8080"
+                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "http://localhost:8080"
                 .storeId(System.getenv("FGA_STORE_ID")) // Not required when calling createStore() or listStores()
                 .authorizationModelId(System.getenv("FGA_AUTHORIZATION_MODEL_ID")) // Optional, can be overridden per request
                 .credentials(new Credentials(

--- a/config/clients/java/template/README_retries.mustache
+++ b/config/clients/java/template/README_retries.mustache
@@ -1,0 +1,24 @@
+By default API requests are retried up to 15 times on 429 and 5xx errors and credential requests are retried up to 15 times on 429 and 5xx errors. In both instances they will wait a minimum of 100 milliseconds between requests.
+
+In order to change the behavior for API requests, when using the `ClientConfiguration` builder, call `maxRetries` to control the amount of retries and `minimumRetryDelay` to control the minimum wait time between retried requests.
+
+```java
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.openfga.sdk.api.client.OpenFgaClient;
+import dev.openfga.sdk.api.configuration.ClientConfiguration;
+import java.net.http.HttpClient;
+
+public class Example {
+    public static void main(String[] args) throws Exception {
+        var config = new ClientConfiguration()
+                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "https://localhost:8080"
+                .storeId(System.getenv("FGA_STORE_ID")) // Not required when calling createStore() or listStores()
+                .authorizationModelId(System.getenv("FGA_AUTHORIZATION_MODEL_ID")) // Optional, can be overridden per request
+                .maxRetries(3) // retry up to 3 times on API requests
+                .minimumRetryDelay(250); // wait a minimum of 250 milliseconds between requests
+
+        var fgaClient = new OpenFgaClient(config);
+        var response = fgaClient.readAuthorizationModels().get();
+    }
+}
+```

--- a/config/clients/java/template/README_retries.mustache
+++ b/config/clients/java/template/README_retries.mustache
@@ -1,6 +1,6 @@
-By default API requests are retried up to 15 times on 429 and 5xx errors and credential requests are retried up to 15 times on 429 and 5xx errors. In both instances they will wait a minimum of 100 milliseconds between requests.
+If a network request fails with a 429 or 5xx error from the server, the SDK will automatically retry the request up to {{defaultMaxRetry}} times with a minimum wait time of {{defaultMinWaitInMs}} milliseconds between each attempt.
 
-In order to change the behavior for API requests, when using the `ClientConfiguration` builder, call `maxRetries` to control the amount of retries and `minimumRetryDelay` to control the minimum wait time between retried requests.
+To customize this behavior, call `maxRetries` and `minimumRetryDelay` on the `ClientConfiguration` builder. `maxRetries` determines the maximum number of retries (up to {{retryMaxAllowedNumber}}), while `minimumRetryDelay` sets the minimum wait time between retries in milliseconds.
 
 ```java
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,7 +11,7 @@ import java.net.http.HttpClient;
 public class Example {
     public static void main(String[] args) throws Exception {
         var config = new ClientConfiguration()
-                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "https://localhost:8080"
+                .apiUrl(System.getenv("FGA_API_URL")) // If not specified, will default to "http://localhost:8080"
                 .storeId(System.getenv("FGA_STORE_ID")) // Not required when calling createStore() or listStores()
                 .authorizationModelId(System.getenv("FGA_AUTHORIZATION_MODEL_ID")) // Optional, can be overridden per request
                 .maxRetries(3) // retry up to 3 times on API requests

--- a/config/clients/java/template/build.gradle.mustache
+++ b/config/clients/java/template/build.gradle.mustache
@@ -90,6 +90,7 @@ testing {
                 implementation "org.junit.jupiter:junit-jupiter:$junit_version"
                 implementation "org.mockito:mockito-core:5.+"
                 runtimeOnly "org.junit.platform:junit-platform-launcher"
+                implementation "org.wiremock:wiremock:3.5.2"
 
                 // This test-only dependency is convenient but not widely used.
                 // Review project activity before updating the version here.

--- a/config/clients/java/template/creds-OAuth2Client.java.mustache
+++ b/config/clients/java/template/creds-OAuth2Client.java.mustache
@@ -15,9 +15,9 @@ public class OAuth2Client {
     private static final String DEFAULT_API_TOKEN_ISSUER_PATH = "/oauth/token";
 
     private final ApiClient apiClient;
-    private final String apiTokenIssuer;
     private final AccessToken token = new AccessToken();
     private final CredentialsFlowRequest authRequest;
+    private final Configuration config;
 
     /**
      * Initializes a new instance of the {@link OAuth2Client} class
@@ -28,10 +28,13 @@ public class OAuth2Client {
         var clientCredentials = configuration.getCredentials().getClientCredentials();
 
         this.apiClient = apiClient;
-        this.apiTokenIssuer = buildApiTokenIssuer(clientCredentials.getApiTokenIssuer());
         this.authRequest = new CredentialsFlowRequest(clientCredentials.getClientId(), clientCredentials.getClientSecret());
         this.authRequest.setAudience(clientCredentials.getApiAudience());
         this.authRequest.setScope(clientCredentials.getScopes());
+        this.config = new Configuration()
+                .apiUrl(buildApiTokenIssuer(clientCredentials.getApiTokenIssuer()))
+                .maxRetries(configuration.getMaxRetries())
+                .minimumRetryDelay(configuration.getMinimumRetryDelay());
     }
 
     /**
@@ -58,8 +61,6 @@ public class OAuth2Client {
      */
     private CompletableFuture<CredentialsFlowResponse> exchangeToken()
             throws ApiException, FgaInvalidParameterException {
-
-            Configuration config = new Configuration().apiUrl(apiTokenIssuer);
 
             HttpRequest.Builder requestBuilder = ApiClient.formRequestBuilder("POST", "", this.authRequest.buildFormRequestBody(), config);
             HttpRequest request = requestBuilder.build();

--- a/config/clients/java/template/creds-OAuth2ClientTest.java.mustache
+++ b/config/clients/java/template/creds-OAuth2ClientTest.java.mustache
@@ -2,6 +2,8 @@
 package {{authPackage}};
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.*;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.pgssoft.httpclient.HttpClientMock;
 import {{clientPackage}}.ApiClient;
 import {{configPackage}}.*;
@@ -14,13 +16,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
+import java.time.Duration;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@WireMockTest
 class OAuth2ClientTest {
     private static final String CLIENT_ID = "client";
     private static final String CLIENT_SECRET = "secret";
@@ -124,6 +129,51 @@ class OAuth2ClientTest {
         assertEquals(ACCESS_TOKEN, result);
     }
 
+
+    @Test
+    public void exchangeOAuth2TokenWithRetriesSuccess(WireMockRuntimeInfo wm) throws Exception {
+        // Return 429 initially
+        stubFor(post(urlEqualTo("/oauth/token"))
+                .inScenario("retries")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(jsonResponse("rate_limited", 429))
+                .willSetStateTo("rate limited once"));
+
+        // Then return 500
+        stubFor(post(urlEqualTo("/oauth/token"))
+                .inScenario("retries")
+                .whenScenarioStateIs("rate limited once")
+                .willReturn(jsonResponse("rate_limited", 500))
+                .willSetStateTo("rate limited twice"));
+
+        // Finally return 200
+        stubFor(post(urlEqualTo("/oauth/token"))
+                .inScenario("retries")
+                .whenScenarioStateIs("rate limited twice")
+                .willReturn(ok(String.format("{\"access_token\":\"%s\"}", ACCESS_TOKEN))));
+
+        OAuth2Client auth0 = newOAuth2Client(wm.getHttpBaseUrl(), false);
+
+        String result = auth0.getAccessToken().get();
+
+        assertEquals(ACCESS_TOKEN, result);
+        verify(3, postRequestedFor(urlEqualTo("/oauth/token")));
+    }
+
+    @Test
+    public void exchangeOAuth2TokenWithRetriesFailure(WireMockRuntimeInfo wm) throws Exception {
+        stubFor(post(urlEqualTo("/oauth/token")).willReturn(jsonResponse("error", 429)));
+
+        OAuth2Client auth0 = newOAuth2Client(wm.getHttpBaseUrl(), false);
+
+        var exception = assertThrows(java.util.concurrent.ExecutionException.class, () -> auth0.getAccessToken()
+                .get());
+
+        assertEquals("dev.openfga.sdk.errors.FgaApiRateLimitExceededError: exchangeToken", exception.getMessage());
+        verify(3, postRequestedFor(urlEqualTo("/oauth/token")));
+    }
+
+
     @Test
     public void apiTokenIssuer_invalidScheme() {
         // When
@@ -162,7 +212,8 @@ class OAuth2ClientTest {
                         .clientId(CLIENT_ID)
                         .clientSecret(CLIENT_SECRET)
                         .apiAudience(AUDIENCE)
-                        .apiTokenIssuer(apiTokenIssuer)));
+                        .apiTokenIssuer(apiTokenIssuer)),
+                    true);
     }
 
     private OAuth2Client newOAuth2Client(String apiTokenIssuer) throws FgaInvalidParameterException {
@@ -172,21 +223,46 @@ class OAuth2ClientTest {
                         .clientId(CLIENT_ID)
                         .clientSecret(CLIENT_SECRET)
                         .scopes(SCOPES)
-                        .apiTokenIssuer(apiTokenIssuer)));
+                        .apiTokenIssuer(apiTokenIssuer)),
+                    true);
     }
 
-    private OAuth2Client newClientCredentialsClient(String apiTokenIssuer, Credentials credentials)
+    private OAuth2Client newOAuth2Client(String apiTokenIssuer, Boolean useMockHttpClient)
+            throws FgaInvalidParameterException {
+        return newClientCredentialsClient(
+                apiTokenIssuer,
+                new Credentials(new ClientCredentials()
+                        .clientId(CLIENT_ID)
+                        .clientSecret(CLIENT_SECRET)
+                        .scopes(SCOPES)
+                        .apiTokenIssuer(apiTokenIssuer)),
+                useMockHttpClient);
+    }
+
+
+    private OAuth2Client newClientCredentialsClient(
+            String apiTokenIssuer, Credentials credentials, Boolean useMockHttpClient)
             throws FgaInvalidParameterException {
         System.setProperty("HttpRequestAttempt.debug-logging", "enable");
 
-        mockHttpClient = new HttpClientMock();
-        mockHttpClient.debugOn();
+         var configuration = new Configuration()
+                .apiUrl("")
+                .credentials(credentials)
+                .maxRetries(2)
+                .minimumRetryDelay(Duration.ofMillis(10));
 
-        var configuration = new Configuration().apiUrl("").credentials(credentials);
+        // If requested, enable the HttpClientMock and set that as the HttpClient to use in ApiClient
+        ApiClient apiClient;
+        if (useMockHttpClient) {
+            mockHttpClient = new HttpClientMock();
+            mockHttpClient.debugOn();
 
-        var apiClient = mock(ApiClient.class);
-        when(apiClient.getHttpClient()).thenReturn(mockHttpClient);
-        when(apiClient.getObjectMapper()).thenReturn(mapper);
+            apiClient = mock(ApiClient.class);
+            when(apiClient.getHttpClient()).thenReturn(mockHttpClient);
+            when(apiClient.getObjectMapper()).thenReturn(mapper);
+        } else {
+            apiClient = new ApiClient();
+        }
 
         return new OAuth2Client(configuration, apiClient);
     }

--- a/config/clients/js/template/README_retries.mustache
+++ b/config/clients/js/template/README_retries.mustache
@@ -1,6 +1,6 @@
-By default API requests are retried up to 15 times on 429 and 5xx errors and credential requests are retried to 3 times on 429 and 5xx errors. In both instances they will wait a minimum of 100 milliseconds between requests.
+By default API requests are retried up to 15 times on 429 and 5xx errors and credential requests are retried up to 3 times on 429 and 5xx errors. In both instances they will wait a minimum of 100 milliseconds between requests.
 
-In order to change the behavior for API requests, pass a `retryParams` object in the `OpenFgaClient` constructor with a `maxRetry` property to control the amount of retries and a `minWaitInMs` to control the minimum wait time between retried requests.
+In order to change the behavior for API requests, pass set `retryParams` in the `OpenFgaClient` constructor to an object with a `maxRetry` property to control the amount of retries and a `minWaitInMs` to control the minimum wait time between retried requests.
 
 ```javascript
 const { OpenFgaClient } = require('@openfga/sdk'); // OR import { OpenFgaClient } from '@openfga/sdk';

--- a/config/clients/js/template/README_retries.mustache
+++ b/config/clients/js/template/README_retries.mustache
@@ -1,0 +1,17 @@
+By default API requests are retried up to 15 times on 429 and 5xx errors and credential requests are retried to 3 times on 429 and 5xx errors. In both instances they will wait a minimum of 100 milliseconds between requests.
+
+In order to change the behavior for API requests, pass a `retryParams` object in the `OpenFgaClient` constructor with a `maxRetry` property to control the amount of retries and a `minWaitInMs` to control the minimum wait time between retried requests.
+
+```javascript
+const { OpenFgaClient } = require('@openfga/sdk'); // OR import { OpenFgaClient } from '@openfga/sdk';
+
+const fgaClient = new OpenFgaClient({
+  apiUrl: process.env.FGA_API_URL, // required
+  storeId: process.env.FGA_STORE_ID, // not needed when calling `CreateStore` or `ListStores`
+  authorizationModelId: process.env.FGA_AUTHORIZATION_MODEL_ID, // Optional, can be overridden per request
+  retryParams: {
+    maxRetry: 3, // retry up to 3 times on API requests
+    minWaitInMs: 250 // wait a minimum of 250 milliseconds between requests
+  }
+});
+```

--- a/config/clients/js/template/README_retries.mustache
+++ b/config/clients/js/template/README_retries.mustache
@@ -1,6 +1,8 @@
-By default API requests are retried up to 15 times on 429 and 5xx errors and credential requests are retried up to 3 times on 429 and 5xx errors. In both instances they will wait a minimum of 100 milliseconds between requests.
+If a network request fails with a 429 or 5xx error from the server, the SDK will automatically retry the request up to {{defaultMaxRetry}} times with a minimum wait time of {{defaultMinWaitInMs}} milliseconds between each attempt.
 
-In order to change the behavior for API requests, pass set `retryParams` in the `OpenFgaClient` constructor to an object with a `maxRetry` property to control the amount of retries and a `minWaitInMs` to control the minimum wait time between retried requests.
+To customize this behavior, create an object with `maxRetry` and `minWaitInMs` properties. `maxRetry` determines the maximum number of retries (up to {{retryMaxAllowedNumber}}), while `minWaitInMs` sets the minimum wait time between retries in milliseconds.
+
+Apply your custom retry values by setting to `retryParams` on the to the configuration object passed to the `OpenFgaClient` call.
 
 ```javascript
 const { OpenFgaClient } = require('@openfga/sdk'); // OR import { OpenFgaClient } from '@openfga/sdk';

--- a/config/clients/python/template/README_retries.mustache
+++ b/config/clients/python/template/README_retries.mustache
@@ -1,28 +1,22 @@
-Should a network request fail due to a 429 or 5xx error response from the server, the SDK will (by default) automatically retry the request up to {{defaultMaxRetry}} times, waiting no less than {{defaultMinWaitInMs}} milliseconds between each attempt.
+If a network request fails with a 429 or 5xx error from the server, the SDK will automatically retry the request up to {{defaultMaxRetry}} times with a minimum wait time of {{defaultMinWaitInMs}} milliseconds between each attempt.
 
-You can override these default values by initializing an instance of the `RetryParams` class. It's constructor accepts two parameters: `max_retry` and `min_wait_in_ms`. The `max_retry` value assigns the maximum number of retries, and the `min_wait_in_ms` value assigns the minimum wait time between retries (in milliseconds.)
+To customize these settings, create a `RetryParams` object with the `max_retry` and `min_wait_in_ms` constructor parameters. `max_retry` determines the maximum number of retries, while `min_wait_in_ms` sets the minimum wait time between retries in milliseconds.
 
-Pass your `RetryParams` object to the `ClientConfiguration` constructor during initialization using the `retry_params` parameter to apply your values.
+Apply your custom retry settings by passing the object to the `ClientConfiguration` constructor's `retry_params` parameter.
 
 ```python
-import os
-
 from {{packageName}} import ClientConfiguration, {{appShortName}}Client
 from {{packageName}}.configuration import RetryParams
-
+from os import environ
 
 async def main():
+    # Configure the client with custom retry settings
     config = ClientConfiguration(
-        api_url=os.getenv("FGA_API_URL"),
-        retry_params=RetryParams(  # Override the default retry behavior
-            max_retry=3,  # Retry up to 3 times
-            min_wait_in_ms=250  # Wait a minimum of 250 milliseconds between attempts
-        )
-    );
+        api_url=environ.get("FGA_API_URL"),
+        retry_params=RetryParams(max_retry=3, min_wait_in_ms=250)
+    )
 
-    # Enter a context with an instance of the {{appShortName}}Client
+    # Create a client instance and read authorization models
     async with {{appShortName}}Client(config) as client:
-        response = await client.read_authorization_models()
-        await client.close()
-        return response
+        return await client.read_authorization_models()
 ```

--- a/config/clients/python/template/README_retries.mustache
+++ b/config/clients/python/template/README_retries.mustache
@@ -1,0 +1,28 @@
+Should a network request fail due to a 429 or 5xx error response from the server, the SDK will (by default) automatically retry the request up to {{defaultMaxRetry}} times, waiting no less than {{defaultMinWaitInMs}} milliseconds between each attempt.
+
+You can override these default values by initializing an instance of the `RetryParams` class. It's constructor accepts two parameters: `max_retry` and `min_wait_in_ms`. The `max_retry` value assigns the maximum number of retries, and the `min_wait_in_ms` value assigns the minimum wait time between retries (in milliseconds.)
+
+Pass your `RetryParams` object to the `ClientConfiguration` constructor during initialization using the `retry_params` parameter to apply your values.
+
+```python
+import os
+
+from {{packageName}} import ClientConfiguration, {{appShortName}}Client
+from {{packageName}}.configuration import RetryParams
+
+
+async def main():
+    config = ClientConfiguration(
+        api_url=os.getenv("FGA_API_URL"),
+        retry_params=RetryParams(  # Override the default retry behavior
+            max_retry=3,  # Retry up to 3 times
+            min_wait_in_ms=250  # Wait a minimum of 250 milliseconds between attempts
+        )
+    );
+
+    # Enter a context with an instance of the {{appShortName}}Client
+    async with {{appShortName}}Client(config) as client:
+        response = await client.read_authorization_models()
+        await client.close()
+        return response
+```

--- a/config/clients/python/template/README_retries.mustache
+++ b/config/clients/python/template/README_retries.mustache
@@ -1,8 +1,8 @@
 If a network request fails with a 429 or 5xx error from the server, the SDK will automatically retry the request up to {{defaultMaxRetry}} times with a minimum wait time of {{defaultMinWaitInMs}} milliseconds between each attempt.
 
-To customize these settings, create a `RetryParams` object with the `max_retry` and `min_wait_in_ms` constructor parameters. `max_retry` determines the maximum number of retries, while `min_wait_in_ms` sets the minimum wait time between retries in milliseconds.
+To customize this behavior, create a `RetryParams` object and assign values to the `max_retry` and `min_wait_in_ms` constructor parameters. `max_retry` determines the maximum number of retries (up to {{retryMaxAllowedNumber}}), while `min_wait_in_ms` sets the minimum wait time between retries in milliseconds.
 
-Apply your custom retry settings by passing the object to the `ClientConfiguration` constructor's `retry_params` parameter.
+Apply your custom retry values by passing the object to the `ClientConfiguration` constructor's `retry_params` parameter.
 
 ```python
 from {{packageName}} import ClientConfiguration, {{appShortName}}Client

--- a/config/common/files/README.mustache
+++ b/config/common/files/README.mustache
@@ -42,6 +42,7 @@
     - [Assertions](#assertions)
       - [Read Assertions](#read-assertions)
       - [Write Assertions](#write-assertions)
+  - [Retries](#retries)
   - [API Endpoints](#api-endpoints)
   - [Models](#models)
 - [Contributing](#contributing)
@@ -94,6 +95,10 @@ If your server is configured with [authentication enabled]({{docsUrl}}/getting-s
 ### Calling the API
 
 {{>README_calling_api}}
+
+### Retries
+
+{{>README_retries}}
 
 ### API Endpoints
 


### PR DESCRIPTION
## Description

Adds a process for documenting the retry strategy of each SDK in the readme following the other SDK specific readme pieces by introducing a `README_retries.mustache` file that will be rendered into the readme.

* 8db7d1ace191cede02976016c91c0abbe2928644 - Introduces retry handling on the oauth2 client for dotnet, this is exercised by the test added in api client.
* b33b16dbb3f39cd2e57b52c405f84ffd003f56d5 - Introduces retry handling on the oauth2 client for java, this is verified manually as unfortunately the features of the HTTP mocking library there are limited.  It can only register one response per URL and I can’t workaround this using the `doAction` feature (e.g track number of requests and change response depending on request count), because any request after the first fails for reason my limited Java knowledge can’t debug. From what I can tell it's only built to handle one request per URL.

Given that last one, I'm putting this into draft to prevent any merge.

## References

#320


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
