### PR TITLE
feat(go-sdk): Allow StoreId to be overridden per-request

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -2371,6 +2371,7 @@ func (client *{{appShortName}}Client) ListRelationsExecute(request SdkClientList
 		body:   &batchRequestBody,
 		options: &ClientBatchCheckOptions{
 			AuthorizationModelId: authorizationModelId,
+			StoreId:              storeId,
 			MaxParallelRequests:  maxParallelReqs,
 		},
 	})

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -83,11 +83,11 @@ func NewSdkClient(cfg *ClientConfiguration) (*{{appShortName}}Client, error) {
 	// store id is already validate as part of configuration validation
 
     if cfg.AuthorizationModelId != "" && !internalutils.IsWellFormedUlidString(cfg.AuthorizationModelId) {
-        return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+        return nil, FgaInvalidError{param: "AuthorizationModelId", description: "Expected ULID format"}
     }
 
     if cfg.StoreId != "" && !internalutils.IsWellFormedUlidString(cfg.StoreId) {
-		return nil, FgaInvalidError{param: "StoreId", description: "ULID"}
+		return nil, FgaInvalidError{param: "StoreId", description: "Expected ULID format"}
 	}
 
 	apiClient := fgaSdk.NewAPIClient(apiConfiguration)
@@ -425,7 +425,7 @@ type SdkClient interface {
 
 func (client *OpenFgaClient) SetAuthorizationModelId(authorizationModelId string) error {
 	if authorizationModelId != "" && !internalutils.IsWellFormedUlidString(authorizationModelId) {
-		return FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+		return FgaInvalidError{param: "AuthorizationModelId", description: "Expected ULID format"}
 	}
 
 	client.config.AuthorizationModelId = authorizationModelId
@@ -436,7 +436,7 @@ func (client *OpenFgaClient) SetAuthorizationModelId(authorizationModelId string
 func (client *OpenFgaClient) GetAuthorizationModelId() (string, error) {
 	modelId := client.config.AuthorizationModelId
 	if modelId != "" && !internalutils.IsWellFormedUlidString(modelId) {
-		return "", FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+		return "", FgaInvalidError{param: "AuthorizationModelId", description: "Expected ULID format"}
 	}
 
 	return modelId, nil
@@ -449,14 +449,14 @@ func (client *{{appShortName}}Client) getAuthorizationModelId(authorizationModel
     }
 
     if modelId != "" && !internalutils.IsWellFormedUlidString(modelId) {
-        return nil, FgaInvalidError{param: "AuthorizationModelId", description: "ULID"}
+        return nil, FgaInvalidError{param: "AuthorizationModelId", description: "Expected ULID format"}
     }
     return &modelId, nil
 }
 
 func (client *OpenFgaClient) SetStoreId(storeId string) error {
 	if storeId != "" && !internalutils.IsWellFormedUlidString(storeId) {
-		return FgaInvalidError{param: "StoreId", description: "ULID"}
+		return FgaInvalidError{param: "StoreId", description: "Expected ULID format"}
 	}
 	client.config.StoreId = storeId
 	return nil
@@ -465,7 +465,7 @@ func (client *OpenFgaClient) SetStoreId(storeId string) error {
 func (client *OpenFgaClient) GetStoreId() (string, error) {
 	storeId := client.config.StoreId
 	if storeId != "" && !internalutils.IsWellFormedUlidString(storeId) {
-		return "", FgaInvalidError{param: "StoreId", description: "ULID"}
+		return "", FgaInvalidError{param: "StoreId", description: "Expected ULID format"}
 	}
 	return storeId, nil
 }
@@ -478,7 +478,7 @@ func (client *OpenFgaClient) getStoreId(storeId *string) (*string, error) {
 		store = *storeId
 	}
 	if store != "" && !internalutils.IsWellFormedUlidString(store) {
-		return nil, FgaInvalidError{param: "StoreId", description: "ULID"}
+		return nil, FgaInvalidError{param: "StoreId", description: "Expected ULID format"}
 	}
 
 	return &store, nil

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -631,12 +631,14 @@ type SdkClientGetStoreRequest struct {
 type SdkClientGetStoreRequestInterface interface{
 	Options(options ClientGetStoreOptions) SdkClientGetStoreRequestInterface
 	Execute() (*ClientGetStoreResponse, error)
+	GetStoreIdOverride() *string
 
     GetContext() _context.Context
     GetOptions() *ClientGetStoreOptions
 }
 
 type ClientGetStoreOptions struct {
+	StoreId  *string `json:"store_id,omitempty"`
 }
 
 type ClientGetStoreResponse = fgaSdk.GetStoreResponse
@@ -644,6 +646,13 @@ type ClientGetStoreResponse = fgaSdk.GetStoreResponse
 func (request *SdkClientGetStoreRequest) Options(options ClientGetStoreOptions) SdkClientGetStoreRequestInterface {
 	request.options = &options
 	return request
+}
+
+func (request *SdkClientGetStoreRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientGetStoreRequest) Execute() (*ClientGetStoreResponse, error) {
@@ -659,7 +668,11 @@ func (request *SdkClientGetStoreRequest) GetOptions() *ClientGetStoreOptions{
 }
 
 func (client *{{appShortName}}Client) GetStoreExecute(request SdkClientGetStoreRequestInterface) (*ClientGetStoreResponse, error) {
-	data, _, err := client.{{appShortName}}Api.GetStore(request.GetContext(), client.config.StoreId).Execute()
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	data, _, err := client.{{appShortName}}Api.GetStore(request.GetContext(), *storeId).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -684,12 +697,14 @@ type SdkClientDeleteStoreRequest struct {
 type SdkClientDeleteStoreRequestInterface interface{
 	Options(options ClientDeleteStoreOptions) SdkClientDeleteStoreRequestInterface
 	Execute() (*ClientDeleteStoreResponse, error)
+	GetStoreIdOverride() *string
 
     GetContext() _context.Context
     GetOptions() *ClientDeleteStoreOptions
 }
 
 type ClientDeleteStoreOptions struct {
+	StoreId *string `json:"store_id,omitempty"`
 }
 
 type ClientDeleteStoreResponse struct{}
@@ -703,6 +718,13 @@ func (request *SdkClientDeleteStoreRequest) Execute() (*ClientDeleteStoreRespons
 	return request.Client.DeleteStoreExecute(request)
 }
 
+func (request *SdkClientDeleteStoreRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
+}
+
 func (request *SdkClientDeleteStoreRequest) GetContext() _context.Context {
 	return request.ctx
 }
@@ -713,7 +735,11 @@ func (request *SdkClientDeleteStoreRequest) GetOptions() *ClientDeleteStoreOptio
 
 
 func (client *{{appShortName}}Client) DeleteStoreExecute(request SdkClientDeleteStoreRequestInterface) (*ClientDeleteStoreResponse, error) {
-	_, err := client.{{appShortName}}Api.DeleteStore(request.GetContext(), client.config.StoreId).Execute()
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	_, err = client.{{appShortName}}Api.DeleteStore(request.GetContext(), *storeId).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -806,6 +832,7 @@ type SdkClientWriteAuthorizationModelRequestInterface interface {
     Options(options ClientWriteAuthorizationModelOptions) SdkClientWriteAuthorizationModelRequestInterface
 	Body(body ClientWriteAuthorizationModelRequest) SdkClientWriteAuthorizationModelRequestInterface
 	Execute() (*ClientWriteAuthorizationModelResponse, error)
+	GetStoreIdOverride() *string
 
 	GetBody() *ClientWriteAuthorizationModelRequest
 	GetOptions() *ClientWriteAuthorizationModelOptions
@@ -815,6 +842,7 @@ type SdkClientWriteAuthorizationModelRequestInterface interface {
 type ClientWriteAuthorizationModelRequest = fgaSdk.WriteAuthorizationModelRequest;
 
 type ClientWriteAuthorizationModelOptions struct {
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientWriteAuthorizationModelResponse = fgaSdk.WriteAuthorizationModelResponse
@@ -833,6 +861,13 @@ func (request *SdkClientWriteAuthorizationModelRequest) Execute() (*ClientWriteA
 	return request.Client.WriteAuthorizationModelExecute(request)
 }
 
+func (request *SdkClientWriteAuthorizationModelRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
+}
+
 func (request *SdkClientWriteAuthorizationModelRequest) GetBody() *ClientWriteAuthorizationModelRequest{
 	return request.body
 }
@@ -846,7 +881,11 @@ func (request *SdkClientWriteAuthorizationModelRequest) GetContext() _context.Co
 }
 
 func (client *{{appShortName}}Client) WriteAuthorizationModelExecute(request SdkClientWriteAuthorizationModelRequestInterface) (*ClientWriteAuthorizationModelResponse, error) {
-	data, _, err := client.{{appShortName}}Api.WriteAuthorizationModel(request.GetContext(), client.config.StoreId).Body(*request.GetBody()).Execute()
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	data, _, err := client.{{appShortName}}Api.WriteAuthorizationModel(request.GetContext(), *storeId).Body(*request.GetBody()).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -874,6 +913,7 @@ type SdkClientReadAuthorizationModelRequestInterface interface {
     Body(body ClientReadAuthorizationModelRequest) SdkClientReadAuthorizationModelRequestInterface
     Execute() (*ClientReadAuthorizationModelResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody()  *ClientReadAuthorizationModelRequest
@@ -885,6 +925,7 @@ type ClientReadAuthorizationModelRequest struct {
 
 type ClientReadAuthorizationModelOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientReadAuthorizationModelResponse = fgaSdk.ReadAuthorizationModelResponse
@@ -899,6 +940,13 @@ func (request *SdkClientReadAuthorizationModelRequest) GetAuthorizationModelIdOv
 		return nil
 	}
 	return request.options.AuthorizationModelId
+}
+
+func (request *SdkClientReadAuthorizationModelRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientReadAuthorizationModelRequest) Body(body ClientReadAuthorizationModelRequest) SdkClientReadAuthorizationModelRequestInterface {
@@ -930,7 +978,11 @@ func (client *{{appShortName}}Client) ReadAuthorizationModelExecute(request SdkC
 	if authorizationModelId == nil || *authorizationModelId == "" {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
-	data, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(request.GetContext(), client.config.StoreId, *authorizationModelId).Execute()
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	data, _, err := client.{{appShortName}}Api.ReadAuthorizationModel(request.GetContext(), *storeId, *authorizationModelId).Execute()
 
 	if err != nil {
 		return nil, err
@@ -1193,6 +1245,7 @@ type SdkClientWriteRequestInterface interface {
 	Body(body ClientWriteRequest) SdkClientWriteRequestInterface
     Execute() (*ClientWriteResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetOptions() *ClientWriteOptions
@@ -1216,6 +1269,7 @@ type TransactionOptions struct {
 
 type ClientWriteOptions struct {
 	AuthorizationModelId *string             `json:"authorization_model_id,omitempty"`
+	StoreId              *string             `json:"store_id,omitempty"`
 	Transaction          *TransactionOptions `json:"transaction_options,omitempty"`
 }
 
@@ -1302,6 +1356,13 @@ func (request *SdkClientWriteRequest) GetAuthorizationModelIdOverride() *string 
 	return request.options.AuthorizationModelId
 }
 
+func (request *SdkClientWriteRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
+}
+
 func (request *SdkClientWriteRequest) Body(body ClientWriteRequest) SdkClientWriteRequestInterface {
 	request.body = &body
 	return request
@@ -1343,6 +1404,11 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 		return nil, err
 	}
 
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+
 	// Unless explicitly disabled, transaction mode is enabled
 	// In transaction mode, the client will send the request to the server as is
 	if request.GetOptions() == nil || request.GetOptions().Transaction == nil || !request.GetOptions().Transaction.Disable {
@@ -1363,7 +1429,7 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 			}
 			writeRequest.Deletes = &deletes
 		}
-		_, httpResponse, err := client.{{appShortName}}Api.Write(request.GetContext(), client.config.StoreId).Body(writeRequest).Execute()
+		_, httpResponse, err := client.{{appShortName}}Api.Write(request.GetContext(), *storeId).Body(writeRequest).Execute()
 
 		clientWriteStatus := SUCCESS
 		if err != nil {
@@ -1648,6 +1714,7 @@ type SdkClientCheckRequestInterface interface {
 	Body(body ClientCheckRequest) SdkClientCheckRequestInterface
 	Execute() (*ClientCheckResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext()    _context.Context
 	GetBody()    *ClientCheckRequest
@@ -1664,6 +1731,7 @@ type ClientCheckRequest struct {
 
 type ClientCheckOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientCheckResponse struct {
@@ -1688,6 +1756,13 @@ func (request *SdkClientCheckRequest) GetAuthorizationModelIdOverride() *string 
 		return nil
 	}
 	return request.options.AuthorizationModelId
+}
+
+func (request *SdkClientCheckRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientCheckRequest) Body(body ClientCheckRequest) SdkClientCheckRequestInterface {
@@ -1722,6 +1797,10 @@ func (client *{{appShortName}}Client) CheckExecute(request SdkClientCheckRequest
 	if err != nil {
 		return nil, err
 	}
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
 	requestBody := fgaSdk.CheckRequest{
 		TupleKey: fgaSdk.CheckRequestTupleKey{
 			User:     request.GetBody().User,
@@ -1733,7 +1812,7 @@ func (client *{{appShortName}}Client) CheckExecute(request SdkClientCheckRequest
 		AuthorizationModelId: authorizationModelId,
 	}
 
-	data, httpResponse, err := client.{{appShortName}}Api.Check(request.GetContext(), client.config.StoreId).Body(requestBody).Execute()
+	data, httpResponse, err := client.{{appShortName}}Api.Check(request.GetContext(), *storeId).Body(requestBody).Execute()
 	return &ClientCheckResponse{CheckResponse: data, HttpResponse: httpResponse}, err
 }
 
@@ -1752,6 +1831,7 @@ type SdkClientBatchCheckRequestInterface interface {
 	Body(body ClientBatchCheckBody) SdkClientBatchCheckRequestInterface
 	Execute() (*ClientBatchCheckResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody() *ClientBatchCheckBody
@@ -1762,6 +1842,7 @@ type ClientBatchCheckBody = []ClientCheckRequest
 
 type ClientBatchCheckOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 	MaxParallelRequests  *int32  `json:"max_parallel_requests,omitempty"`
 }
 
@@ -1790,6 +1871,13 @@ func (request *SdkClientBatchCheckRequest) GetAuthorizationModelIdOverride() *st
 		return nil
 	}
 	return request.options.AuthorizationModelId
+}
+
+func (request *SdkClientBatchCheckRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientBatchCheckRequest) Body(body ClientBatchCheckBody) SdkClientBatchCheckRequestInterface {
@@ -1829,6 +1917,11 @@ func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCh
 		return nil, err
 	}
 
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+
 	for index, checkBody := range *request.GetBody() {
 		index, checkBody := index, checkBody
 		group.Go(func() error {
@@ -1838,6 +1931,7 @@ func (client *{{appShortName}}Client) BatchCheckExecute(request SdkClientBatchCh
 				body:   &checkBody,
 				options: &ClientCheckOptions{
 					AuthorizationModelId: authorizationModelId,
+					StoreId:              storeId,
 				},
 			})
 
@@ -1876,6 +1970,7 @@ type SdkClientExpandRequestInterface interface {
     Body(body ClientExpandRequest) SdkClientExpandRequestInterface
 	Execute() (*ClientExpandResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody() *ClientExpandRequest
@@ -1889,6 +1984,7 @@ type ClientExpandRequest struct {
 
 type ClientExpandOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientExpandResponse = fgaSdk.ExpandResponse
@@ -1910,6 +2006,13 @@ func (request *SdkClientExpandRequest) GetAuthorizationModelIdOverride() *string
 		return nil
 	}
 	return request.options.AuthorizationModelId
+}
+
+func (request *SdkClientExpandRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientExpandRequest) Body(body ClientExpandRequest) SdkClientExpandRequestInterface {
@@ -1938,8 +2041,12 @@ func (client *{{appShortName}}Client) ExpandExecute(request SdkClientExpandReque
 	if err != nil {
 		return nil, err
 	}
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
 
-	data, _, err := client.{{appShortName}}Api.Expand(request.GetContext(), client.config.StoreId).Body(fgaSdk.ExpandRequest{
+	data, _, err := client.{{appShortName}}Api.Expand(request.GetContext(), *storeId).Body(fgaSdk.ExpandRequest{
 		TupleKey: fgaSdk.ExpandRequestTupleKey{
 			Relation: request.GetBody().Relation,
 			Object:   request.GetBody().Object,
@@ -1966,6 +2073,7 @@ type SdkClientListObjectsRequestInterface interface {
 	Body(body ClientListObjectsRequest) SdkClientListObjectsRequestInterface
 	Execute() (*ClientListObjectsResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody() *ClientListObjectsRequest
@@ -1982,6 +2090,7 @@ type ClientListObjectsRequest struct {
 
 type ClientListObjectsOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientListObjectsResponse = fgaSdk.ListObjectsResponse
@@ -2003,6 +2112,13 @@ func (request *SdkClientListObjectsRequest) GetAuthorizationModelIdOverride() *s
 		return nil
 	}
 	return request.options.AuthorizationModelId
+}
+
+func (request *SdkClientListObjectsRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientListObjectsRequest) Body(body ClientListObjectsRequest) SdkClientListObjectsRequestInterface {
@@ -2037,7 +2153,11 @@ func (client *{{appShortName}}Client) ListObjectsExecute(request SdkClientListOb
 	if err != nil {
 		return nil, err
 	}
-	data, _, err := client.{{appShortName}}Api.ListObjects(request.GetContext(), client.config.StoreId).Body(fgaSdk.ListObjectsRequest{
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	data, _, err := client.{{appShortName}}Api.ListObjects(request.GetContext(), *storeId).Body(fgaSdk.ListObjectsRequest{
 		User:                 request.GetBody().User,
 		Relation:             request.GetBody().Relation,
 		Type:                 request.GetBody().Type,
@@ -2066,6 +2186,7 @@ type SdkClientListRelationsRequestInterface interface {
 	Body(body ClientListRelationsRequest) SdkClientListRelationsRequestInterface
     Execute() (*ClientListRelationsResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody() *ClientListRelationsRequest
@@ -2083,6 +2204,7 @@ type ClientListRelationsRequest struct {
 type ClientListRelationsOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	MaxParallelRequests  *int32  `json:"max_parallel_requests,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientListRelationsResponse struct {
@@ -2112,6 +2234,13 @@ func (request *SdkClientListRelationsRequest) GetAuthorizationModelIdOverride() 
 		return nil
 	}
 	return request.options.AuthorizationModelId
+}
+
+func (request *SdkClientListRelationsRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientListRelationsRequest) Body(body ClientListRelationsRequest) SdkClientListRelationsRequestInterface {
@@ -2151,6 +2280,10 @@ func (client *{{appShortName}}Client) ListRelationsExecute(request SdkClientList
 		})
 	}
 	authorizationModelId, err := client.getAuthorizationModelId(request.GetAuthorizationModelIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
 	if err != nil {
 		return nil, err
 	}
@@ -2196,6 +2329,7 @@ type SdkClientListUsersRequestInterface interface {
 	Body(body ClientListUsersRequest) SdkClientListUsersRequestInterface
 	Execute() (*ClientListUsersResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody() *ClientListUsersRequest
@@ -2213,6 +2347,7 @@ type ClientListUsersRequest struct {
 
 type ClientListUsersOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientListUsersResponse = fgaSdk.ListUsersResponse
@@ -2234,6 +2369,13 @@ func (request *SdkClientListUsersRequest) GetAuthorizationModelIdOverride() *str
 		return nil
 	}
 	return request.options.AuthorizationModelId
+}
+
+func (request *SdkClientListUsersRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientListUsersRequest) Body(body ClientListUsersRequest) SdkClientListUsersRequestInterface {
@@ -2268,7 +2410,11 @@ func (client *OpenFgaClient) ListUsersExecute(request SdkClientListUsersRequestI
 	if err != nil {
 		return nil, err
 	}
-	data, _, err := client.OpenFgaApi.ListUsers(request.GetContext(), client.config.StoreId).Body(fgaSdk.ListUsersRequest{
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	data, _, err := client.OpenFgaApi.ListUsers(request.GetContext(), *storeId).Body(fgaSdk.ListUsersRequest{
 		Object:               request.GetBody().Object,
 		Relation:             request.GetBody().Relation,
 		UserFilters:          request.GetBody().UserFilters,
@@ -2294,6 +2440,7 @@ type SdkClientReadAssertionsRequestInterface interface {
 	Options(options ClientReadAssertionsOptions) SdkClientReadAssertionsRequestInterface
     Execute() (*ClientReadAssertionsResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetOptions() *ClientReadAssertionsOptions
@@ -2301,6 +2448,7 @@ type SdkClientReadAssertionsRequestInterface interface {
 
 type ClientReadAssertionsOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientReadAssertionsResponse = fgaSdk.ReadAssertionsResponse
@@ -2324,6 +2472,13 @@ func (request *SdkClientReadAssertionsRequest) GetAuthorizationModelIdOverride()
 	return request.options.AuthorizationModelId
 }
 
+func (request *SdkClientReadAssertionsRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
+}
+
 func (request *SdkClientReadAssertionsRequest) Execute() (*ClientReadAssertionsResponse, error) {
 	return request.Client.ReadAssertionsExecute(request)
 }
@@ -2344,7 +2499,11 @@ func (client *{{appShortName}}Client) ReadAssertionsExecute(request SdkClientRea
 	if authorizationModelId == nil || *authorizationModelId == "" {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
-	data, _, err := client.{{appShortName}}Api.ReadAssertions(request.GetContext(), client.config.StoreId, *authorizationModelId).Execute()
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	data, _, err := client.{{appShortName}}Api.ReadAssertions(request.GetContext(), *storeId, *authorizationModelId).Execute()
 	if err != nil {
 		return nil, err
 	}
@@ -2365,6 +2524,7 @@ type SdkClientWriteAssertionsRequestInterface interface {
     Body(body ClientWriteAssertionsRequest) SdkClientWriteAssertionsRequestInterface
 	Execute() (*ClientWriteAssertionsResponse, error)
 	GetAuthorizationModelIdOverride() *string
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody() *ClientWriteAssertionsRequest
@@ -2394,6 +2554,7 @@ func (clientAssertion ClientAssertion) ToAssertion() fgaSdk.Assertion {
 
 type ClientWriteAssertionsOptions struct {
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 type ClientWriteAssertionsResponse struct {
@@ -2416,6 +2577,13 @@ func (request *SdkClientWriteAssertionsRequest) GetAuthorizationModelIdOverride(
 		return nil
 	}
 	return request.options.AuthorizationModelId
+}
+
+func (request *SdkClientWriteAssertionsRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
 }
 
 func (request *SdkClientWriteAssertionsRequest) Body(body ClientWriteAssertionsRequest) SdkClientWriteAssertionsRequestInterface {
@@ -2448,11 +2616,15 @@ func (client *{{appShortName}}Client) WriteAssertionsExecute(request SdkClientWr
 	if authorizationModelId == nil || *authorizationModelId == ""  {
 		return nil, FgaRequiredParamError{param: "AuthorizationModelId"}
 	}
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
 	for index := 0; index < len(*request.GetBody()); index++ {
 		clientAssertion := (*request.GetBody())[index]
 		writeAssertionsRequest.Assertions = append(writeAssertionsRequest.Assertions, clientAssertion.ToAssertion())
 	}
-	_, err = client.{{appShortName}}Api.WriteAssertions(request.GetContext(), client.config.StoreId, *authorizationModelId).Body(writeAssertionsRequest).Execute()
+	_, err = client.{{appShortName}}Api.WriteAssertions(request.GetContext(), *storeId, *authorizationModelId).Body(writeAssertionsRequest).Execute()
 
 	if err != nil {
 		return nil, err

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -1110,6 +1110,7 @@ type SdkClientReadChangesRequestInterface interface {
     Options(options ClientReadChangesOptions) SdkClientReadChangesRequestInterface
     Body(body ClientReadChangesRequest) SdkClientReadChangesRequestInterface
 	Execute() (*ClientReadChangesResponse, error)
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetBody() *ClientReadChangesRequest
@@ -1123,6 +1124,7 @@ type ClientReadChangesRequest struct {
 type ClientReadChangesOptions struct {
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
+	StoreId           *string `json:"store_id"`
 }
 
 type ClientReadChangesResponse = fgaSdk.ReadChangesResponse
@@ -1148,6 +1150,13 @@ func (request *SdkClientReadChangesRequest) Execute() (*ClientReadChangesRespons
 	return request.Client.ReadChangesExecute(request)
 }
 
+func (request *SdkClientReadChangesRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
+}
+
 func (request *SdkClientReadChangesRequest) GetContext() _context.Context{
 	return request.ctx
 }
@@ -1161,12 +1170,23 @@ func (request *SdkClientReadChangesRequest) GetOptions() *ClientReadChangesOptio
 }
 
 func (client *{{appShortName}}Client) ReadChangesExecute(request SdkClientReadChangesRequestInterface) (*ClientReadChangesResponse, error) {
-	req := client.{{appShortName}}Api.ReadChanges(request.GetContext(), client.config.StoreId)
-	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
+	pagingOpts := ClientPaginationOptions{}
+	if request.GetOptions() != nil {
+    	pagingOpts.PageSize = request.GetOptions().PageSize
+    	pagingOpts.ContinuationToken = request.GetOptions().ContinuationToken
+	}
+
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+
+	req := client.{{appShortName}}Api.ReadChanges(request.GetContext(), *storeId)
+	pageSize := getPageSizeFromRequest(&pagingOpts)
 	if pageSize != nil {
 		req = req.PageSize(*pageSize)
 	}
-	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
+	continuationToken := getContinuationTokenFromRequest(&pagingOpts)
 	if continuationToken != nil {
 		req = req.ContinuationToken(*continuationToken)
 	}

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -815,7 +815,7 @@ func (client *{{appShortName}}Client) ReadAuthorizationModelsExecute(request Sdk
 	if err != nil {
 		return nil, err
 	}
-	
+
 	req := client.{{appShortName}}Api.ReadAuthorizationModels(request.GetContext(), *storeId)
 	pageSize := getPageSizeFromRequest(&pagingOpts)
 	if pageSize != nil {
@@ -1028,12 +1028,14 @@ type SdkClientReadLatestAuthorizationModelRequest struct {
 type SdkClientReadLatestAuthorizationModelRequestInterface interface {
     Options(options ClientReadLatestAuthorizationModelOptions) SdkClientReadLatestAuthorizationModelRequestInterface
     Execute() (*ClientReadAuthorizationModelResponse, error)
+	GetStoreIdOverride() *string
 
     GetContext()  _context.Context
 	GetOptions() *ClientReadLatestAuthorizationModelOptions
 }
 
 type ClientReadLatestAuthorizationModelOptions struct {
+	StoreId              *string `json:"store_id,omitempty"`
 }
 
 func (client *{{appShortName}}Client) ReadLatestAuthorizationModel(ctx _context.Context) SdkClientReadLatestAuthorizationModelRequestInterface {
@@ -1052,6 +1054,13 @@ func (request *SdkClientReadLatestAuthorizationModelRequest) Execute() (*ClientR
 	return request.Client.ReadLatestAuthorizationModelExecute(request)
 }
 
+func (request *SdkClientReadLatestAuthorizationModelRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
+}
+
 func (request *SdkClientReadLatestAuthorizationModelRequest) GetContext() _context.Context {
 	return request.ctx
 }
@@ -1061,9 +1070,15 @@ func (request *SdkClientReadLatestAuthorizationModelRequest) GetOptions() *Clien
 }
 
 func (client *{{appShortName}}Client) ReadLatestAuthorizationModelExecute(request SdkClientReadLatestAuthorizationModelRequestInterface) (*ClientReadAuthorizationModelResponse, error) {
-	response, err := client.ReadAuthorizationModels(request.GetContext()).Options(ClientReadAuthorizationModelsOptions{
+	opts := ClientReadAuthorizationModelsOptions{
 		PageSize: fgaSdk.PtrInt32(1),
-	}).Execute()
+	}
+	if request.GetOptions() != nil {
+		opts.StoreId = request.GetOptions().StoreId
+	}
+	req := client.ReadAuthorizationModels(request.GetContext()).Options(opts)
+
+	response, err := req.Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -1215,6 +1215,7 @@ type SdkClientReadRequestInterface interface {
     Options(options ClientReadOptions) SdkClientReadRequestInterface
     Body(body ClientReadRequest) SdkClientReadRequestInterface
     Execute() (*ClientReadResponse, error)
+    GetStoreIdOverride() *string
 
     GetContext() _context.Context
 	GetBody() *ClientReadRequest
@@ -1230,6 +1231,7 @@ type ClientReadRequest struct {
 type ClientReadOptions struct {
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
+	StoreId           *string `json:"store_id,omitempty"`
 }
 
 type ClientReadResponse = fgaSdk.ReadResponse
@@ -1255,6 +1257,13 @@ func (request *SdkClientReadRequest) Execute() (*ClientReadResponse, error) {
 	return request.Client.ReadExecute(request)
 }
 
+func (request *SdkClientReadRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
+}
+
 func (request *SdkClientReadRequest) GetContext() _context.Context {
 	return request.ctx
 }
@@ -1268,9 +1277,15 @@ func (request *SdkClientReadRequest) GetOptions() *ClientReadOptions {
 }
 
 func (client *{{appShortName}}Client) ReadExecute(request SdkClientReadRequestInterface) (*ClientReadResponse, error) {
+    pagingOpts := ClientPaginationOptions{}
+    if request.GetOptions() != nil {
+        pagingOpts.PageSize = request.GetOptions().PageSize
+        pagingOpts.ContinuationToken = request.GetOptions().ContinuationToken
+    }
+
 	body := fgaSdk.ReadRequest{
-		PageSize:          getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions())),
-		ContinuationToken: getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions())),
+		PageSize:          getPageSizeFromRequest(&pagingOpts),
+		ContinuationToken: getContinuationTokenFromRequest(&pagingOpts),
 	}
 	if request.GetBody() != nil && (request.GetBody().User != nil || request.GetBody().Relation != nil || request.GetBody().Object != nil) {
 		body.TupleKey = &fgaSdk.ReadRequestTupleKey{
@@ -1279,7 +1294,11 @@ func (client *{{appShortName}}Client) ReadExecute(request SdkClientReadRequestIn
 			Object:   request.GetBody().Object,
 		}
 	}
-	data, _, err := client.{{appShortName}}Api.Read(request.GetContext(), client.config.StoreId).Body(body).Execute()
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	data, _, err := client.{{appShortName}}Api.Read(request.GetContext(), *storeId).Body(body).Execute()
 	if err != nil {
 		return nil, err
 	}

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -766,6 +766,7 @@ type SdkClientReadAuthorizationModelsRequest struct {
 type SdkClientReadAuthorizationModelsRequestInterface interface{
     Options(options ClientReadAuthorizationModelsOptions) SdkClientReadAuthorizationModelsRequestInterface
 	Execute() (*ClientReadAuthorizationModelsResponse, error)
+	GetStoreIdOverride() *string
 
 	GetContext() _context.Context
 	GetOptions() *ClientReadAuthorizationModelsOptions
@@ -774,6 +775,7 @@ type SdkClientReadAuthorizationModelsRequestInterface interface{
 type ClientReadAuthorizationModelsOptions struct {
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
+	StoreId           *string `json:"store_id,omitempty"`
 }
 
 type ClientReadAuthorizationModelsResponse = fgaSdk.ReadAuthorizationModelsResponse
@@ -787,6 +789,13 @@ func (request *SdkClientReadAuthorizationModelsRequest) Execute() (*ClientReadAu
 	return request.Client.ReadAuthorizationModelsExecute(request)
 }
 
+func (request *SdkClientReadAuthorizationModelsRequest) GetStoreIdOverride() *string {
+	if request.options == nil {
+		return nil
+	}
+	return request.options.StoreId
+}
+
 func (request *SdkClientReadAuthorizationModelsRequest) GetContext() _context.Context {
     return request.ctx
 }
@@ -796,12 +805,23 @@ func (request *SdkClientReadAuthorizationModelsRequest) GetOptions() *ClientRead
 }
 
 func (client *{{appShortName}}Client) ReadAuthorizationModelsExecute(request SdkClientReadAuthorizationModelsRequestInterface) (*ClientReadAuthorizationModelsResponse, error) {
-	req := client.{{appShortName}}Api.ReadAuthorizationModels(request.GetContext(), client.config.StoreId)
-	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
+	pagingOpts := ClientPaginationOptions{}
+	if request.GetOptions() != nil {
+		pagingOpts.PageSize = request.GetOptions().PageSize
+		pagingOpts.ContinuationToken = request.GetOptions().ContinuationToken
+	}
+
+	storeId, err := client.getStoreId(request.GetStoreIdOverride())
+	if err != nil {
+		return nil, err
+	}
+	
+	req := client.{{appShortName}}Api.ReadAuthorizationModels(request.GetContext(), *storeId)
+	pageSize := getPageSizeFromRequest(&pagingOpts)
 	if pageSize != nil {
 		req = req.PageSize(*pageSize)
 	}
-	continuationToken := getContinuationTokenFromRequest((*ClientPaginationOptions)(request.GetOptions()))
+	continuationToken := getContinuationTokenFromRequest(&pagingOpts)
 	if continuationToken != nil {
 		req = req.ContinuationToken(*continuationToken)
 	}

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -1144,6 +1144,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.Read(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadOptions{
+    		StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.Read(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("Write", func(t *testing.T) {

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -1060,6 +1060,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadChangesOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadChanges(context.Background()).Body(body).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadChangesOptions{
+    		StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadChanges(context.Background()).Body(body).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("Read", func(t *testing.T) {

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -288,6 +288,36 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientGetStoreOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.GetStore(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientGetStoreOptions{
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		_, err = fgaClient.GetStore(context.Background()).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		
 	})
 
 	t.Run("GetStoreAfterSettingStoreId", func(t *testing.T) {
@@ -382,6 +412,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 		}
 		// DeleteStore without options should work
 		_, err = fgaClient.DeleteStore(context.Background()).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientDeleteStoreOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.DeleteStore(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientDeleteStoreOptions{
+    		StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, "{}")
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.DeleteStore(context.Background()).Options(storeOverrideOptions).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -515,6 +573,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 
 		// WriteAuthorizationModel without options should work
 		_, err = fgaClient.WriteAuthorizationModel(context.Background()).Body(requestBody).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientWriteAuthorizationModelOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.WriteAuthorizationModel(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("%v", err)
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientWriteAuthorizationModelOptions{
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.WriteAuthorizationModel(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
@@ -792,6 +878,35 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("Expected error:%v, got: %v", expectedError, err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadAuthorizationModelOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadAuthorizationModel(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadAuthorizationModelOptions{
+			AuthorizationModelId: {{packageName}}.PtrString(modelId),
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath, modelId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadAuthorizationModel(context.Background()).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("ReadLatestAuthorizationModel", func(t *testing.T) {
@@ -1030,6 +1145,25 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// store ID can be overridden
+		storeOverrideOptions := ClientWriteOptions{
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.Write(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("Write with invalid auth model id", func(t *testing.T) {
@@ -1059,6 +1193,36 @@ func Test{{appShortName}}Client(t *testing.T) {
 		_, err := fgaClient.Write(context.Background()).Body(requestBody).Options(options).Execute()
 		if err == nil {
 			t.Fatalf("Expect error due to invalid auth model ID but there is none")
+		}
+	})
+
+	t.Run("Write with invalid store id", func(t *testing.T) {
+		test := TestDefinition{
+			Name:           "Write",
+			JsonResponse:   `{}`,
+			ResponseStatus: http.StatusOK,
+			Method:         http.MethodPost,
+			RequestPath:    "write",
+		}
+		requestBody := ClientWriteRequest{
+			Writes: []ClientTupleKey{ {
+				User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+				Relation: "viewer",
+				Object:   "document:roadmap",
+			} },
+		}
+		options := ClientWriteOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+
+		var expectedResponse map[string]interface{}
+		if err := json.Unmarshal([]byte(test.JsonResponse), &expectedResponse); err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		_, err := fgaClient.Write(context.Background()).Body(requestBody).Options(options).Execute()
+		if err == nil {
+			t.Fatalf("Expect error due to invalid store ID but there is none")
 		}
 	})
 
@@ -1391,6 +1555,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientWriteOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.WriteTuples(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientWriteOptions{
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.WriteTuples(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("DeleteTuples", func(t *testing.T) {
@@ -1474,6 +1666,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientWriteOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.DeleteTuples(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientWriteOptions{
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.DeleteTuples(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	/* Relationship Queries */
@@ -1542,6 +1762,33 @@ func Test{{appShortName}}Client(t *testing.T) {
 		_, err = fgaClient.Check(context.Background()).Body(requestBody).Options(badOptions).Execute()
 		if err == nil {
 			t.Fatalf("Expect error with bad auth model id but there is none")
+		}
+		// invalid store id should result in error
+		badStoreOptions := ClientCheckOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.Check(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientCheckOptions{
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.Check(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 
 	})
@@ -1653,6 +1900,15 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth model id but there is none")
 		}
+		// invalid store ID should fail
+		badStoreOptions := ClientBatchCheckOptions{
+			StoreId:             {{packageName}}.PtrString("INVALID"),
+			MaxParallelRequests: {{packageName}}.PtrInt32(5),
+		}
+		_, err = fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
 
 		if httpmock.GetTotalCallCount() != 0 {
 			t.Fatalf("Expected no calls to be made")
@@ -1668,6 +1924,26 @@ func Test{{appShortName}}Client(t *testing.T) {
 		_, err = fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(options).Execute()
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth but there is none")
+		}
+
+		// store should be overridden
+		storeOverrideOptions := ClientBatchCheckOptions{
+			StoreId:             {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+			MaxParallelRequests: {{packageName}}.PtrInt32(5),
+		}
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		_, err = fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 	})
 
@@ -1725,6 +2001,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 		_, err = fgaClient.Expand(context.Background()).Body(requestBody).Options(badOptions).Execute()
 		if err == nil {
 			t.Fatalf("Expect error for invalid auth model id but there is none")
+		}
+
+		// Invalid auth model ID should result in error
+		badStoreOptions := ClientExpandOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.Expand(context.Background()).Body(requestBody).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error for invalid auth model id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientExpandOptions{
+    		StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.Expand(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 	})
 
@@ -1792,6 +2096,7 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
 		// Invalid auth model id should result in error
 		badOptions := ClientListObjectsOptions{
 			AuthorizationModelId: {{packageName}}.PtrString("INVALID"),
@@ -1802,6 +2107,39 @@ func Test{{appShortName}}Client(t *testing.T) {
 			Execute()
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
+		// Invalid store id should result in error
+		badStoreOptions := ClientListObjectsOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ListObjects(context.Background()).
+			Body(requestBody).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid auth model id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientListObjectsOptions{
+    		StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ListObjects(context.Background()).
+			Body(requestBody).
+			Options(storeOverrideOptions).
+			Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 	})
 
@@ -1892,6 +2230,53 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth model id but there is none")
 		}
+
+		// invalid store ID should result in error
+		badStoreOptions := ClientListRelationsOptions{
+			AuthorizationModelId: {{packageName}}.PtrString(authModelId),
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ListRelations(context.Background()).
+			Body(requestBody).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientListRelationsOptions{
+    		StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterMatcherResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			httpmock.BodyContainsString(`"relation":"can_delete"`),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, {{packageName}}.CheckResponse{Allowed: {{packageName}}.PtrBool(false)})
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		_, err = fgaClient.ListRelations(context.Background()).
+			Body(requestBody).
+			Options(storeOverrideOptions).
+			Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
 
 	})
 
@@ -2034,6 +2419,41 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Expect error with invalid auth model id but there is none")
 		}
+		// Invalid store id should result in error
+		badStoreOptions := ClientListUsersOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ListUsers(context.Background()).
+			Body(requestBody).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Expect error with invalid store model id but there is none")
+		}
+
+		// StoreId can be overridden
+		storeOverrideOptions := ClientListUsersOptions{
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+
+		_, err = fgaClient.ListUsers(context.Background()).
+			Body(requestBody).
+			Options(storeOverrideOptions).
+			Execute()
+
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	/* Assertions */
@@ -2099,6 +2519,39 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Invalid auth model ID should result in error")
 		}
+
+		// Invalid store id should result in error
+		badStoreOptions := ClientReadAssertionsOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadAssertions(context.Background()).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Invalid store ID should result in error")
+		}
+
+		// store can be overriden
+		storeOverrideOptions := ClientReadAssertionsOptions{
+			AuthorizationModelId: {{packageName}}.PtrString(modelId),
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath, modelId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadAssertions(context.Background()).
+			Options(storeOverrideOptions).
+			Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("WriteAssertions", func(t *testing.T) {
@@ -2156,6 +2609,40 @@ func Test{{appShortName}}Client(t *testing.T) {
 			Execute()
 		if err == nil {
 			t.Fatalf("Invalid auth model id should result in error but there is none")
+		}
+
+		badStoreOptions := ClientWriteAssertionsOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.WriteAssertions(context.Background()).
+			Body(requestBody).
+			Options(badStoreOptions).
+			Execute()
+		if err == nil {
+			t.Fatalf("Invalid store id should result in error but there is none")
+		}
+
+		// store can be overriden
+		storeOverrideOptions := ClientWriteAssertionsOptions{
+			AuthorizationModelId: {{packageName}}.PtrString(modelId),
+			StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath, modelId),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, "")
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.WriteAssertions(context.Background()).
+			Body(requestBody).
+			Options(storeOverrideOptions).
+			Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
 		}
 	})
 }

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -493,6 +493,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadAuthorizationModelsOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadAuthorizationModels(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadAuthorizationModelsOptions{
+    		StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadAuthorizationModels(context.Background()).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	t.Run("WriteAuthorizationModel", func(t *testing.T) {

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -982,6 +982,34 @@ func Test{{appShortName}}Client(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
+
+		// invalid store id should result in error
+		badStoreOptions := ClientReadLatestAuthorizationModelOptions{
+			StoreId: {{packageName}}.PtrString("INVALID"),
+		}
+		_, err = fgaClient.ReadLatestAuthorizationModel(context.Background()).Options(badStoreOptions).Execute()
+		if err == nil {
+			t.Fatalf("Expect error with bad store id but there is none")
+		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientReadLatestAuthorizationModelOptions{
+    		StoreId: {{packageName}}.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		_, err = fgaClient.ReadLatestAuthorizationModel(context.Background()).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 	})
 
 	/* Relationship Tuples */


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Enables overriding the store ID using `client.go` for all APIs except for ListStores and CreateStore.

## Description
<!-- Provide a detailed description of the changes -->

For endpoints that use the store ID, a `StoreId` was added to its respective request options. If set, it will be used when making the request. If not set, the store ID configured for the client will be used instead.

```go
client, err := NewSdkClient(&ClientConfiguration{
         ApiUrl:  os.GetEnv("FGA_API_URL"),     
         StoreId: os.GetEnv("FGA_STORE_ID"),
})

if err != nil {
        // handle error
}

// Uses StoreId from ClientConfiguration
got, err := client.GetStore(context.Background()).Execute()
if err != nil {
        // ....
}
fmt.Printf("Got store %v", got.Name)

// store can be overridden
storeOverrideOptions := ClientGetStoreOptions{
	StoreId: "01RXYB9SWCFGFCX1QZA9DN8T4Y",
}

got, err = client.GetStore(context.Background()).Options(storeOverrideOptions).Execute()
if err != nil {
	// ....
}

fmt.Printf("Got store %v", got.Name)
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
Completes the `go-sdk` work captured in #118 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
