### PR TITLE
fix(js-sdk): resolve circular import

### DIFF
--- a/config/clients/js/config.overrides.json
+++ b/config/clients/js/config.overrides.json
@@ -117,6 +117,7 @@
     "example/example1/package.json.mustache": {
       "destinationFilename": "example/example1/package.json",
       "templateType": "SupportingFiles"
-    }
+    },
+    ".madgerc": {}
   }
 }

--- a/config/clients/js/template/.github/dependabot.yaml
+++ b/config/clients/js/template/.github/dependabot.yaml
@@ -16,3 +16,5 @@ updates:
      dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "eslint"

--- a/config/clients/js/template/.madgerc
+++ b/config/clients/js/template/.madgerc
@@ -1,0 +1,7 @@
+{
+  "detectiveOptions": {
+    "ts": {
+      "skipTypeImports": true
+    }
+  }
+}

--- a/config/clients/js/template/common.mustache
+++ b/config/clients/js/template/common.mustache
@@ -3,7 +3,7 @@
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { Configuration } from "./configuration";
-import { Credentials } from "./credentials";
+import type { Credentials } from "./credentials";
 import {
   FgaApiError,
   FgaApiInternalError,
@@ -169,15 +169,13 @@ export async function attemptHttpRequest<B, R>(
 /**
  * creates an axios request function
  */
-export const createRequestFunction = function (axiosArgs: RequestArgs, axiosInstance: AxiosInstance, configuration: Configuration, credentials?: Credentials) {
+export const createRequestFunction = function (axiosArgs: RequestArgs, axiosInstance: AxiosInstance, configuration: Configuration, credentials: Credentials) {
   configuration.isValid();
 
   const retryParams = axiosArgs.options?.retryParams ? axiosArgs.options?.retryParams : configuration.retryParams;
   const maxRetry:number = retryParams ? retryParams.maxRetry : 0;
   const minWaitInMs:number = retryParams ? retryParams.minWaitInMs : 0;
-  if (!credentials) {
-    credentials = Credentials.init(configuration);
-  }
+
   return async (axios: AxiosInstance = axiosInstance) : PromiseResult<any> => {
     await setBearerAuthToObject(axiosArgs.options.headers, credentials!);
 


### PR DESCRIPTION
## Description

Fixes the circular import being flagged by the new version of madge

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
