### PR TITLE
docs: allow configuration of generated OpenTelemetry documentation path

### DIFF
--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -31,7 +31,7 @@
   "enumUnknownDefaultCase": true,
   "allowUnicodeIdentifiers": true,
   "caseInsensitiveResponseHeaders": true,
-  "supportsOpenTelemetry": true,
+  "openTelemetryDocumentation": "OpenTelemetry.md",
   "files": {
     "auth-model.json": {
       "destinationFilename": "src/test-integration/resources/auth-model.json",

--- a/config/clients/js/config.overrides.json
+++ b/config/clients/js/config.overrides.json
@@ -10,7 +10,7 @@
   "useSingleRequestParameter": false,
   "supportsES6": true,
   "modelPropertyNaming": "original",
-  "supportsOpenTelemetry": true,
+  "openTelemetryDocumentation": "opentelemetry.md",
   "files": {
     ".github/workflows/main.yaml.mustache": {
       "destinationFilename": ".github/workflows/main.yaml",
@@ -119,7 +119,7 @@
       "destinationFilename": "example/example1/package.json",
       "templateType": "SupportingFiles"
     },
-    "example/opentelemetry/.npmrc": {},   
+    "example/opentelemetry/.npmrc": {},
     "example/opentelemetry/opentelemetry.mjs": {},
     "example/opentelemetry/README.md": {},
     "example/opentelemetry/instrumentation.mjs": {},

--- a/config/clients/python/config.overrides.json
+++ b/config/clients/python/config.overrides.json
@@ -10,7 +10,7 @@
   "infoEmail": "community@openfga.dev",
   "docPrefix": "https://github.com/openfga/python-sdk/blob/main/",
   "pythonMinimumRuntime": "3.10",
-  "supportsOpenTelemetry": true,
+  "openTelemetryDocumentation": "opentelemetry.md",
   "files": {
     ".github/workflows/main.yaml.mustache": {
       "destinationFilename": ".github/workflows/main.yaml",

--- a/config/common/files/README.mustache
+++ b/config/common/files/README.mustache
@@ -46,9 +46,9 @@
   - [Retries](#retries)
   - [API Endpoints](#api-endpoints)
   - [Models](#models)
-{{#supportsOpenTelemetry}}
+{{#openTelemetryDocumentation}}
   - [OpenTelemetry](#opentelemetry)
-{{/supportsOpenTelemetry}}
+{{/openTelemetryDocumentation}}
 - [Contributing](#contributing)
   - [Issues](#issues)
   - [Pull Requests](#pull-requests)
@@ -112,12 +112,12 @@ If your server is configured with [authentication enabled]({{docsUrl}}/getting-s
 
 {{>README_models}}
 
-{{#supportsOpenTelemetry}}
+{{#openTelemetryDocumentation}}
 ### OpenTelemetry
 
-This SDK supports producing metrics that can be consumed as part of an [OpenTelemetry](https://opentelemetry.io/) setup. For more information, please see [the documentation](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/blob/main/docs/opentelemetry.md)
+This SDK supports producing metrics that can be consumed as part of an [OpenTelemetry](https://opentelemetry.io/) setup. For more information, please see [the documentation](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/blob/main/docs/{{openTelemetryDocumentation}})
 
-{{/supportsOpenTelemetry}}
+{{/openTelemetryDocumentation}}
 ## Contributing
 
 ### Issues


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This pull request replaces the `supportsOpenTelemetry` configuration override with a `openTelemetryDocumentation` variable. This enables us to change the link/path used in the README to the OpenTelemetry documentation in a manner appropriate to the standards of the target programming language (for example, pascal for Java, snake for Python, etc.)

As an example, in Java's case, it is preferable to output the OpenTelemetry documentation to https://github.com/openfga/java-sdk/blob/main/docs/OpenTelemetry.md instead of https://github.com/openfga/java-sdk/blob/main/docs/opentelemetry.md, as the casing for all the other generated documentation uses pascal case.

This change updates the base README template to point to the configured filename, rather than the generic `opentelemetry.md` filename.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
