### PR TITLE
fix(java-sdk): ensure `MeterProvider` uses the correct package version

### DIFF
--- a/config/clients/java/template/telemetry-Metrics.java.mustache
+++ b/config/clients/java/template/telemetry-Metrics.java.mustache
@@ -19,14 +19,14 @@ public class Metrics {
     private final Configuration configuration;
 
     public Metrics() {
-        this.meter = OpenTelemetry.noop().getMeterProvider().get("openfga-sdk/0.5.0");
+        this.meter = OpenTelemetry.noop().getMeterProvider().get("{{artifactId}}/{{packageVersion}}");
         this.counters = new HashMap<>();
         this.histograms = new HashMap<>();
         this.configuration = new Configuration();
     }
 
     public Metrics(Configuration configuration) {
-        this.meter = OpenTelemetry.noop().getMeterProvider().get("openfga-sdk/0.5.0");
+        this.meter = OpenTelemetry.noop().getMeterProvider().get("{{artifactId}}/{{packageVersion}}");
         this.counters = new HashMap<>();
         this.histograms = new HashMap<>();
         this.configuration = configuration;


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR follows up on #407 to ensure the SDK output includes the proper SDK version for the OpenTelemetry MeterProvider signature.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
