### PR TITLE
Removing excluded users from ListUsers response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Main config
 OPENFGA_DOCKER_TAG = v1.5.3
-OPEN_API_REF ?= db6f987744909bb59e3bd8e1d4ebf47b2f35d36f
+OPEN_API_REF ?= f33cb24bcd9707c5fba8cbbc4a4441ab24a3442d
 OPEN_API_URL = https://raw.githubusercontent.com/openfga/api/${OPEN_API_REF}/docs/openapiv2/apidocs.swagger.json
 OPENAPI_GENERATOR_CLI_DOCKER_TAG = v6.4.0
 NODE_DOCKER_TAG = 20-alpine

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Main config
 OPENFGA_DOCKER_TAG = v1.5.3
-OPEN_API_REF ?= 2b164f5813a735bf0bb76fb39bd35b3bb29196ed
+OPEN_API_REF ?= db6f987744909bb59e3bd8e1d4ebf47b2f35d36f
 OPEN_API_URL = https://raw.githubusercontent.com/openfga/api/${OPEN_API_REF}/docs/openapiv2/apidocs.swagger.json
 OPENAPI_GENERATOR_CLI_DOCKER_TAG = v6.4.0
 NODE_DOCKER_TAG = 20-alpine

--- a/config/clients/dotnet/template/OpenFgaClientTests.mustache
+++ b/config/clients/dotnet/template/OpenFgaClientTests.mustache
@@ -1440,7 +1440,6 @@ public class {{appShortName}}ClientTests {
                 }
 
             },
