### PR TITLE
fix: missing import in ClientCredentials example

### DIFF
--- a/config/clients/js/template/README_initializing.mustache
+++ b/config/clients/js/template/README_initializing.mustache
@@ -35,7 +35,7 @@ const fgaClient = new {{appShortName}}Client({
 #### Client Credentials
 
 ```javascript
-const { {{appShortName}}Client } = require('{{packageName}}'); // OR import { {{appShortName}}Client } from '{{packageName}}';
+const { {{appShortName}}Client, CredentialsMethod } = require('{{packageName}}'); // OR import { {{appShortName}}Client } from '{{packageName}}';
 
 const fgaClient = new {{appShortName}}Client({
   apiUrl: process.env.FGA_API_URL, // required


### PR DESCRIPTION
## Description
Example listed in https://github.com/openfga/js-sdk/blob/main/README.md#client-credentials did not work as is because CredentialsMethod was not being imported.

## References
- Fixes #392 
## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
