### PR TITLE
chore(js-sdk): bump `axios` dependency to `^1.7.4`

### DIFF
--- a/config/clients/js/template/package.mustache
+++ b/config/clients/js/template/package.mustache
@@ -21,7 +21,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/semantic-conventions": "^1.25.0",
-    "axios": "^1.6.8",
+    "axios": "^1.7.4",
     "tiny-async-pool": "^2.1.0"
   },
   "devDependencies": {

--- a/config/clients/js/template/package.mustache
+++ b/config/clients/js/template/package.mustache
@@ -20,21 +20,21 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/semantic-conventions": "^1.25.0",
+    "@opentelemetry/semantic-conventions": "^1.25.1",
     "axios": "^1.7.4",
     "tiny-async-pool": "^2.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "^20.12.7",
+    "@types/node": "^22.2.0",
     "@types/tiny-async-pool": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "nock": "^13.5.4",
-    "ts-jest": "^29.1.2",
-    "typescript": "^5.4.5"
+    "ts-jest": "^29.2.4",
+    "typescript": "^5.5.4"
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR bumps the `axios` dependency used by the JS SDK to address https://github.com/axios/axios/issues/6463

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Generates the same output as https://github.com/openfga/js-sdk/pull/137

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
