### PR TITLE
feat(java-sdk): support context and contextual tuples on listrelations

### DIFF
--- a/config/clients/java/template/client-ClientListRelationsRequest.java.mustache
+++ b/config/clients/java/template/client-ClientListRelationsRequest.java.mustache
@@ -8,6 +8,7 @@ public class ClientListRelationsRequest {
     private String _object;
     private List<String> relations;
     private List<ClientTupleKey> contextualTupleKeys;
+    private Object context;
 
     public ClientListRelationsRequest user(String user) {
         this.user = user;
@@ -51,5 +52,18 @@ public class ClientListRelationsRequest {
 
     public List<ClientTupleKey> getContextualTupleKeys() {
         return contextualTupleKeys;
+    }
+
+    public ClientListRelationsRequest context(Object context) {
+        this.context = context;
+        return this;
+    }
+
+    /**
+     * Get context
+     * @return context
+     **/
+    public Object getContext() {
+        return context;
     }
 }

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -717,7 +717,9 @@ public class OpenFgaClient {
                 .map(relation -> new ClientCheckRequest()
                         .user(request.getUser())
                         .relation(relation)
-                        ._object(request.getObject()))
+                        ._object(request.getObject())
+                        .contextualTuples(request.getContextualTupleKeys())
+                        .context(request.getContext()))
                 .collect(Collectors.toList());
 
         return this.batchCheck(batchCheckRequests, options.asClientBatchCheckOptions())

--- a/config/clients/java/template/client-OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClientTest.java.mustache
@@ -1963,6 +1963,30 @@ public class OpenFgaClientTest {
                 "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseData());
     }
 
+    @Test
+    public void listObjectsWithContextTest() throws Exception {
+        // Given
+        String postPath = String.format("https://localhost/stores/%s/list-objects", DEFAULT_STORE_ID);
+        String expectedBody = String.format(
+                "{\"authorization_model_id\":\"%s\",\"type\":null,\"relation\":\"%s\",\"user\":\"%s\",\"contextual_tuples\":null,\"context\":{\"some\":\"context\"}}",
+                DEFAULT_AUTH_MODEL_ID, DEFAULT_RELATION, DEFAULT_USER);
+        mockHttpClient
+                .onPost(postPath)
+                .withBody(is(expectedBody))
+                .doReturn(200, String.format("{\"objects\":[\"%s\"]}", DEFAULT_OBJECT));
+        ClientListObjectsRequest request = new ClientListObjectsRequest()
+                .relation(DEFAULT_RELATION)
+                .user(DEFAULT_USER)
+                .context(Map.of("some", "context"));
+
+        // When
+        ClientListObjectsResponse response = fga.listObjects(request).get();
+
+        // Then
+        mockHttpClient.verify().post(postPath).withBody(is(expectedBody)).called(1);
+        assertEquals(List.of(DEFAULT_OBJECT), response.getObjects());
+    }
+
     /**
      * Check whether a user is authorized to access an object.
      */

--- a/config/clients/java/template/client-OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClientTest.java.mustache
@@ -2184,6 +2184,54 @@ public class OpenFgaClientTest {
                 "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseData());
     }
 
+    @Test
+    public void listRelations_contextAndContextualTuples() throws Exception {
+        // Given
+        String postUrl = String.format("https://localhost/stores/%s/check", DEFAULT_STORE_ID);
+        String expectedBody = String.format(
+                "{\"tuple_key\":{\"user\":\"%s\",\"relation\":\"%s\",\"object\":\"%s\"},\"contextual_tuples\":{\"tuple_keys\":[{\"user\":\"%s\",\"relation\":\"%s\",\"object\":\"%s\",\"condition\":null}]},\"authorization_model_id\":\"%s\",\"trace\":null,\"context\":{\"some\":\"context\"}}",
+                DEFAULT_USER,
+                "owner",
+                DEFAULT_OBJECT,
+                DEFAULT_USER,
+                DEFAULT_RELATION,
+                DEFAULT_OBJECT,
+                DEFAULT_AUTH_MODEL_ID);
+        mockHttpClient
+                .onPost(postUrl)
+                .withBody(is(expectedBody))
+                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
+                .doReturn(200, "{\"allowed\":false}");
+        ClientListRelationsRequest request = new ClientListRelationsRequest()
+                .relations(List.of("owner"))
+                ._object(DEFAULT_OBJECT)
+                .user(DEFAULT_USER)
+                .context(Map.of("some", "context"))
+                .contextualTupleKeys(List.of(new ClientTupleKey()
+                        .user(DEFAULT_USER)
+                        .relation(DEFAULT_RELATION)
+                        ._object(DEFAULT_OBJECT)));
+        ClientListRelationsOptions options =
+                new ClientListRelationsOptions().authorizationModelId(DEFAULT_AUTH_MODEL_ID);
+
+        // When
+        ClientListRelationsResponse response =
+                fga.listRelations(request, options).get();
+
+        // Then
+        mockHttpClient
+                .verify()
+                .post(postUrl)
+                .withBody(is(expectedBody))
+                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
+                .called(1);
+        assertNotNull(response);
+        assertNotNull(response.getRelations());
+        assertTrue(response.getRelations().isEmpty());
+    }
+
     /**
      * Read assertions for an authorization model ID.
      */


### PR DESCRIPTION
## Description

Adds support for passing context and contextual tuples to a `listRelations` call, also adds a test to cover the addition for context on `listObjects`

## References

Closes #334
Generates openfga/java-sdk/pull/72

## Review Checklist

- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
