### PR TITLE
fix(python-sdk): Do not set fga-client.request.client_id if client_id  is None

### DIFF
--- a/config/clients/python/template/src/api_client.py.mustache
+++ b/config/clients/python/template/src/api_client.py.mustache
@@ -293,9 +293,10 @@ class ApiClient:
             )
 
             try:
-                _telemetry_attributes[TelemetryAttributes().request_client_id] = (
-                    self.configuration.credentials.configuration.client_id
-                )
+                if self.configuration.credentials.configuration.client_id is not None:
+                    _telemetry_attributes[TelemetryAttributes().request_client_id] = (
+                        self.configuration.credentials.configuration.client_id
+                    )
             except AttributeError:
                 pass
 

--- a/config/clients/python/template/src/sync/api_client.py.mustache
+++ b/config/clients/python/template/src/sync/api_client.py.mustache
@@ -274,9 +274,10 @@ class ApiClient:
             )
 
             try:
-                _telemetry_attributes[TelemetryAttributes().request_client_id] = (
-                    self.configuration.credentials.configuration.client_id
-                )
+                if self.configuration.credentials.configuration.client_id is not None:
+                    _telemetry_attributes[TelemetryAttributes().request_client_id] = (
+                        self.configuration.credentials.configuration.client_id
+                    )
             except AttributeError:
                 pass
 


### PR DESCRIPTION
Updates the Python SDK Code to not set fga-client.request.client_id attribute if the client_id is None

Fixes: https://github.com/openfga/python-sdk/issues/117

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