-            ExcludedUsers = new List<ObjectOrUserset>()
         };
         mockHandler.Protected()
             .Setup<Task<HttpResponseMessage>>(

--- a/config/clients/dotnet/template/README_calling_api.mustache
+++ b/config/clients/dotnet/template/README_calling_api.mustache
@@ -544,7 +544,6 @@ const response = await fgaClient.listUsers({
 }, options);
 
 // response.users = [{object: {type: "user", id: "81684243-9356-4421-8fbf-a4f8d36aa31b"}}, {userset: { type: "user" }}, ...]
-// response.excluded_users = [ {object: {type: "user", id: "4a455e27-d15a-4434-82e0-136f9c2aa4cf"}}, ... ]
 ```
 
 #### Assertions

--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -1484,7 +1484,6 @@ namespace {{testPackageName}}.Api {
                     }
 
                 },
-                ExcludedUsers = new List<ObjectOrUserset>()
             };
             mockHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(

--- a/config/clients/go/template/README_calling_api.mustache
+++ b/config/clients/go/template/README_calling_api.mustache
@@ -621,7 +621,6 @@ data, err := fgaClient.ListRelations(context.Background()).
   Execute()
 
 // response.users = [{object: {type: "user", id: "81684243-9356-4421-8fbf-a4f8d36aa31b"}}, {userset: { type: "user" }}, ...]
-// response.excluded_users = [ {object: {type: "user", id: "4a455e27-d15a-4434-82e0-136f9c2aa4cf"}}, ... ]
 ```
 
 ### Assertions

--- a/config/clients/go/template/README_calling_api.mustache
+++ b/config/clients/go/template/README_calling_api.mustache
@@ -597,7 +597,7 @@ userFilters := []openfga.UserTypeFilter{{ Type: "user" }}
 // userFilters := []openfga.UserTypeFilter{{ Type: "team", Relation: openfga.PtrString("member") }}
 
 requestBody := ClientListUsersRequest{
-    Object: openfga.Object{
+    Object: openfga.FgaObject{
         Type: "document",
         Id:   "roadmap",
     },

--- a/config/clients/go/template/api_test.mustache
+++ b/config/clients/go/template/api_test.mustache
@@ -882,7 +882,7 @@ func Test{{appShortName}}Api(t *testing.T) {
 		test := TestDefinition{
 			Name: "ListUsers",
 			// A real API would not return all these for the filter provided, these are just for test purposes
-			JsonResponse:   `{"excluded_users":null,"users":[{"object":{"id":"81684243-9356-4421-8fbf-a4f8d36aa31b","type":"user"}},{"userset":{"id":"fga","relation":"member","type":"team"}},{"wildcard":{"type":"user"}}]}`,
+			JsonResponse:   `{"users":[{"object":{"id":"81684243-9356-4421-8fbf-a4f8d36aa31b","type":"user"}},{"userset":{"id":"fga","relation":"member","type":"team"}},{"wildcard":{"type":"user"}}]}`,
 			ResponseStatus: http.StatusOK,
 			Method:         http.MethodPost,
 			RequestPath:    "list-users",
@@ -962,10 +962,6 @@ func Test{{appShortName}}Api(t *testing.T) {
 
 		if got.Users[2].GetWildcard().Type != expectedResponse.Users[2].GetWildcard().Type {
 			t.Fatalf("{{appShortName}}%v().Execute() = %v, want %v (%v)", test.Name, got.Users[2], expectedResponse.Users[2], "wildcard: { type: \"user\" }")
-		}
-
-		if len(got.ExcludedUsers) != len(expectedResponse.ExcludedUsers) {
-			t.Fatalf("{{appShortName}}%v().Execute() = %v, want %v", test.Name, got.GetExcludedUsers(), expectedResponse.GetExcludedUsers())
 		}
 	})
 

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -2431,7 +2431,7 @@ func Test{{appShortName}}Client(t *testing.T) {
 		test := TestDefinition{
 			Name: "ListUsers",
 			// A real API would not return all these for the filter provided, these are just for test purposes
-			JsonResponse:   `{"excluded_users":null,"users":[{"object":{"id":"81684243-9356-4421-8fbf-a4f8d36aa31b","type":"user"}},{"userset":{"id":"fga","relation":"member","type":"team"}},{"wildcard":{"type":"user"}}]}`,
+			JsonResponse:   `{"users":[{"object":{"id":"81684243-9356-4421-8fbf-a4f8d36aa31b","type":"user"}},{"userset":{"id":"fga","relation":"member","type":"team"}},{"wildcard":{"type":"user"}}]}`,
 			ResponseStatus: http.StatusOK,
 			Method:         http.MethodPost,
 			RequestPath:    "list-users",
@@ -2508,10 +2508,6 @@ func Test{{appShortName}}Client(t *testing.T) {
 
 		if got.Users[2].GetWildcard().Type != expectedResponse.Users[2].GetWildcard().Type {
 			t.Fatalf("{{appShortName}}%v().Execute() = %v, want %v (%v)", test.Name, got.Users[2], expectedResponse.Users[2], "wildcard: { type: \"user\" }")
-		}
-
-		if len(got.ExcludedUsers) != len(expectedResponse.ExcludedUsers) {
-			t.Fatalf("{{appShortName}}%v().Execute() = %v, want %v", test.Name, got.GetExcludedUsers(), expectedResponse.GetExcludedUsers())
 		}
 
 		// ListUsers without options should work

--- a/config/clients/java/template/README_calling_api.mustache
+++ b/config/clients/java/template/README_calling_api.mustache
@@ -564,7 +564,6 @@ var options = new ClientListUsersOptions()
 var response = fgaClient.listUsers(request, options).get();
 
 // response.getUsers() = [{object: {type: "user", id: "81684243-9356-4421-8fbf-a4f8d36aa31b"}}, {userset: { type: "user" }}, ...]
-// response.getExcludedUsers = [ {object: {type: "user", id: "4a455e27-d15a-4434-82e0-136f9c2aa4cf"}}, ... ]
 ```
 
 #### Assertions

--- a/config/clients/java/template/client-ClientListUsersResponse.java.mustache
+++ b/config/clients/java/template/client-ClientListUsersResponse.java.mustache
@@ -17,8 +17,6 @@ public class ClientListUsersResponse extends ListUsersResponse {
         this.rawResponse = apiResponse.getRawResponse();
         ListUsersResponse response = apiResponse.getData();
         this.setUsers(response.getUsers());
-        this.setExcludedUsers(response.getExcludedUsers());
-
     }
 
     public int getStatusCode() {

--- a/config/clients/java/template/client-OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClientTest.java.mustache
@@ -2330,7 +2330,7 @@ public class OpenFgaClientTest {
                 .withBody(is(expectedBody))
                 .doReturn(
                         200,
-                        "{\"excluded_users\":null,\"users\":[{\"object\":{\"id\":\"81684243-9356-4421-8fbf-a4f8d36aa31b\",\"type\":\"user\"}},{\"userset\":{\"id\":\"fga\",\"relation\":\"member\",\"type\":\"team\"}},{\"wildcard\":{\"type\":\"user\"}}]}");
+                        "{\"users\":[{\"object\":{\"id\":\"81684243-9356-4421-8fbf-a4f8d36aa31b\",\"type\":\"user\"}},{\"userset\":{\"id\":\"fga\",\"relation\":\"member\",\"type\":\"team\"}},{\"wildcard\":{\"type\":\"user\"}}]}");
 
         ClientListUsersRequest request = new ClientListUsersRequest()
                 ._object(new FgaObject().type(DEFAULT_TYPE).id(DEFAULT_ID))
@@ -2356,8 +2356,6 @@ public class OpenFgaClientTest {
                                         new UsersetUser().type("team").id("fga").relation("member")),
                         new User().wildcard(new TypedWildcard().type("user"))),
                 response.getUsers());
-
-        assertNull(response.getExcludedUsers());
     }
 
     /**

--- a/config/clients/js/template/README_calling_api.mustache
+++ b/config/clients/js/template/README_calling_api.mustache
@@ -462,7 +462,6 @@ const response = await fgaClient.listUsers({
 }, options);
 
 // response.users = [{object: {type: "user", id: "81684243-9356-4421-8fbf-a4f8d36aa31b"}}, {userset: { type: "user" }}, ...]
-// response.excluded_users = [ {object: {type: "user", id: "4a455e27-d15a-4434-82e0-136f9c2aa4cf"}}, ... ]
 ```
 
 #### Assertions

--- a/config/clients/js/template/tests/client.test.ts.mustache
+++ b/config/clients/js/template/tests/client.test.ts.mustache
@@ -769,19 +769,8 @@ describe("{{appTitleCaseName}} Client", () => {
             wildcard: {
               type: "employee"
             }
-          }],
-          excluded_users: [{
-            object: {
-              type: "user",
-              id: "76cebb86-6569-4440-b653-db3525a85831"
-            },
-          }, {
-            userset: {
-              type: "team",
-              id: "marketing",
-              relation: "member"
-            },
-          }] };
+          }]
+        };
         const scope = nocks.listUsers(baseConfig.storeId!, mockedResponse);
 
         expect(scope.isDone()).toBe(false);
@@ -831,20 +820,6 @@ describe("{{appTitleCaseName}} Client", () => {
           wildcard: {
             type: "employee"
           }
-        });
-        expect(response.excluded_users).toHaveLength(mockedResponse.excluded_users.length);
-        expect(response.excluded_users[0]).toMatchObject({
-          object: {
-            type: "user",
-            id: "76cebb86-6569-4440-b653-db3525a85831"
-          },
-        });
-        expect(response.excluded_users[1]).toMatchObject({
-          userset: {
-            type: "team",
-            id: "marketing",
-            relation: "member"
-          },
         });
         expect(response).toEqual(mockedResponse);
       });

--- a/config/clients/python/template/README_calling_api.mustache
+++ b/config/clients/python/template/README_calling_api.mustache
@@ -721,7 +721,6 @@ async with OpenFgaClient(configuration) as api_client:
     response = await api_client.list_users(request, options)
 
     # response.users = [{object: {type: "user", id: "81684243-9356-4421-8fbf-a4f8d36aa31b"}}, {userset: { type: "user" }}, ...]
-    # response.excluded_users = [ {object: {type: "user", id: "4a455e27-d15a-4434-82e0-136f9c2aa4cf"}}, ... ]
 ```
 
 #### Assertions

--- a/config/clients/python/template/api_test.mustache
+++ b/config/clients/python/template/api_test.mustache
@@ -387,7 +387,6 @@ class {{#operations}}Test{{classname}}(IsolatedAsyncioTestCase):
         """
 
         response_body = """{
-  "excluded_users": [],
   "users": [
     {
       "object": {

--- a/config/clients/python/template/api_test_sync.mustache
+++ b/config/clients/python/template/api_test_sync.mustache
@@ -390,7 +390,6 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
         """
 
         response_body = """{
-  "excluded_users": [],
   "users": [
     {
       "object": {

--- a/config/clients/python/template/client/test_client.mustache
+++ b/config/clients/python/template/client/test_client.mustache
@@ -2039,7 +2039,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         """
 
         response_body = """{
-  "excluded_users": [],
   "users": [
     {
       "object": {

--- a/config/clients/python/template/client/test_client_sync.mustache
+++ b/config/clients/python/template/client/test_client_sync.mustache
@@ -2039,7 +2039,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         """
 
         response_body = """{
-  "excluded_users": [],
   "users": [
     {
       "object": {


### PR DESCRIPTION
## Description
Removes excluded_users from the response of all SDKs as it was removed from OpenFGA with https://github.com/openfga/api/pull/171. 

This feature was originally a well-intentioned way to communicate any negations that may exist on public-typed wildcard (e.g. user:*) as a means of being abundantly clear about what a user:* result entails. However, as we discover more possible situations where excluded users could arise, we realize that we were making a premature decision about the API. We fully intend to re-add excluded_users at some point in the future but may or may not be a flattened list as previously implemented.

**Please note:** 
- This is technically a breaking but is acceptable provided that the ListUsers API is still experimental
- The API commit this PR is based off of is not merged into `main` yet

## References
- Related OpenFGA API change: https://github.com/openfga/api/pull/171

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
