### PR TITLE
fix(python-sdk): honor retryMaxAllowedNumber

### DIFF
--- a/config/clients/python/.openapi-generator-ignore
+++ b/config/clients/python/.openapi-generator-ignore
@@ -2,6 +2,7 @@ git_push.sh
 test/*
 !test/__init__.py
 !test/test_open_fga_api.py
+!test/test_configuration.py
 !test/test_credentials.py
 !test/test_client.py
 !test/test_client_sync.py

--- a/config/clients/python/config.overrides.json
+++ b/config/clients/python/config.overrides.json
@@ -10,10 +10,8 @@
   "infoEmail": "community@openfga.dev",
   "docPrefix": "https://github.com/openfga/python-sdk/blob/main/",
   "files": {
-    ".github/workflows/main.yaml": {
-    },
-    ".snyk": {
-    },
+    ".github/workflows/main.yaml": {},
+    ".snyk": {},
     "credentials.mustache": {
       "destinationFilename": "openfga_sdk/credentials.py",
       "templateType": "SupportingFiles"
@@ -24,7 +22,7 @@
     },
     "client/__init__.mustache": {
       "destinationFilename": "openfga_sdk/client/__init__.py",
-      "templateType": "SupportingFiles" 
+      "templateType": "SupportingFiles"
     },
     "client/client.mustache": {
       "destinationFilename": "openfga_sdk/client/client.py",
@@ -52,7 +50,7 @@
     },
     "client/models/check_request.mustache": {
       "destinationFilename": "openfga_sdk/client/models/check_request.py",
-      "templateType": "SupportingFiles" 
+      "templateType": "SupportingFiles"
     },
     "client/models/expand_request.mustache": {
       "destinationFilename": "openfga_sdk/client/models/expand_request.py",
@@ -68,7 +66,7 @@
     },
     "client/models/read_changes_request.mustache": {
       "destinationFilename": "openfga_sdk/client/models/read_changes_request.py",
-      "templateType": "SupportingFiles" 
+      "templateType": "SupportingFiles"
     },
     "client/models/tuple.mustache": {
       "destinationFilename": "openfga_sdk/client/models/tuple.py",
@@ -84,11 +82,19 @@
     },
     "client/models/write_single_response.mustache": {
       "destinationFilename": "openfga_sdk/client/models/write_single_response.py",
-      "templateType": "SupportingFiles" 
+      "templateType": "SupportingFiles"
     },
     "client/models/write_transaction_opts.mustache": {
       "destinationFilename": "openfga_sdk/client/models/write_transaction_opts.py",
-      "templateType": "SupportingFiles" 
+      "templateType": "SupportingFiles"
+    },
+    "configuration.mustache": {
+      "destinationFilename": "openfga_sdk/configuration.py",
+      "templateType": "SupportingFiles"
+    },
+    "test_configuration.mustache": {
+      "destinationFilename": "test/test_configuration.py",
+      "templateType": "SupportingFiles"
     },
     "validation.mustache": {
       "destinationFilename": "openfga_sdk/validation.py",

--- a/config/clients/python/template/configuration.mustache
+++ b/config/clients/python/template/configuration.mustache
@@ -40,6 +40,9 @@ class RetryParams:
         """
         Return the maximum number of retry
         """
+        if self._max_retry > {{{retryMaxAllowedNumber}}}:
+            raise FgaValidationException("RetryParams.max_retry exceeds maximum allowed limit of {{retryMaxAllowedNumber}}");
+
         return self._max_retry
 
     @max_retry.setter
@@ -47,6 +50,12 @@ class RetryParams:
         """
         Update the maximum number of retry
         """
+        if not isinstance(value, int) or value < 0:
+            raise FgaValidationException("RetryParams.max_retry must be an integer greater than or equal to 0");
+
+        if value > {{{retryMaxAllowedNumber}}}:
+            raise FgaValidationException("RetryParams.max_retry exceeds maximum allowed limit of {{retryMaxAllowedNumber}}");
+
         self._max_retry = value
 
     @property
@@ -61,6 +70,11 @@ class RetryParams:
         """
         Update the minimum wait (in ms) in between retry
         """
+        if not isinstance(value, int) or value < 0:
+            raise FgaValidationException(
+                "RetryParams.min_wait_in_ms must be an integer greater than or equal to 0"
+            )
+
         self._min_wait_in_ms = value
 
 
@@ -275,16 +289,6 @@ class Configuration:
         result.logger_file = self.logger_file
         result.debug = self.debug
         return result
-
-    def __setattr__(self, name, value):
-        object.__setattr__(self, name, value)
-        if name == 'disabled_client_side_validations':
-            s = set(filter(None, value.split(',')))
-            for v in s:
-                if v not in JSON_SCHEMA_VALIDATION_KEYWORDS:
-                    raise ApiValueError(
-                        f"Invalid keyword: '{v}''")
-            self._disabled_client_side_validations = s
 
     @classmethod
     def set_default(cls, default):
@@ -571,6 +575,11 @@ class Configuration:
     @api_scheme.setter
     def api_scheme(self, value):
         """Update connection scheme (https or http)."""
+        if value is not None and value not in ["https", "http"]:
+            raise FgaValidationException(
+                f"api_scheme `{value}` must be either `http` or `https`"
+            )
+
         self._scheme = value
 
     @property
@@ -628,3 +637,20 @@ class Configuration:
         Update retry parameters
         """
         self._retry_params = value
+
+    @property
+    def disabled_client_side_validations(self):
+        """Return disable_client_side_validations."""
+        return self._disabled_client_side_validations
+
+    @disabled_client_side_validations.setter
+    def disabled_client_side_validations(self, value):
+        """Update disable_client_side_validations."""
+        self._disabled_client_side_validations = {}
+
+        if isinstance(value, str) and value:
+            s = set(filter(None, value.split(",")))
+            for v in s:
+                if v not in JSON_SCHEMA_VALIDATION_KEYWORDS:
+                    raise FgaValidationException(f"Invalid keyword: '{v}''")
+            self._disabled_client_side_validations = s

--- a/config/clients/python/template/test_configuration.mustache
+++ b/config/clients/python/template/test_configuration.mustache
@@ -1,0 +1,385 @@
+{{>partial_header}}
+
+import pytest
+import copy
+
+from unittest.mock import Mock
+from {{packageName}}.configuration import Configuration, RetryParams
+from {{packageName}}.exceptions import ApiValueError, FgaValidationException
+
+
+@pytest.fixture
+def configuration():
+    return Configuration()
+
+
+@pytest.fixture
+def servers():
+    return [
+        {"url": "https://example1.{{sampleApiDomain}}", "description": "Example 1"},
+        {"url": "https://example2.{{sampleApiDomain}}", "description": "Example 2"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "scheme,expected",
+    [
+        ("https", True),
+        ("http", True),
+        ("ftp", False),
+    ],
+)
+def test_configuration_api_scheme(configuration, scheme, expected):
+    assert configuration.api_scheme == "https"
+
+    if expected is True:
+        configuration.api_scheme = scheme
+        assert configuration.api_scheme == scheme
+    else:
+        with pytest.raises(FgaValidationException):
+            configuration.api_scheme = scheme
+
+
+def test_configuration_api_host(configuration):
+    assert configuration.api_host is None
+    configuration.api_host = "{{sampleApiDomain}}"
+    assert configuration.api_host == "{{sampleApiDomain}}"
+
+    with pytest.raises(ApiValueError):
+        configuration.api_host = "ftp://{{sampleApiDomain}}"
+        configuration.is_valid()
+
+
+def test_configuration_api_url(configuration):
+    assert configuration.api_url is None
+    configuration.api_url = "https://{{sampleApiDomain}}/api"
+    assert configuration.api_url == "https://{{sampleApiDomain}}/api"
+
+
+def test_configuration_store_id(configuration):
+    assert configuration.store_id is None
+    configuration.store_id = "store123"
+    assert configuration.store_id == "store123"
+
+
+def test_configuration_credentials(configuration):
+    assert configuration.credentials is None
+    credentials_mock = Mock()
+    configuration.credentials = credentials_mock
+    assert configuration.credentials == credentials_mock
+
+
+def test_configuration_retry_params_default_values(configuration):
+    assert configuration.retry_params.max_retry == {{{defaultMaxRetry}}}
+    assert configuration.retry_params.min_wait_in_ms == {{{defaultMinWaitInMs}}}
+
+
+def test_configuration_retry_params_custom_values(configuration):
+    retry_params = RetryParams(max_retry=10, min_wait_in_ms=50)
+    configuration.retry_params = retry_params
+    assert configuration.retry_params.max_retry == 10
+    assert configuration.retry_params.min_wait_in_ms == 50
+
+
+def test_configuration_retry_params_invalid_max_retry(configuration):
+    with pytest.raises(FgaValidationException):
+        configuration.retry_params.max_retry = -1
+
+
+def test_configuration_retry_params_max_retry_greater_than_max(configuration):
+    with pytest.raises(FgaValidationException):
+        configuration.retry_params.max_retry = 20
+
+
+def test_configuration_retry_params_invalid_min_wait_in_ms(configuration):
+    with pytest.raises(FgaValidationException):
+        configuration.retry_params.min_wait_in_ms = -1
+
+
+class TestConfigurationSetDefaultAndGetDefaultCopy:
+    def test_configuration_set_default(self, configuration):
+        default_config = Configuration()
+        default_config.api_scheme = "https"
+        default_config.api_host = "{{sampleApiDomain}}"
+        default_config.store_id = "store123"
+        default_config.credentials = Mock(
+            _client_id="client123",
+            _client_secret="secret123",
+            _api_audience="audience123",
+            _api_issuer="issuer123",
+            _api_token="token123",
+        )
+        default_config.retry_params = RetryParams(max_retry=10, min_wait_in_ms=50)
+        default_config.api_key = {"api_key1": "key1", "api_key2": "key2"}
+        default_config.api_key_prefix = {"api_key1": "Bearer", "api_key2": "Bearer"}
+        default_config.username = "user"
+        default_config.password = "pass"
+        default_config.discard_unknown_keys = True
+        default_config.disabled_client_side_validations = "maxLength,minLength"
+        default_config.server_index = 1
+        default_config.server_variables = {"variable1": "value1", "variable2": "value2"}
+        default_config.server_operation_index = {"operation1": 1, "operation2": 2}
+        default_config.server_operation_variables = {
+            "operation1": {"var1": "val1"},
+            "operation2": {"var2": "val2"},
+        }
+        default_config.ssl_ca_cert = "/path/to/ca_cert.pem"
+        default_config.api_url = "https://{{sampleApiDomain}}/api"
+        Configuration.set_default(default_config)
+
+        assert Configuration._default.api_scheme == "https"
+        assert Configuration._default.api_host == "{{sampleApiDomain}}"
+        assert Configuration._default.store_id == "store123"
+        assert (
+            isinstance(Configuration._default.credentials, Mock)
+            or Configuration._default.credentials is None
+        )
+        if Configuration._default.credentials:
+            assert Configuration._default.credentials._client_id == "client123"
+            assert Configuration._default.credentials._client_secret == "secret123"
+            assert Configuration._default.credentials._api_audience == "audience123"
+            assert Configuration._default.credentials._api_issuer == "issuer123"
+            assert Configuration._default.credentials._api_token == "token123"
+        assert Configuration._default.retry_params.max_retry == 10
+        assert Configuration._default.retry_params.min_wait_in_ms == 50
+        assert Configuration._default.api_key == {
+            "api_key1": "key1",
+            "api_key2": "key2",
+        }
+        assert Configuration._default.api_key_prefix == {
+            "api_key1": "Bearer",
+            "api_key2": "Bearer",
+        }
+        assert Configuration._default.username == "user"
+        assert Configuration._default.password == "pass"
+        assert Configuration._default.discard_unknown_keys is True
+        assert Configuration._default.disabled_client_side_validations == {
+            "maxLength",
+            "minLength",
+        }
+        assert Configuration._default.server_index == 1
+        assert Configuration._default.server_variables == {
+            "variable1": "value1",
+            "variable2": "value2",
+        }
+        assert Configuration._default.server_operation_index == {
+            "operation1": 1,
+            "operation2": 2,
+        }
+        assert Configuration._default.server_operation_variables == {
+            "operation1": {"var1": "val1"},
+            "operation2": {"var2": "val2"},
+        }
+        assert Configuration._default.ssl_ca_cert == "/path/to/ca_cert.pem"
+        assert Configuration._default.api_url == "https://{{sampleApiDomain}}/api"
+
+    def test_configuration_get_default_copy(self, configuration):
+        default_config = Configuration()
+        default_config.api_scheme = "https"
+        default_config.api_host = "{{sampleApiDomain}}"
+        default_config.store_id = "store123"
+        default_config.credentials = Mock(
+            _client_id="client123",
+            _client_secret="secret123",
+            _api_audience="audience123",
+            _api_issuer="issuer123",
+            _api_token="token123",
+        )
+        default_config.retry_params = RetryParams(max_retry=10, min_wait_in_ms=50)
+        default_config.api_key = {"api_key1": "key1", "api_key2": "key2"}
+        default_config.api_key_prefix = {"api_key1": "Bearer", "api_key2": "Bearer"}
+        default_config.username = "user"
+        default_config.password = "pass"
+        default_config.discard_unknown_keys = True
+        default_config.disabled_client_side_validations = "maxLength,minLength"
+        default_config.server_index = 1
+        default_config.server_variables = {"variable1": "value1", "variable2": "value2"}
+        default_config.server_operation_index = {"operation1": 1, "operation2": 2}
+        default_config.server_operation_variables = {
+            "operation1": {"var1": "val1"},
+            "operation2": {"var2": "val2"},
+        }
+        default_config.ssl_ca_cert = "/path/to/ca_cert.pem"
+        default_config.api_url = "https://{{sampleApiDomain}}/api"
+        Configuration.set_default(default_config)
+
+        copied_config = Configuration.get_default_copy()
+
+        assert copied_config.api_scheme == "https"
+        assert copied_config.api_host == "{{sampleApiDomain}}"
+        assert copied_config.store_id == "store123"
+        assert (
+            isinstance(copied_config.credentials, Mock)
+            or copied_config.credentials is None
+        )
+        if copied_config.credentials:
+            assert copied_config.credentials._client_id == "client123"
+            assert copied_config.credentials._client_secret == "secret123"
+            assert copied_config.credentials._api_audience == "audience123"
+            assert copied_config.credentials._api_issuer == "issuer123"
+            assert copied_config.credentials._api_token == "token123"
+
+
+class TestConfigurationValidityChecks:
+    def test_configuration_is_valid_missing_api_url(self, configuration):
+        with pytest.raises(FgaValidationException):
+            configuration.is_valid()
+
+    def test_configuration_is_valid_invalid_store_id(self, configuration):
+        configuration.api_url = "https://{{sampleApiDomain}}"
+        configuration.store_id = "invalid_ulid"
+        with pytest.raises(FgaValidationException):
+            configuration.is_valid()
+
+    def test_configuration_is_valid(self, configuration):
+        configuration.api_url = "https://{{sampleApiDomain}}"
+        configuration.store_id = "01F9ZCDXDZBXK83WVMY1VZT23V"
+        assert configuration.is_valid() is None
+
+
+class TestConfigurationLogging:
+    def test_configuration_logger_format(self, configuration):
+        assert configuration.logger_format == "%(asctime)s %(levelname)s %(message)s"
+        configuration.logger_format = "%(levelname)s: %(message)s"
+        assert configuration.logger_format == "%(levelname)s: %(message)s"
+
+    def test_configuration_debug(self, configuration):
+        assert not configuration.debug
+        configuration.debug = True
+        assert configuration.debug
+        configuration.debug = False
+        assert not configuration.debug
+
+    def test_configuration_logger_file(self, configuration):
+        assert configuration.logger_file is None
+        configuration.logger_file = "debug.log"
+        assert configuration.logger_file == "debug.log"
+
+    def test_configuration_disabled_client_side_validations(self, configuration):
+        assert configuration.disabled_client_side_validations == {}
+        configuration.disabled_client_side_validations = "maxLength,minLength"
+        assert configuration.disabled_client_side_validations == {
+            "maxLength",
+            "minLength",
+        }
+
+    def test_configuration_disabled_client_side_validations_invalid_keyword(
+        self, configuration
+    ):
+        with pytest.raises(FgaValidationException):
+            configuration.disabled_client_side_validations = "invalidKeyword"
+
+
+class TestConfigurationHostSettings:
+    def test_configuration_get_host_settings(self, configuration):
+        assert configuration.get_host_settings() == [
+            {"url": "", "description": "No description provided"}
+        ]
+
+    def test_configuration_get_host_from_settings(self, configuration, servers):
+        assert (
+            configuration.get_host_from_settings(0, servers=servers)
+            == "https://example1.{{sampleApiDomain}}"
+        )
+        assert (
+            configuration.get_host_from_settings(1, servers=servers)
+            == "https://example2.{{sampleApiDomain}}"
+        )
+
+    def test_configuration_get_host_from_settings_invalid_value(self, configuration):
+        servers = [
+            {
+                "url": "https://{region}.{{sampleApiDomain}}",
+                "description": "Example",
+                "variables": {"region": {"default_value": "us"}},
+            }
+        ]
+        variables = {"region": "invalid"}
+        with pytest.raises(ValueError):
+            configuration.get_host_from_settings(999, variables={"var": "value"})
+
+
+class TestConfigurationMiscellaneous:
+    def test_configuration_get_api_key_with_prefix(self, configuration):
+        configuration.api_key = {"api_key": "123"}
+        configuration.api_key_prefix = {"api_key": "Bearer"}
+        assert configuration.get_api_key_with_prefix("api_key") == "Bearer 123"
+
+    def test_configuration_get_basic_auth_token(self, configuration):
+        configuration.username = "user"
+        configuration.password = "pass"
+        assert configuration.get_basic_auth_token() == "Basic dXNlcjpwYXNz"
+
+    def test_configuration_auth_settings(self, configuration):
+        assert configuration.auth_settings() == {}
+
+    def test_configuration_to_debug_report(self, configuration):
+        report = configuration.to_debug_report()
+        assert "Python SDK Debug Report" in report
+        assert "OS" in report
+        assert "Python Version" in report
+        assert "Version of the API" in report
+        assert "SDK Package Version" in report
+
+    def test_configuration_deepcopy(self, configuration):
+        # Create a Configuration object with some values
+        config = Configuration(
+            api_scheme="https",
+            api_host="{{sampleApiDomain}}",
+            store_id="store123",
+            credentials=Mock(
+                _client_id="client123",
+                _client_secret="secret123",
+                _api_audience="audience123",
+                _api_issuer="issuer123",
+                _api_token="token123",
+            ),
+            retry_params=RetryParams(max_retry=10, min_wait_in_ms=50),
+            api_key={"api_key1": "key1", "api_key2": "key2"},
+            api_key_prefix={"api_key1": "Bearer", "api_key2": "Bearer"},
+            username="user",
+            password="pass",
+            discard_unknown_keys=True,
+            disabled_client_side_validations="maxLength,minLength",
+            server_index=1,
+            server_variables={"variable1": "value1", "variable2": "value2"},
+            server_operation_index={"operation1": 1, "operation2": 2},
+            server_operation_variables={
+                "operation1": {"var1": "val1"},
+                "operation2": {"var2": "val2"},
+            },
+            ssl_ca_cert="/path/to/ca_cert.pem",
+            api_url="https://{{sampleApiDomain}}/api",
+        )
+
+        # Perform deep copy
+        copied_config = copy.deepcopy(config)
+
+        # Verify all attributes of copied object are equal to original object
+        assert copied_config.api_scheme == config.api_scheme
+        assert copied_config.api_host == config.api_host
+        assert copied_config.store_id == config.store_id
+        assert (
+            isinstance(Configuration._default.credentials, Mock)
+            or Configuration._default.credentials is None
+        )
+        assert Configuration._default.retry_params.max_retry == 10
+        assert Configuration._default.retry_params.min_wait_in_ms == 50
+        assert copied_config.api_key == config.api_key
+        assert copied_config.api_key_prefix == config.api_key_prefix
+        assert copied_config.username == config.username
+        assert copied_config.password == config.password
+        assert copied_config.discard_unknown_keys == config.discard_unknown_keys
+        assert (
+            copied_config.disabled_client_side_validations
+            == config.disabled_client_side_validations
+        )
+        assert copied_config.server_index == config.server_index
+        assert copied_config.server_variables == config.server_variables
+        assert copied_config.server_operation_index == config.server_operation_index
+        assert (
+            copied_config.server_operation_variables
+            == config.server_operation_variables
+        )
+        assert copied_config.ssl_ca_cert == config.ssl_ca_cert
+        assert copied_config.api_url == config.api_url


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR:

- Ensures the `RetryParams` class does not permit `max_retry` to exceed the hardcoded limit of 15 retries, as configured by the SDK Generator.
- Includes a new comprehensive unit test file for the SDK's Configuration class, which was not present before. These tests increase our code coverage substantially.

Other small bug fixes and improvements to the Configuration were made, which I noticed as I was writing the unit tests:

- `disabled_client_side_validations` was not working reliably and was unnecessarily using the `__setattr__` magic method. This introduced a tiny and unnecessary performance hit when making ANY configuration adjustments. I've created a getter/setter for this property to resolve this.
- `min_wait_in_ms` was not checking for negative values, or indeed if the passed value was an integer at all.
- The `api_scheme` setter was not validating the assigned string as being either HTTP or HTTPS.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- https://github.com/openfga/sdk-generator/pull/333#discussion_r1548802143
- https://github.com/openfga/python-sdk/pull/87

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
