### PR TITLE
ci(java-sdk): handle gradle action deprecations

### DIFF
--- a/config/clients/java/template/.github/workflows/main.yaml.mustache
+++ b/config/clients/java/template/.github/workflows/main.yaml.mustache
@@ -60,13 +60,14 @@ jobs:
           distribution: "temurin"
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@216d1ad2b3710bf005dc39237337b9673fd8fcd5 # v3.3.2
+        uses: gradle/actions/wrapper-validation@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
 
-      - name: Publish package
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
-        with:
-          # Tasks created by https://github.com/gradle-nexus/publish-plugin
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+
+        # Tasks created by https://github.com/gradle-nexus/publish-plugin
+      - name: Publish package
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
@@ -92,13 +93,14 @@ jobs:
           distribution: "temurin"
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@216d1ad2b3710bf005dc39237337b9673fd8fcd5 # v3.3.2
+        uses: gradle/actions/wrapper-validation@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
 
-      - name: Publish package
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
-        with:
-          # Tasks created by https://docs.gradle.org/current/userguide/publishing_maven.html
-          arguments: publishAllPublicationsToGitHubPackagesRepository
+
+      # Tasks created by https://docs.gradle.org/current/userguide/publishing_maven.html
+      - name: Publish package
+        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}


### PR DESCRIPTION
## Description

Noticed a warning about this on the release job so figured we should switch over, it's functionally identical just renamed

Also changes the publish step to the new way of setting up gradle and then calling the tasks as `arguments` is now deprecated too

## References

https://github.com/openfga/java-sdk/actions/runs/8925573963

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
