### PR TITLE
fix(go-sdk): set http client

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -50,6 +50,7 @@ func newClientConfiguration(cfg *fgaSdk.Configuration) ClientConfiguration {
 		DefaultHeaders: cfg.DefaultHeaders,
 		UserAgent:      cfg.UserAgent,
 		Debug:          cfg.Debug,
+		HTTPClient:	    cfg.HTTPClient,
 		RetryParams:    cfg.RetryParams,
 	}
 }
@@ -69,6 +70,7 @@ func NewSdkClient(cfg *ClientConfiguration) (*{{appShortName}}Client, error) {
 		DefaultHeaders: cfg.DefaultHeaders,
 		UserAgent:      cfg.UserAgent,
 		Debug:          cfg.Debug,
+		HTTPClient:	    cfg.HTTPClient,
 		RetryParams:    cfg.RetryParams,
 	})
 

--- a/config/clients/go/template/configuration.mustache
+++ b/config/clients/go/template/configuration.mustache
@@ -68,6 +68,7 @@ func NewConfiguration(config Configuration) (*Configuration, error) {
         DefaultHeaders: config.DefaultHeaders,
         UserAgent:      config.UserAgent,
         Debug:          config.Debug,
+		HTTPClient:	    config.HTTPClient,
         RetryParams:    config.RetryParams,
     }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Fixed set HTTP Client of Go SDK.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
Closes https://github.com/openfga/sdk-generator/issues/370

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
