### PR TITLE
feat(token): token endpoint is now configurable

### DIFF
--- a/config/clients/python/template/src/credentials.py.mustache
+++ b/config/clients/python/template/src/credentials.py.mustache
@@ -161,7 +161,7 @@ class Credentials:
             raise ApiValueError(e)
 
         if parsed_url.netloc is None and parsed_url.path is None:
-            raise ApiValueError(f"Invalid issuer")
+            raise ApiValueError("Invalid issuer")
 
         if parsed_url.scheme == "":
             parsed_url = urlparse(f"https://{issuer}")

--- a/config/clients/python/template/src/credentials.py.mustache
+++ b/config/clients/python/template/src/credentials.py.mustache
@@ -150,6 +150,31 @@ class Credentials:
         """
         self._configuration = value
 
+    def _parse_issuer(self, issuer: str):
+        default_endpoint_path = '/oauth/token'
+
+        parsed_url = urlparse(issuer.strip())
+
+        try:
+            parsed_url.port
+        except ValueError as e:
+            raise ApiValueError(e)
+
+        if parsed_url.netloc is None and parsed_url.path is None:
+            raise ApiValueError(f"Invalid issuer")
+
+        if parsed_url.scheme == "":
+            parsed_url = urlparse(f"https://{issuer}")
+        elif parsed_url.scheme not in ("http", "https"):
+            raise ApiValueError(f"Invalid issuer scheme {parsed_url.scheme} must be HTTP or HTTPS")
+
+        if parsed_url.path in ("", "/"):
+            parsed_url = parsed_url._replace(path=default_endpoint_path)
+
+        valid_url = urlunparse(parsed_url)
+
+        return valid_url
+
     def validate_credentials_config(self):
         """
         Check whether credentials configuration is valid
@@ -164,15 +189,6 @@ class Credentials:
             if self.configuration is None or none_or_empty(self.configuration.client_id) or none_or_empty(self.configuration.client_secret) or none_or_empty(self.configuration.api_audience) or none_or_empty(self.configuration.api_issuer):
                 raise ApiValueError('configuration `{}` requires client_id, client_secret, api_audience and api_issuer defined for client_credentials method.')
             # validate token issuer
-            combined_url = 'https://' + self.configuration.api_issuer
-            parsed_url = None
-            try:
-                parsed_url = urlparse(combined_url)
-            except ValueError:
-                raise ApiValueError(
-                    f"api_issuer `{self.configuration.api_issuer}` is invalid"
-                )
-            if (parsed_url.netloc == ''):
-                raise ApiValueError(
-                    f"api_issuer `{self.configuration.api_issuer}` is invalid"
-                )
+
+            parsed_issuer_url = self._parse_issuer(self.configuration.api_issuer)
+

--- a/config/clients/python/template/src/credentials.py.mustache
+++ b/config/clients/python/template/src/credentials.py.mustache
@@ -1,6 +1,6 @@
 {{>partial_header}}
 
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from {{packageName}}.exceptions import ApiValueError
 

--- a/config/clients/python/template/test/credentials_test.py.mustache
+++ b/config/clients/python/template/test/credentials_test.py.mustache
@@ -1,11 +1,12 @@
 {{>partial_header}}
 
 from unittest import IsolatedAsyncioTestCase
+import unittest
 
 import {{packageName}}{{^asyncio}} as openfga_sdk{{/asyncio}}
 
 from {{packageName}}.credentials import CredentialConfiguration, Credentials
-
+from {{packageName}}.exceptions import ApiValueError
 
 class TestCredentials(IsolatedAsyncioTestCase):
     """Credentials unit test"""
@@ -131,3 +132,58 @@ class TestCredentials(IsolatedAsyncioTestCase):
         with self.assertRaises(openfga_sdk.ApiValueError):
             credential.validate_credentials_config()
 
+
+class TestCredentialsIssuer(unittest.TestCase):
+    def setUp(self):
+        # Setup a basic configuration that can be modified per test case
+        self.configuration = CredentialConfiguration(api_issuer="https://example.com")
+        self.credentials = Credentials(method="client_credentials", configuration=self.configuration)
+
+    def test_valid_issuer_https(self):
+        # Test a valid HTTPS URL
+        self.configuration.api_issuer = "issuer.fga.example	"
+        result = self.credentials._parse_issuer(self.configuration.api_issuer)
+        self.assertEqual(result, "https://issuer.fga.example/oauth/token")
+
+    def test_valid_issuer_with_oauth_endpoint_https(self):
+        # Test a valid HTTPS URL
+        self.configuration.api_issuer = "https://example.com/oauth/token"
+        result = self.credentials._parse_issuer(self.configuration.api_issuer)
+        self.assertEqual(result, "https://example.com/oauth/token")
+
+    def test_valid_issuer_with_some_endpoint_https(self):
+        # Test a valid HTTPS URL
+        self.configuration.api_issuer = "https://example.com/oauth/some/endpoint"
+        result = self.credentials._parse_issuer(self.configuration.api_issuer)
+        self.assertEqual(result, "https://example.com/oauth/some/endpoint")
+
+    def test_valid_issuer_http(self):
+        # Test a valid HTTP URL
+        self.configuration.api_issuer = "fga.example/some_endpoint"
+        result = self.credentials._parse_issuer(self.configuration.api_issuer)
+        self.assertEqual(result, "https://fga.example/some_endpoint")
+
+    def test_invalid_issuer_no_scheme(self):
+        # Test an issuer URL without a scheme
+        self.configuration.api_issuer = "https://issuer.fga.example:8080/some_endpoint	"
+        result = self.credentials._parse_issuer(self.configuration.api_issuer)
+        self.assertEqual(result, "https://issuer.fga.example:8080/some_endpoint")
+
+    def test_invalid_issuer_bad_scheme(self):
+        # Test an issuer with an unsupported scheme
+        self.configuration.api_issuer = "ftp://example.com"
+        with self.assertRaises(ApiValueError):
+            self.credentials._parse_issuer(self.configuration.api_issuer)
+
+    def test_invalid_issuer_with_port(self):
+        # Test an issuer with an unsupported scheme
+        self.configuration.api_issuer = "https://issuer.fga.example:8080 "
+        result = self.credentials._parse_issuer(self.configuration.api_issuer)
+        self.assertEqual(result, "https://issuer.fga.example:8080/oauth/token")
+
+    # this should raise error
+    def test_invalid_issuer_bad_hostname(self):
+        # Test an issuer with an invalid hostname
+        self.configuration.api_issuer = "https://example?.com"
+        with self.assertRaises(ApiValueError):
+            self.credentials._parse_issuer(self.configuration.api_issuer)


### PR DESCRIPTION
This pull request introduces the `_parse_issuer` function, enhancing the validation and normalization of issuer URLs for OAuth token requests. It ensures URLs adhere to standards by verifying schemes and appending a default path if needed. 

## Description
This pull request introduces a new function, `_parse_issuer`, to the authentication system, specifically designed to enhance the validation and normalization of issuer URLs used in OAuth token requests. 

This function systematically checks and corrects the structure of the issuer URL, ensuring it adheres to expected standards, such as including a valid scheme (http or https) and appending a default endpoint path if none is provided. 

Additionally, comprehensive tests have been added to validate the functionality of this new method against various edge cases and common URL formatting errors.

## Changes
- Added `_parse_issuer` function to enhance issuer URL validation in `Credentials`.
- Implemented unit tests for `_parse_issuer` to ensure robust handling of a variety of URL inputs.

## References
This PR closes issue #238 for Python SDK

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
