### PR TITLE
docs: add unreleased section to changelogs

### DIFF
--- a/config/clients/dotnet/CHANGELOG.md.mustache
+++ b/config/clients/dotnet/CHANGELOG.md.mustache
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased](https://github.com/openfga/dotnet-sdk/compare/v{{packageVersion}}...HEAD)
+
 ## v0.5.0
 
 ### [0.5.0](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.4.0...v0.5.0) (2024-08-28)

--- a/config/clients/go/CHANGELOG.md.mustache
+++ b/config/clients/go/CHANGELOG.md.mustache
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased](https://github.com/openfga/go-sdk/compare/v{{packageVersion}}...HEAD)
+
 ## v0.6.3
 
 ### [0.6.3](https://github.com/openfga/go-sdk/compare/v0.6.2...v0.6.3) (2024-10-22)

--- a/config/clients/java/CHANGELOG.md.mustache
+++ b/config/clients/java/CHANGELOG.md.mustache
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased](https://github.com/openfga/java-sdk/compare/v{{packageVersion}}...HEAD)
+
 ## v0.7.1
 
 ### [0.7.1](https://github.com/openfga/java-sdk/compare/v0.7.0...v0.7.1) (2024-09-23)

--- a/config/clients/js/CHANGELOG.md.mustache
+++ b/config/clients/js/CHANGELOG.md.mustache
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## [Unreleased](https://github.com/openfga/js-sdk/compare/v{{packageVersion}}...HEAD)
+
+fix: error correctly if apiUrl is not provided (#161)
+
 ## v0.7.0
 
 ### [0.7.0](https://github.com/openfga/js-sdk/compare/v0.6.3...v0.7.0) (2024-08-30)

--- a/config/clients/python/CHANGELOG.md.mustache
+++ b/config/clients/python/CHANGELOG.md.mustache
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased](https://github.com/openfga/python-sdk/compare/v{{packageVersion}}...HEAD)
+
+- feat: allow configuring the token endpoint (#137)
+- feat: add per-HTTP request counter metric (#135)
+- refactor: remove SDK version for OpenTelemetry meter name (#134)
+- fix: only send SDK method header from SDK wrapper methods (#142)
+- fix: unable to pass `retry_params` (#144)
+- fix: list users should send contextual tuples as a list (#147)
+- fix: handle no models existing in `read_latest_authorization_model` (#147)
+
 ## v0.7.2
 
 ### [0.7.2](https://github.com/openfga/python-sdk/compare/v0.7.1...v0.7.2) (2024-09-22)


### PR DESCRIPTION
## Description

This introduces an `unreleased` section to the changelog with the intention of tracking changes that are yet to be released in each SDK in an attempt to reduce the effort required to cut a new release.

It also add any unreleased changes to this header, it does not attempt to add any enforcement of this.

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
