### PR TITLE
fix(python): correct usage of the sdk method header

### DIFF
--- a/config/clients/python/template/src/client/client.py.mustache
+++ b/config/clients/python/template/src/client/client.py.mustache
@@ -193,7 +193,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
         # convert options to kwargs
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListStores")
         kwargs = options_to_kwargs(options)
         api_response = {{#asyncio}}await {{/asyncio}}self._api.list_stores(
             **kwargs,
@@ -208,7 +207,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "CreateStore")
         kwargs = options_to_kwargs(options)
         api_response = {{#asyncio}}await {{/asyncio}}self._api.create_store(
            body,
@@ -224,7 +222,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "GetStore")
         kwargs = options_to_kwargs(options)
         api_response = {{#asyncio}}await {{/asyncio}}self._api.get_store(
             **kwargs,
@@ -239,7 +236,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "DeleteStore")
         kwargs = options_to_kwargs(options)
         api_response = {{#asyncio}}await {{/asyncio}}self._api.delete_store(
             **kwargs,
@@ -258,7 +254,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadAuthorizationModels")
         kwargs = options_to_kwargs(options)
         api_response = {{#asyncio}}await {{/asyncio}}self._api.read_authorization_models(
             **kwargs,
@@ -274,7 +269,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "WriteAuthorizationModel")
         kwargs = options_to_kwargs(options)
         api_response = {{#asyncio}}await {{/asyncio}}self._api.write_authorization_model(
             body,
@@ -290,7 +284,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadAuthorizationModel")
         kwargs = options_to_kwargs(options)
         authorization_model_id=self._get_authorization_model_id(options)
         api_response = {{#asyncio}}await {{/asyncio}}self._api.read_authorization_model(
@@ -307,7 +300,7 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthoriationModel")
+        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel")
         options["page_size"] = 1
         api_response = {{#asyncio}}await {{/asyncio}}self.read_authorization_models(options)
         return ReadAuthorizationModelResponse(api_response.authorization_models[0])
@@ -327,7 +320,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadChanges")
         kwargs = options_to_kwargs(options)
         kwargs["type"] = body.type
         api_response = {{#asyncio}}await {{/asyncio}}self._api.read_changes(
@@ -347,7 +339,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Read")
         page_size = None
         continuation_token = None
         if options:
@@ -449,7 +440,7 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Writes")
+        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Write")
         transaction = options_to_transaction_info(options)
         if not transaction.disabled:
             results = {{#asyncio}}await {{/asyncio}}self._write_with_transaction(body, options)
@@ -506,8 +497,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Check")
-
         kwargs = options_to_kwargs(options)
 
         req_body = CheckRequest(
@@ -594,7 +583,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Expand")
         kwargs = options_to_kwargs(options)
 
         req_body = ExpandRequest(
@@ -622,7 +610,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListObjects")
         kwargs = options_to_kwargs(options)
 
         req_body = ListObjectsRequest(
@@ -677,7 +664,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListUsers")
         kwargs = options_to_kwargs(options)
 
         req_body = ListUsersRequest(
@@ -711,7 +697,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadAssertions")
 
         kwargs = options_to_kwargs(options)
         authorization_model_id=self._get_authorization_model_id(options)
@@ -728,7 +713,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "WriteAssertions")
         kwargs = options_to_kwargs(options)
         authorization_model_id=self._get_authorization_model_id(options)
 

--- a/config/clients/python/template/src/sync/client/client.py.mustache
+++ b/config/clients/python/template/src/sync/client/client.py.mustache
@@ -179,7 +179,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
         # convert options to kwargs
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListStores")
         kwargs = options_to_kwargs(options)
         api_response = self._api.list_stores(
             **kwargs,
@@ -194,7 +193,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "CreateStore")
         kwargs = options_to_kwargs(options)
         api_response = self._api.create_store(
            body,
@@ -210,7 +208,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "GetStore")
         kwargs = options_to_kwargs(options)
         api_response = self._api.get_store(
             **kwargs,
@@ -225,7 +222,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "DeleteStore")
         kwargs = options_to_kwargs(options)
         api_response = self._api.delete_store(
             **kwargs,
@@ -244,7 +240,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadAuthorizationModels")
         kwargs = options_to_kwargs(options)
         api_response = self._api.read_authorization_models(
             **kwargs,
@@ -260,7 +255,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "WriteAuthorizationModel")
         kwargs = options_to_kwargs(options)
         api_response = self._api.write_authorization_model(
             body,
@@ -276,7 +270,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadAuthorizationModel")
         kwargs = options_to_kwargs(options)
         authorization_model_id=self._get_authorization_model_id(options)
         api_response = self._api.read_authorization_model(
@@ -293,7 +286,7 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthoriationModel")
+        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel")
         options["page_size"] = 1
         api_response = self.read_authorization_models(options)
         return ReadAuthorizationModelResponse(api_response.authorization_models[0])
@@ -313,7 +306,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadChanges")
         kwargs = options_to_kwargs(options)
         kwargs["type"] = body.type
         api_response = self._api.read_changes(
@@ -333,7 +325,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Read")
         page_size = None
         continuation_token = None
         if options:
@@ -486,8 +477,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Check")
-
         kwargs = options_to_kwargs(options)
 
         req_body = CheckRequest(
@@ -565,7 +554,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Expand")
         kwargs = options_to_kwargs(options)
 
         req_body = ExpandRequest(
@@ -593,7 +581,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListObjects")
         kwargs = options_to_kwargs(options)
 
         req_body = ListObjectsRequest(
@@ -647,7 +634,6 @@ class OpenFgaClient:
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListUsers")
         kwargs = options_to_kwargs(options)
 
         req_body = ListUsersRequest(
@@ -682,7 +668,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadAssertions")
 
         kwargs = options_to_kwargs(options)
         authorization_model_id=self._get_authorization_model_id(options)
@@ -699,7 +684,6 @@ class OpenFgaClient:
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "WriteAssertions")
         kwargs = options_to_kwargs(options)
         authorization_model_id=self._get_authorization_model_id(options)
 


### PR DESCRIPTION
## Description

Currently the Python SDK is sending the sdk method header for all requests, the expectation (and behaviour in other SDKs) for this header is that it is only sent for SDK methods that are wrappers of APIs as the intent is to provide a way for implementors of OpenFGA to track usage of these SDK wrapper methods.

So it should be sent for:

- `read_latest_authorization_model`
- `write`
  - Should also send `CLIENT_BULK_REQUEST_ID_HEADER` when not in transaction mode
- `write_tuples`
  - Should also send `CLIENT_BULK_REQUEST_ID_HEADER` when not in transaction mode (handled via `write`)
- `delete_tuples`
  - Should also send `CLIENT_BULK_REQUEST_ID_HEADER` when not in transaction mode (handled via `write`)
- `batch_check`
-   - Should also send `CLIENT_BULK_REQUEST_ID_HEADER`
- `list_relations`
  - Should also send `CLIENT_BULK_REQUEST_ID_HEADER` when not in transaction mode


## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
