### PR TITLE
fix(go-sdk): data race of the TelemetryInstances variable

### DIFF
--- a/config/clients/go/template/telemetry/telemetry.mustache
+++ b/config/clients/go/template/telemetry/telemetry.mustache
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -42,6 +43,9 @@ type QueryDurationMetricParameters struct {
 type TelemetryContextKey struct{}
 
 var (
+	telemetryInstancesLock sync.Mutex
+	// Warning: do not use directly, it may cause data race.
+	// Deprecated: this map will be renamed to telemetryInstances.
 	TelemetryInstances map[*Configuration]*Telemetry
 	TelemetryContext   TelemetryContextKey
 )
@@ -64,6 +68,9 @@ func Get(factory TelemetryFactoryParameters) *Telemetry {
 	if configuration == nil {
 		configuration = DefaultTelemetryConfiguration()
 	}
+
+	telemetryInstancesLock.Lock()
+	defer telemetryInstancesLock.Unlock()
 
 	if TelemetryInstances == nil {
 		TelemetryInstances = make(map[*Configuration]*Telemetry)

--- a/config/clients/go/template/telemetry/telemetry_test.mustache
+++ b/config/clients/go/template/telemetry/telemetry_test.mustache
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 

--- a/config/clients/go/template/telemetry/telemetry_test.mustache
+++ b/config/clients/go/template/telemetry/telemetry_test.mustache
@@ -225,3 +225,24 @@ func TestBuildTelemetryAttributesMethod(t *testing.T) {
 		t.Fatalf("Expected requestDuration to be 100, but got %v", requestDuration)
 	}
 }
+
+// Run this test with the "-race" flag.
+//
+//	go test -race -run ^TestGetRace$ github.com/openfga/go-sdk/telemetry
+func TestGetRace(t *testing.T) {
+	t.Parallel()
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			Get(TelemetryFactoryParameters{})
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

Fix the data race around the `telemetry.TelemetryInstances` variable.
`TelemetryInstances` should not be exported, but it cannot be renamed for backwards compatibility.

Before fix:

```shell
go test -race -run ^TestGetRace$ github.com/openfga/go-sdk/telemetry
```

Output:
```
==================
WARNING: DATA RACE
Read at 0x00000094a240 by goroutine 9:
  github.com/openfga/go-sdk/telemetry.Get()
      /go-sdk/telemetry/telemetry.go:75 +0x47
  github.com/openfga/go-sdk/telemetry.TestGetRace.func1()
      /go-sdk/telemetry/telemetry_test.go:244 +0x73

Previous write at 0x00000094a240 by goroutine 11:
  github.com/openfga/go-sdk/telemetry.Get()
      /go-sdk/telemetry/telemetry.go:76 +0x67
  github.com/openfga/go-sdk/telemetry.TestGetRace.func1()
      /go-sdk/telemetry/telemetry_test.go:244 +0x73
```


## References

- Example in the [go-sdk](https://github.com/openfga/go-sdk/pull/134) package.

<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
