### PR TITLE
Update README to correct synchronous client example

### DIFF
--- a/config/clients/python/template/README_initializing.mustache
+++ b/config/clients/python/template/README_initializing.mustache
@@ -83,7 +83,8 @@ from `openfga_sdk.sync` that supports all the credential types and calls,
 without requiring async/await.
 
 ```python
-from {{packageName}}.sync import ClientConfiguration, OpenFgaClient
+from {{packageName}}.client import ClientConfiguration
+from {{packageName}}.sync import OpenFgaClient
 
 
 def main():


### PR DESCRIPTION
Updated the OpenFGA Python sdk repository README to correct the example shown for using the synchronous client option. 

When using the synchronous client ClientConfiguration still needs to be imported from openfga_sdk.client instead of openfga_sdk.sync


## Description
Adjust the imports shown in the example in the README



## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
