### PR TITLE
feat(python): support auto-retry of failed network requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ build-client-python:
 
 .PHONY: test-client-python
 test-client-python: build-client-python
-	make run-in-docker sdk_language=python image=python:${PYTHON_DOCKER_TAG} command="/bin/sh -c 'python -m pip install -r test-requirements.txt; pytest; flake8 . --count --show-source --statistics'"
+	make run-in-docker sdk_language=python image=python:${PYTHON_DOCKER_TAG} command="/bin/sh -c 'python -m pip install -r test-requirements.txt; pytest --cov-report term-missing --cov=openfga_sdk test/; flake8 . --count --show-source --statistics'"
 
 ### Java
 .PHONY: tag-client-java

--- a/config/clients/python/template/api.mustache
+++ b/config/clients/python/template/api.mustache
@@ -1,13 +1,9 @@
 {{>partial_header}}
 
-import re
 
+from {{packageName}}.exceptions import ApiValueError, FgaValidationException
 from {{packageName}}.api_client import ApiClient
 from {{packageName}}.oauth2 import OAuth2Client
-from {{packageName}}.exceptions import (
-    FgaValidationException,
-    ApiValueError
-)
 
 
 {{#operations}}

--- a/config/clients/python/template/api_client.mustache
+++ b/config/clients/python/template/api_client.mustache
@@ -22,7 +22,7 @@ import tornado.gen
 
 from {{packageName}}.configuration import Configuration
 from {{packageName}} import rest, oauth2
-from {{packageName}}.exceptions import ApiValueError, ApiException, FgaValidationException, RateLimitExceededError
+from {{packageName}}.exceptions import ApiValueError, ApiException, FgaValidationException, RateLimitExceededError, ServiceException
 
 
 DEFAULT_USER_AGENT = '{{{userAgent}}}'
@@ -220,8 +220,8 @@ class ApiClient:
                     post_params=post_params, body=body,
                     _preload_content=_preload_content,
                     _request_timeout=_request_timeout)
-            except RateLimitExceededError as e:
-                if x < max_retry:
+            except (RateLimitExceededError, ServiceException) as e:
+                if x < max_retry and e.status != 501:
                     {{#asyncio}}await asyncio.sleep(random_time(x, min_wait_in_ms)){{/asyncio}}
                     {{^asyncio}}time.sleep(random_time(x, min_wait_in_ms)){{/asyncio}}
                     continue

--- a/config/clients/python/template/api_client_sync.mustache
+++ b/config/clients/python/template/api_client_sync.mustache
@@ -17,7 +17,7 @@ import tornado.gen
 
 from {{packageName}}.configuration import Configuration
 from {{packageName}}.sync import rest, oauth2
-from {{packageName}}.exceptions import ApiValueError, ApiException, FgaValidationException, RateLimitExceededError
+from {{packageName}}.exceptions import ApiValueError, ApiException, FgaValidationException, RateLimitExceededError, ServiceException
 
 
 DEFAULT_USER_AGENT = '{{{userAgent}}}'
@@ -202,8 +202,8 @@ class ApiClient:
                     post_params=post_params, body=body,
                     _preload_content=_preload_content,
                     _request_timeout=_request_timeout)
-            except RateLimitExceededError as e:
-                if x < max_retry:
+            except (RateLimitExceededError, ServiceException) as e:
+                if x < max_retry and e.status != 501:
                     time.sleep(random_time(x, min_wait_in_ms))
                     continue
                 e.body = e.body.decode('utf-8')

--- a/config/clients/python/template/api_test.mustache
+++ b/config/clients/python/template/api_test.mustache
@@ -1116,6 +1116,8 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
 
         configuration = self.configuration
         configuration.store_id = store_id
+        configuration.retry_params.max_retry = 0
+
         {{#asyncio}}async {{/asyncio}}with {{packageName}}.ApiClient(configuration) as api_client:
             api_instance = open_fga_api.OpenFgaApi(api_client)
             body = CheckRequest(
@@ -1132,6 +1134,89 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
             self.assertIsInstance(api_exception.exception.parsed_exception, InternalErrorMessageResponse)
             self.assertEqual(api_exception.exception.parsed_exception.code, InternalErrorCode.INTERNAL_ERROR)
             self.assertEqual(api_exception.exception.parsed_exception.message, "Internal Server Error")
+            mock_request.assert_called()
+            self.assertEqual(mock_request.call_count, 1)
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_500_error_retry(self, mock_request):
+        """
+        Test to ensure 5xxx retries  are handled properly
+        """
+        response_body = """
+{
+  "code": "internal_error",
+  "message": "Internal Server Error"
+}
+        """
+        mock_request.side_effect = [
+            ServiceException(http_resp=http_mock_response(response_body, 500)),
+            ServiceException(http_resp=http_mock_response(response_body, 502)),
+            ServiceException(http_resp=http_mock_response(response_body, 503)),
+            ServiceException(http_resp=http_mock_response(response_body, 504)),
+            mock_response(response_body, 200),
+        ]
+
+        retry = openfga_sdk.configuration.RetryParams(5, 10)
+        configuration = self.configuration
+        configuration.store_id = store_id
+        configuration.retry_params = retry
+
+        async with openfga_sdk.ApiClient(configuration) as api_client:
+            api_instance = open_fga_api.OpenFgaApi(api_client)
+            body = CheckRequest(
+                tuple_key=TupleKey(
+                    object="document:2021-budget",
+                    relation="reader",
+                    user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                ),
+            )
+
+            api_response = await api_instance.check(
+                body=body,
+            )
+
+            self.assertIsInstance(api_response, CheckResponse)
+            mock_request.assert_called()
+            self.assertEqual(mock_request.call_count, 5)
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_501_error_retry(self, mock_request):
+        """
+        Test to ensure 501 responses are not auto-retried
+        """
+        response_body = """
+{
+  "code": "not_implemented",
+  "message": "Not Implemented"
+}
+        """
+        mock_request.side_effect = [
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            mock_response(response_body, 200),
+        ]
+
+        retry = openfga_sdk.configuration.RetryParams(5, 10)
+        configuration = self.configuration
+        configuration.store_id = store_id
+        configuration.retry_params = retry
+
+        async with openfga_sdk.ApiClient(configuration) as api_client:
+            api_instance = open_fga_api.OpenFgaApi(api_client)
+            body = CheckRequest(
+                tuple_key=TupleKey(
+                    object="document:2021-budget",
+                    relation="reader",
+                    user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                ),
+            )
+            with self.assertRaises(ServiceException) as api_exception:
+                await api_instance.check(
+                    body=body,
+                )
+            mock_request.assert_called()
+            self.assertEqual(mock_request.call_count, 1)
 
     @patch.object(rest.RESTClientObject, 'request')
     async def test_check_api_token(self, mock_request):

--- a/config/clients/python/template/api_test_sync.mustache
+++ b/config/clients/python/template/api_test_sync.mustache
@@ -1117,6 +1117,8 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
 
         configuration = self.configuration
         configuration.store_id = store_id
+        configuration.retry_params.max_retry = 0
+
         with ApiClient(configuration) as api_client:
             api_instance = open_fga_api.OpenFgaApi(api_client)
             body = CheckRequest(
@@ -1133,6 +1135,89 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
             self.assertIsInstance(api_exception.exception.parsed_exception, InternalErrorMessageResponse)
             self.assertEqual(api_exception.exception.parsed_exception.code, InternalErrorCode.INTERNAL_ERROR)
             self.assertEqual(api_exception.exception.parsed_exception.message, "Internal Server Error")
+            mock_request.assert_called()
+            self.assertEqual(mock_request.call_count, 1)
+
+        @patch.object(rest.RESTClientObject, "request")
+        async def test_500_error(self, mock_request):
+            """
+            Test to ensure 5xx retries are handled properly
+            """
+            response_body = """
+    {
+      "code": "internal_error",
+      "message": "Internal Server Error"
+    }
+            """
+            mock_request.side_effect = [
+                ServiceException(http_resp=http_mock_response(response_body, 500)),
+                ServiceException(http_resp=http_mock_response(response_body, 502)),
+                ServiceException(http_resp=http_mock_response(response_body, 503)),
+                ServiceException(http_resp=http_mock_response(response_body, 504)),
+                mock_response(response_body, 200),
+            ]
+
+            retry = openfga_sdk.configuration.RetryParams(5, 10)
+            configuration = self.configuration
+            configuration.store_id = store_id
+            configuration.retry_params = retry
+
+            with ApiClient(configuration) as api_client:
+                api_instance = open_fga_api.OpenFgaApi(api_client)
+                body = CheckRequest(
+                    tuple_key=TupleKey(
+                        object="document:2021-budget",
+                        relation="reader",
+                        user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                    ),
+                )
+
+                api_response = api_instance.check(
+                    body=body,
+                )
+
+                self.assertIsInstance(api_response, CheckResponse)
+                mock_request.assert_called()
+                self.assertEqual(mock_request.call_count, 5)
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_501_error_retry(self, mock_request):
+        """
+        Test to ensure 501 responses are not auto-retried
+        """
+        response_body = """
+{
+  "code": "not_implemented",
+  "message": "Not Implemented"
+}
+        """
+        mock_request.side_effect = [
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            ServiceException(http_resp=http_mock_response(response_body, 501)),
+            mock_response(response_body, 200),
+        ]
+
+        retry = openfga_sdk.configuration.RetryParams(5, 10)
+        configuration = self.configuration
+        configuration.store_id = store_id
+        configuration.retry_params = retry
+
+        with ApiClient(configuration) as api_client:
+            api_instance = open_fga_api.OpenFgaApi(api_client)
+            body = CheckRequest(
+                tuple_key=TupleKey(
+                    object="document:2021-budget",
+                    relation="reader",
+                    user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                ),
+            )
+            with self.assertRaises(ServiceException) as api_exception:
+                api_instance.check(
+                    body=body,
+                )
+            mock_request.assert_called()
+            self.assertEqual(mock_request.call_count, 1)
 
     @patch.object(rest.RESTClientObject, 'request')
     async def test_check_api_token(self, mock_request):

--- a/config/clients/python/template/credentials_test.mustache
+++ b/config/clients/python/template/credentials_test.mustache
@@ -79,7 +79,7 @@ class TestCredentials(IsolatedAsyncioTestCase):
         """
         credential = Credentials(method="client_credentials",
             configuration=CredentialConfiguration(client_id='myclientid',
-                client_secret='mysecret', api_issuer='www.testme.com', api_audience='myaudience'))
+                client_secret='mysecret', api_issuer='issuer.{{sampleApiDomain}}', api_audience='myaudience'))
         credential.validate_credentials_config()
         self.assertEqual(credential.method, 'client_credentials')
 
@@ -97,7 +97,7 @@ class TestCredentials(IsolatedAsyncioTestCase):
         """
         credential = Credentials(method="client_credentials",
             configuration=CredentialConfiguration(
-                client_secret='mysecret', api_issuer='www.testme.com', api_audience='myaudience'))
+                client_secret='mysecret', api_issuer='issuer.{{sampleApiDomain}}', api_audience='myaudience'))
         with self.assertRaises(openfga_sdk.ApiValueError):
             credential.validate_credentials_config()
 
@@ -107,7 +107,7 @@ class TestCredentials(IsolatedAsyncioTestCase):
         """
         credential = Credentials(method="client_credentials",
             configuration=CredentialConfiguration(client_id='myclientid',
-                api_issuer='www.testme.com', api_audience='myaudience'))
+                api_issuer='issuer.{{sampleApiDomain}}', api_audience='myaudience'))
         with self.assertRaises(openfga_sdk.ApiValueError):
             credential.validate_credentials_config()
 
@@ -127,7 +127,7 @@ class TestCredentials(IsolatedAsyncioTestCase):
         """
         credential = Credentials(method="client_credentials",
             configuration=CredentialConfiguration(client_id='myclientid',
-                client_secret='mysecret', api_issuer='www.testme.com'))
+                client_secret='mysecret', api_issuer='issuer.{{sampleApiDomain}}'))
         with self.assertRaises(openfga_sdk.ApiValueError):
             credential.validate_credentials_config()
 

--- a/config/clients/python/template/oauth2.mustache
+++ b/config/clients/python/template/oauth2.mustache
@@ -1,21 +1,45 @@
 {{>partial_header}}
 
-from datetime import datetime, timedelta
+import asyncio
 import json
+import math
+import random
+import sys
+from datetime import datetime, timedelta
+
 import urllib3
 
+from {{packageName}}.configuration import Configuration
 from {{packageName}}.credentials import Credentials
 from {{packageName}}.exceptions import AuthenticationError
 
+
+def jitter(loop_count, min_wait_in_ms):
+    """
+    Generate a random jitter value for exponential backoff
+    """
+    minimum = math.ceil(2**loop_count * min_wait_in_ms)
+    maximum = math.ceil(2 ** (loop_count + 1) * min_wait_in_ms)
+    jitter = random.randrange(minimum, maximum) / 1000
+
+    # If running in pytest, set jitter to 0 to speed up tests
+    if "pytest" in sys.modules:
+        jitter = 0
+
+    return jitter
+
+
 class OAuth2Client:
 
-    def __init__(
-        self,
-        credentials: Credentials
-    ):
+    def __init__(self, credentials: Credentials, configuration=None):
         self._credentials = credentials
         self._access_token = None
         self._access_expiry_time = None
+
+        if configuration is None:
+            configuration = Configuration.get_default_copy()
+
+        self.configuration = configuration
 
     def _token_valid(self):
         """
@@ -32,25 +56,59 @@ class OAuth2Client:
         Perform OAuth2 and obtain token
         """
         configuration = self._credentials.configuration
+
         token_url = f'https://{configuration.api_issuer}/oauth/token'
+
         post_params = {
             'client_id': configuration.client_id,
             'client_secret': configuration.client_secret,
             'audience': configuration.api_audience,
             'grant_type': "client_credentials",
         }
+
         headers = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
-        raw_response = await client.POST(token_url, headers=headers, post_params=post_params);
-        if 200 <= raw_response.status <= 299:
-            try:
-                api_response = json.loads(raw_response.data)
-            except:
-                raise AuthenticationError(http_resp=raw_response)
-            if not api_response.get('expires_in') or not api_response.get('access_token'):
-                raise AuthenticationError(http_resp=raw_response)
-            self._access_expiry_time = datetime.now() + timedelta(seconds=int(api_response.get('expires_in')))
-            self._access_token = api_response.get('access_token')
-        else:
+
+        max_retry = (
+            self.configuration.retry_params.max_retry
+            if (
+                self.configuration.retry_params is not None
+                and self.configuration.retry_params.max_retry is not None
+            )
+            else 0
+        )
+
+        min_wait_in_ms = (
+            self.configuration.retry_params.min_wait_in_ms
+            if (
+                self.configuration.retry_params is not None
+                and self.configuration.retry_params.min_wait_in_ms is not None
+            )
+            else 0
+        )
+
+        for attempt in range(max_retry + 1):
+            raw_response = await client.POST(
+                token_url, headers=headers, post_params=post_params
+            )
+
+            if 500 <= raw_response.status <= 599 or raw_response.status == 429:
+                if attempt < max_retry and raw_response.status != 501:
+                    await asyncio.sleep(jitter(attempt, min_wait_in_ms))
+                    continue
+
+            if 200 <= raw_response.status <= 299:
+                try:
+                    api_response = json.loads(raw_response.data)
+                except:
+                    raise AuthenticationError(http_resp=raw_response)
+
+                if api_response.get("expires_in") and api_response.get("access_token"):
+                    self._access_expiry_time = datetime.now() + timedelta(
+                        seconds=int(api_response.get("expires_in"))
+                    )
+                    self._access_token = api_response.get("access_token")
+                    break
+
             raise AuthenticationError(http_resp=raw_response)
 
     async def get_authentication_header(self, client):

--- a/config/clients/python/template/oauth2_sync.mustache
+++ b/config/clients/python/template/oauth2_sync.mustache
@@ -1,21 +1,45 @@
 {{>partial_header}}
 
-from datetime import datetime, timedelta
 import json
+import math
+import random
+import sys
+import time
+from datetime import datetime, timedelta
+
 import urllib3
 
+from {{packageName}}.configuration import Configuration
 from {{packageName}}.credentials import Credentials
 from {{packageName}}.exceptions import AuthenticationError
 
+
+def jitter(loop_count, min_wait_in_ms):
+    """
+    Generate a random jitter value for exponential backoff
+    """
+    minimum = math.ceil(2**loop_count * min_wait_in_ms)
+    maximum = math.ceil(2 ** (loop_count + 1) * min_wait_in_ms)
+    jitter = random.randrange(minimum, maximum) / 1000
+
+    # If running in pytest, set jitter to 0 to speed up tests
+    if "pytest" in sys.modules:
+        jitter = 0
+
+    return jitter
+
+
 class OAuth2Client:
 
-    def __init__(
-        self,
-        credentials: Credentials
-    ):
+    def __init__(self, credentials: Credentials, configuration=None):
         self._credentials = credentials
         self._access_token = None
         self._access_expiry_time = None
+
+        if configuration is None:
+            configuration = Configuration.get_default_copy()
+
+        self.configuration = configuration
 
     def _token_valid(self):
         """
@@ -32,25 +56,59 @@ class OAuth2Client:
         Perform OAuth2 and obtain token
         """
         configuration = self._credentials.configuration
+
         token_url = f'https://{configuration.api_issuer}/oauth/token'
+
         post_params = {
             'client_id': configuration.client_id,
             'client_secret': configuration.client_secret,
             'audience': configuration.api_audience,
             'grant_type': "client_credentials",
         }
+
         headers = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
-        raw_response = client.POST(token_url, headers=headers, post_params=post_params);
-        if 200 <= raw_response.status <= 299:
-            try:
-                api_response = json.loads(raw_response.data)
-            except:
-                raise AuthenticationError(http_resp=raw_response)
-            if not api_response.get('expires_in') or not api_response.get('access_token'):
-                raise AuthenticationError(http_resp=raw_response)
-            self._access_expiry_time = datetime.now() + timedelta(seconds=int(api_response.get('expires_in')))
-            self._access_token = api_response.get('access_token')
-        else:
+
+        max_retry = (
+            self.configuration.retry_params.max_retry
+            if (
+                self.configuration.retry_params is not None
+                and self.configuration.retry_params.max_retry is not None
+            )
+            else 0
+        )
+
+        min_wait_in_ms = (
+            self.configuration.retry_params.min_wait_in_ms
+            if (
+                self.configuration.retry_params is not None
+                and self.configuration.retry_params.min_wait_in_ms is not None
+            )
+            else 0
+        )
+
+        for attempt in range(max_retry + 1):
+            raw_response = client.POST(
+                token_url, headers=headers, post_params=post_params
+            )
+
+            if 500 <= raw_response.status <= 599 or raw_response.status == 429:
+                if attempt < max_retry and raw_response.status != 501:
+                    time.sleep(jitter(attempt, min_wait_in_ms))
+                    continue
+
+            if 200 <= raw_response.status <= 299:
+                try:
+                    api_response = json.loads(raw_response.data)
+                except:
+                    raise AuthenticationError(http_resp=raw_response)
+
+                if api_response.get("expires_in") and api_response.get("access_token"):
+                    self._access_expiry_time = datetime.now() + timedelta(
+                        seconds=int(api_response.get("expires_in"))
+                    )
+                    self._access_token = api_response.get("access_token")
+                    break
+
             raise AuthenticationError(http_resp=raw_response)
 
     def get_authentication_header(self, client):

--- a/config/clients/python/template/oauth2_test.mustache
+++ b/config/clients/python/template/oauth2_test.mustache
@@ -59,7 +59,7 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
 
         credentials = Credentials(method="client_credentials",
             configuration=CredentialConfiguration(client_id='myclientid',
-                client_secret='mysecret', api_issuer='www.testme.com', api_audience='myaudience'))
+                client_secret='mysecret', api_issuer='issuer.{{sampleApiDomain}}', api_audience='myaudience'))
         rest_client = rest.RESTClientObject(Configuration())
         current_time = datetime.now()
         client = OAuth2Client(credentials)
