### PR TITLE
docs(js): correct casing for contextual tuples

### DIFF
--- a/config/clients/js/template/README_calling_api.mustache
+++ b/config/clients/js/template/README_calling_api.mustache
@@ -311,7 +311,7 @@ const { responses } = await fgaClient.batchCheck([{
   user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
   relation: "viewer",
   object: "document:roadmap",
-  contextual_tuples: [{
+  contextualTuples: [{
     user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation: "writer",
     object: "document:roadmap"
@@ -340,7 +340,7 @@ responses = [{
     user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation: "viewer",
     object: "document:roadmap",
-    contextual_tuples: [{
+    contextualTuples: [{
       user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
       relation: "writer",
       object: "document:roadmap"
@@ -386,7 +386,7 @@ const response = await fgaClient.listObjects({
   user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
   relation: "viewer",
   type: "document",
-  contextual_tuples: [{
+  contextualTuples: [{
     user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation: "writer",
     object: "document:budget"
@@ -412,7 +412,7 @@ const response = await fgaClient.listRelations({
   user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
   object: "document:roadmap",
   relations: ["can_view", "can_edit", "can_delete"],
-  contextual_tuples: [{
+  contextualTuples: [{
     user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     relation: "writer",
     object: "document:roadmap"


### PR DESCRIPTION
## Description

Corrects the readme docs casing for contextual tuples

## References

https://github.com/openfga/js-sdk/pull/94
Part of https://github.com/openfga/sdk-generator/issues/346


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
