### PR TITLE
fix: update links to `SECURITY.md`

### DIFF
--- a/config/clients/python/template/.github/ISSUE_TEMPLATE/bug_report.md.mustache
+++ b/config/clients/python/template/.github/ISSUE_TEMPLATE/bug_report.md.mustache
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**Please do not report security vulnerabilities here**. See the [Responsible Disclosure Program](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/blob/main/.github/SECURITY.md).
+**Please do not report security vulnerabilities here**. See the [Responsible Disclosure Program](https://github.com/openfga/.github/blob/main/SECURITY.md).
 
 **Thank you in advance for helping us to improve this library!** Please read through the template below and answer all relevant questions. Your additional work here is greatly appreciated and will help us respond as quickly as possible.
 

--- a/config/common/files/CONTRIBUTING.md.mustache
+++ b/config/common/files/CONTRIBUTING.md.mustache
@@ -43,4 +43,4 @@ Please do not open issues for general support or usage questions. Instead, join 
 
 ### Vulnerability Reporting
 
-Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/blob/main/.github/SECURITY.md) details the procedure for disclosing security issues.
+Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://github.com/openfga/.github/blob/main/SECURITY.md) details the procedure for disclosing security issues.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
The links to `SECURITY.md` in:

- https://github.com/openfga/java-sdk/blob/4947d98a11711eddfbde88caacf36af77da5dcbd/CONTRIBUTING.md?plain=1#L46,
- https://github.com/openfga/java-sdk/blob/4947d98a11711eddfbde88caacf36af77da5dcbd/.github/ISSUE_TEMPLATE/bug_report.md?plain=1#L10,

are broken.

Similarly in [go-sdk](https://github.com/openfga/go-sdk), [python-sdk](https://github.com/openfga/python-sdk), and [dotned-sdk](https://github.com/openfga/dotnet-sdk).

I decided to link directly to [`SECURITY.md`](https://github.com/openfga/.github/blob/main/SECURITY.md).

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