@@ -70,7 +70,7 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         expected_header = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
         mock_request.assert_called_once_with(
             'POST',
-            'https://www.testme.com/oauth/token',
+            'https://issuer.{{sampleApiDomain}}/oauth/token',
             headers=expected_header,
             query_params=None, body=None, _preload_content=True, _request_timeout=None,
             post_params={"client_id": "myclientid", "client_secret": "mysecret", "audience": "myaudience", "grant_type": "client_credentials"}
@@ -91,9 +91,151 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
 
         credentials = Credentials(method="client_credentials",
             configuration=CredentialConfiguration(client_id='myclientid',
-                client_secret='mysecret', api_issuer='www.testme.com', api_audience='myaudience'))
+                client_secret='mysecret', api_issuer='issuer.{{sampleApiDomain}}', api_audience='myaudience'))
         rest_client = rest.RESTClientObject(Configuration())
         client = OAuth2Client(credentials)
         with self.assertRaises(AuthenticationError):
             await client.get_authentication_header(rest_client)
+        await rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_get_authentication_obtain_with_expired_client_credentials_failed(
+        self, mock_request
+    ):
+        """
+        Expired token should trigger a new token request
+        """
+
+        response_body = """
+{
+  "reason": "Unauthorized"
+}
+        """
+        mock_request.return_value = mock_response(response_body, 403)
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.{{sampleApiDomain}}",
+                api_audience="myaudience",
+            ),
+        )
+        rest_client = rest.RESTClientObject(Configuration())
+        client = OAuth2Client(credentials)
+
+        client._access_token = "XYZ123"
+        client._access_expiry_time = datetime.now() - timedelta(seconds=240)
+
+        with self.assertRaises(AuthenticationError):
+            await client.get_authentication_header(rest_client)
+        await rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_get_authentication_unexpected_response_fails(self, mock_request):
+        """
+        Receiving an unexpected response from the server should raise an exception
+        """
+
+        response_body = """
+This is not a JSON response
+        """
+        mock_request.return_value = mock_response(response_body, 200)
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.{{sampleApiDomain}}",
+                api_audience="myaudience",
+            ),
+        )
+        rest_client = rest.RESTClientObject(Configuration())
+        client = OAuth2Client(credentials)
+
+        with self.assertRaises(AuthenticationError):
+            await client.get_authentication_header(rest_client)
+        await rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_get_authentication_erroneous_response_fails(self, mock_request):
+        """
+        Receiving an erroneous response from the server that's missing properties should raise an exception
+        """
+
+        response_body = """
+{
+  "access_token": "AABBCCDD"
+}
+        """
+        mock_request.return_value = mock_response(response_body, 200)
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.{{sampleApiDomain}}",
+                api_audience="myaudience",
+            ),
+        )
+        rest_client = rest.RESTClientObject(Configuration())
+        client = OAuth2Client(credentials)
+
+        with self.assertRaises(AuthenticationError):
+            await client.get_authentication_header(rest_client)
+        await rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_get_authentication_retries_5xx_responses(self, mock_request):
+        """
+        Receiving a 5xx response from the server should be retried
+        """
+
+        error_response_body = """
+{
+  "code": "rate_limit_exceeded",
+  "message": "Rate Limit exceeded"
+}
+        """
+
+        response_body = """
+{
+  "expires_in": 120,
+  "access_token": "AABBCCDD"
+}
+        """
+
+        mock_request.side_effect = [
+            mock_response(error_response_body, 429),
+            mock_response(error_response_body, 429),
+            mock_response(error_response_body, 429),
+            mock_response(response_body, 200),
+        ]
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.{{sampleApiDomain}}",
+                api_audience="myaudience",
+            ),
+        )
+
+        configuration = Configuration()
+        configuration.retry_params.max_retry = 5
+        configuration.retry_params.retry_interval = 0
+
+        rest_client = rest.RESTClientObject(configuration)
+        client = OAuth2Client(credentials, configuration)
+
+        auth_header = await client.get_authentication_header(rest_client)
+
+        mock_request.assert_called()
+        self.assertEqual(mock_request.call_count, 4)  # 3 retries, 1 success
+        self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
+
         await rest_client.close()

