### PR TITLE
Minor Python fixes

### DIFF
--- a/config/clients/python/template/example/example1/example1.py.mustache
+++ b/config/clients/python/template/example/example1/example1.py.mustache
@@ -16,6 +16,7 @@ from {{packageName}} import (
     TypeDefinition,
     Userset,
     Usersets,
+    UserTypeFilter,
     WriteAuthorizationModelRequest,
 )
 from {{packageName}}.client.models import (
@@ -306,16 +307,17 @@ async def main():
         # ListUsers
         print("Listing user who have access to object")
 
-        response = await fga_client.list_objects(
+        response = await fga_client.list_users(
             ClientListUsersRequest(
                 relation="viewer",
                 object=FgaObject(type="document", id="roadmap"),
                 user_filters=[
-                    FgaObject(type="user"),
+                    UserTypeFilter(type="user"),
                 ],
+                context=dict(ViewCount=100),
             )
         )
-        print(f"Users: {response.objects}")
+        print(f"Users: {response.users}")
 
         # WriteAssertions
         await fga_client.write_assertions(

--- a/config/clients/python/template/src/client/client.py.mustache
+++ b/config/clients/python/template/src/client/client.py.mustache
@@ -303,7 +303,8 @@ class OpenFgaClient:
         options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel")
         options["page_size"] = 1
         api_response = {{#asyncio}}await {{/asyncio}}self.read_authorization_models(options)
-        return ReadAuthorizationModelResponse(api_response.authorization_models[0])
+        model = api_response.authorization_models[0] if len(api_response.authorization_models) > 0 else None
+        return ReadAuthorizationModelResponse(model)
 
     #######################
     # Relationship Tuples

--- a/config/clients/python/template/src/client/client.py.mustache
+++ b/config/clients/python/template/src/client/client.py.mustache
@@ -683,9 +683,7 @@ class OpenFgaClient:
         )
 
         if body.contextual_tuples:
-            req_body.contextual_tuples = ContextualTupleKeys(
-                tuple_keys=convert_tuple_keys(body.contextual_tuples)
-            )
+            req_body.contextual_tuples = convert_tuple_keys(body.contextual_tuples)
 
         api_response = {{#asyncio}}await {{/asyncio}}self._api.list_users(body=req_body, **kwargs)
 

--- a/config/clients/python/template/src/sync/client/client.py.mustache
+++ b/config/clients/python/template/src/sync/client/client.py.mustache
@@ -289,7 +289,8 @@ class OpenFgaClient:
         options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel")
         options["page_size"] = 1
         api_response = self.read_authorization_models(options)
-        return ReadAuthorizationModelResponse(api_response.authorization_models[0])
+        model = api_response.authorization_models[0] if len(api_response.authorization_models) > 0 else None
+        return ReadAuthorizationModelResponse(model)
 
     #######################
     # Relationship Tuples

--- a/config/clients/python/template/src/sync/client/client.py.mustache
+++ b/config/clients/python/template/src/sync/client/client.py.mustache
@@ -653,9 +653,7 @@ class OpenFgaClient:
         )
 
         if body.contextual_tuples:
-            req_body.contextual_tuples = ContextualTupleKeys(
-                tuple_keys=convert_tuple_keys(body.contextual_tuples)
-            )
+            req_body.contextual_tuples = convert_tuple_keys(body.contextual_tuples)
 
         api_response = self._api.list_users(body=req_body, **kwargs)
 

--- a/config/clients/python/template/test/client/client_test.py.mustache
+++ b/config/clients/python/template/test/client/client_test.py.mustache
@@ -561,6 +561,39 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             )
 
 
+
+    @patch.object(rest.RESTClientObject, 'request')
+    {{#asyncio}}async {{/asyncio}}def test_read_latest_authorization_model_with_no_models(self, mock_request):
+        """Test case for read_latest_authorization_model when no models are in the store
+
+        Return the latest authorization models configured for the store
+        """
+        response_body = '''
+{
+  "authorization_models": []
+}
+        '''
+        mock_request.return_value = mock_response(response_body, 200)
+        configuration = self.configuration
+        configuration.store_id = store_id
+        # Enter a context with an instance of the API client
+        {{#asyncio}}async {{/asyncio}}with OpenFgaClient(configuration) as api_client:
+
+            # Return a particular version of an authorization model
+            api_response = {{#asyncio}}await {{/asyncio}}api_client.read_latest_authorization_model(
+                options={}
+            )
+            self.assertIsInstance(api_response, ReadAuthorizationModelResponse)
+            self.assertIsNone(api_response.authorization_model)
+            mock_request.assert_called_once_with(
+                'GET',
+                'http://api.{{sampleApiDomain}}/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models',
+                headers=ANY,
+                query_params=[('page_size', 1)],
+                _preload_content=ANY,
+                _request_timeout=None
+            )
+
     @patch.object(rest.RESTClientObject, 'request')
     {{#asyncio}}async {{/asyncio}}def test_read_changes(self, mock_request):
         """Test case for read_changes
@@ -2076,7 +2109,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                 relation="can_read",
                 user_filters=[
                     UserTypeFilter(type="user"),
-                    UserTypeFilter(type="team", relation="member"),
                 ],
                 context={},
                 contextual_tuples=[
@@ -2137,7 +2169,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     "relation": "can_read",
                     "user_filters": [
                         {"type": "user"},
-                        {"type": "team", "relation": "member"},
                     ],
                     "contextual_tuples": [
                         {

--- a/config/clients/python/template/test/client/client_test.py.mustache
+++ b/config/clients/python/template/test/client/client_test.py.mustache
@@ -2139,20 +2139,18 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                         {"type": "user"},
                         {"type": "team", "relation": "member"},
                     ],
-                    "contextual_tuples": {
-                        "tuple_keys": [
-                            {
-                                "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
-                                "relation": "editor",
-                                "object": "folder:product",
-                            },
-                            {
-                                "user": "folder:product",
-                                "relation": "parent",
-                                "object": "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
-                            },
-                        ]
-                    },
+                    "contextual_tuples": [
+                        {
+                            "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                            "relation": "editor",
+                            "object": "folder:product",
+                        },
+                        {
+                            "user": "folder:product",
+                            "relation": "parent",
+                            "object": "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+                        },
+                    ],
                     "context": {},
                     "consistency": "MINIMIZE_LATENCY",
                 },

--- a/config/clients/python/template/test/sync/client/client_test.py.mustache
+++ b/config/clients/python/template/test/sync/client/client_test.py.mustache
@@ -561,6 +561,38 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 
 
     @patch.object(rest.RESTClientObject, 'request')
+    def test_read_latest_authorization_model_with_no_models(self, mock_request):
+        """Test case for read_latest_authorization_model when no models are in the store
+
+        Return the latest authorization models configured for the store
+        """
+        response_body = '''
+{
+  "authorization_models": []
+}
+        '''
+        mock_request.return_value = mock_response(response_body, 200)
+        configuration = self.configuration
+        configuration.store_id = store_id
+        # Enter a context with an instance of the API client
+        with OpenFgaClient(configuration) as api_client:
+
+            # Return a particular version of an authorization model
+            api_response = api_client.read_latest_authorization_model(
+                options={}
+            )
+            self.assertIsInstance(api_response, ReadAuthorizationModelResponse)
+            self.assertIsNone(api_response.authorization_model)
+            mock_request.assert_called_once_with(
+                'GET',
+                'http://api.{{sampleApiDomain}}/stores/01YCP46JKYM8FJCQ37NMBYHE5X/authorization-models',
+                headers=ANY,
+                query_params=[('page_size', 1)],
+                _preload_content=ANY,
+                _request_timeout=None
+            )
+
+    @patch.object(rest.RESTClientObject, 'request')
     def test_read_changes(self, mock_request):
         """Test case for read_changes
 
@@ -2085,7 +2117,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             body.relation = "can_read"
             body.user_filters = [
                 UserTypeFilter(type="user"),
-                UserTypeFilter(type="team", relation="member"),
             ]
             body.context = {}
             body.contextual_tuples = [
@@ -2145,7 +2176,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                     "relation": "can_read",
                     "user_filters": [
                         {"type": "user"},
-                        {"type": "team", "relation": "member"},
                     ],
                     "contextual_tuples": [
                         {

--- a/config/clients/python/template/test/sync/client/client_test.py.mustache
+++ b/config/clients/python/template/test/sync/client/client_test.py.mustache
@@ -2147,20 +2147,18 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
                         {"type": "user"},
                         {"type": "team", "relation": "member"},
                     ],
-                    "contextual_tuples": {
-                        "tuple_keys": [
-                            {
-                                "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
-                                "relation": "editor",
-                                "object": "folder:product",
-                            },
-                            {
-                                "user": "folder:product",
-                                "relation": "parent",
-                                "object": "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
-                            },
-                        ]
-                    },
+                    "contextual_tuples": [
+                        {
+                            "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                            "relation": "editor",
+                            "object": "folder:product",
+                        },
+                        {
+                            "user": "folder:product",
+                            "relation": "parent",
+                            "object": "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+                        },
+                    ],
                     "context": {},
                     "consistency": "MINIMIZE_LATENCY",
                 },


### PR DESCRIPTION
## Description

This PR fixes some minor issues I noticed while updating the `openfga/api` sha on `main. Splitting out to a separate PR to help review.

They are as follows:

- the `ListUsers` API differs on the shape of `contextual_tuples`, rather than an object with a `tuple_keys` property it just takes the array directly. So we don't need the `ContextualTupleKeys` type
- `read_latest_authorization_model` errors if there are no models
- `list_users` in the example was using the wrong types

## References

https://github.com/openfga/python-sdk/pull/147

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
It differs from other endpoints in that it isn't an object but just an array directly