--- a/config/clients/python/template/oauth2_test_sync.mustache
+++ b/config/clients/python/template/oauth2_test_sync.mustache
@@ -59,7 +59,7 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
 
         credentials = Credentials(method="client_credentials",
             configuration=CredentialConfiguration(client_id='myclientid',
-                client_secret='mysecret', api_issuer='www.testme.com', api_audience='myaudience'))
+                client_secret='mysecret', api_issuer='issuer.{{sampleApiDomain}}', api_audience='myaudience'))
         rest_client = rest.RESTClientObject(Configuration())
         current_time = datetime.now()
         client = OAuth2Client(credentials)
@@ -70,7 +70,7 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
         expected_header = urllib3.response.HTTPHeaderDict({'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'openfga-sdk (python) {{packageVersion}}'})
         mock_request.assert_called_once_with(
             'POST',
-            'https://www.testme.com/oauth/token',
+            'https://issuer.{{sampleApiDomain}}/oauth/token',
             headers=expected_header,
             query_params=None, body=None, _preload_content=True, _request_timeout=None,
             post_params={"client_id": "myclientid", "client_secret": "mysecret", "audience": "myaudience", "grant_type": "client_credentials"}
@@ -91,9 +91,151 @@ class TestOAuth2Client(IsolatedAsyncioTestCase):
 
         credentials = Credentials(method="client_credentials",
             configuration=CredentialConfiguration(client_id='myclientid',
-                client_secret='mysecret', api_issuer='www.testme.com', api_audience='myaudience'))
+                client_secret='mysecret', api_issuer='issuer.{{sampleApiDomain}}', api_audience='myaudience'))
         rest_client = rest.RESTClientObject(Configuration())
         client = OAuth2Client(credentials)
         with self.assertRaises(AuthenticationError):
             client.get_authentication_header(rest_client)
+        rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_get_authentication_obtain_with_expired_client_credentials_failed(
+        self, mock_request
+    ):
+        """
+        Expired token should trigger a new token request
+        """
+
+        response_body = """
+{
+  "reason": "Unauthorized"
+}
+        """
+        mock_request.return_value = mock_response(response_body, 403)
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.{{sampleApiDomain}}",
+                api_audience="myaudience",
+            ),
+        )
+        rest_client = rest.RESTClientObject(Configuration())
+        client = OAuth2Client(credentials)
+
+        client._access_token = "XYZ123"
+        client._access_expiry_time = datetime.now() - timedelta(seconds=240)
+
+        with self.assertRaises(AuthenticationError):
+            client.get_authentication_header(rest_client)
+        rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_get_authentication_unexpected_response_fails(self, mock_request):
+        """
+        Receiving an unexpected response from the server should raise an exception
+        """
+
+        response_body = """
+This is not a JSON response
+        """
+        mock_request.return_value = mock_response(response_body, 200)
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.{{sampleApiDomain}}",
+                api_audience="myaudience",
+            ),
+        )
+        rest_client = rest.RESTClientObject(Configuration())
+        client = OAuth2Client(credentials)
+
+        with self.assertRaises(AuthenticationError):
+            client.get_authentication_header(rest_client)
+        rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_get_authentication_erroneous_response_fails(self, mock_request):
+        """
+        Receiving an erroneous response from the server that's missing properties should raise an exception
+        """
+
+        response_body = """
+{
+  "access_token": "AABBCCDD"
+}
+        """
+        mock_request.return_value = mock_response(response_body, 200)
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.{{sampleApiDomain}}",
+                api_audience="myaudience",
+            ),
+        )
+        rest_client = rest.RESTClientObject(Configuration())
+        client = OAuth2Client(credentials)
+
+        with self.assertRaises(AuthenticationError):
+            client.get_authentication_header(rest_client)
+        rest_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
+    async def test_get_authentication_retries_5xx_responses(self, mock_request):
+        """
+        Receiving a 5xx response from the server should be retried
+        """
+
+        error_response_body = """
+{
+  "code": "rate_limit_exceeded",
+  "message": "Rate Limit exceeded"
+}
+        """
+
+        response_body = """
+{
+  "expires_in": 120,
+  "access_token": "AABBCCDD"
+}
+        """
+
+        mock_request.side_effect = [
+            mock_response(error_response_body, 429),
+            mock_response(error_response_body, 429),
+            mock_response(error_response_body, 429),
+            mock_response(response_body, 200),
+        ]
+
+        credentials = Credentials(
+            method="client_credentials",
+            configuration=CredentialConfiguration(
+                client_id="myclientid",
+                client_secret="mysecret",
+                api_issuer="issuer.{{sampleApiDomain}}",
+                api_audience="myaudience",
+            ),
+        )
+
+        configuration = Configuration()
+        configuration.retry_params.max_retry = 5
+        configuration.retry_params.retry_interval = 0
+
+        rest_client = rest.RESTClientObject(configuration)
+        client = OAuth2Client(credentials, configuration)
+
+        auth_header = client.get_authentication_header(rest_client)
+
+        mock_request.assert_called()
+        self.assertEqual(mock_request.call_count, 4)  # 3 retries, 1 success
+        self.assertEqual(auth_header, {"Authorization": "Bearer AABBCCDD"})
+
         rest_client.close()

--- a/config/clients/python/template/test-requirements.mustache
+++ b/config/clients/python/template/test-requirements.mustache
@@ -2,5 +2,5 @@
 
 mock >= 5.1.0, < 6
 flake8 >= 7.0.0, < 8
-pytest-cov >= 4.1.0, < 5
+pytest-cov >= 5, < 6
 griffe >= 0.41.2, < 1


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR rolls up the changes in the following PRs from the Python SDK and updates the generator to incorporate those updates:

- https://github.com/openfga/python-sdk/pull/78
- https://github.com/openfga/python-sdk/pull/79

To summarize, these changes introduce auto-retry support for failed requests (429, 500, 502, ...) to the `/oauth/token` auth endpoint, and enhance existing auto-retry of failed requests to the OpenFGA server to cover 5xx series error responses. In both cases, 501 is excluded from retries.

This PR also updates the makefile to generate a more robust code coverage report when running unit tests of the Python SDK. There is 100% coverage of these changes.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
