### PR TITLE
fix(go-sdk): update client interface with store and model getter/setter

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -428,6 +428,27 @@ type SdkClient interface {
 	 * @return *ClientWriteAssertionsResponse
 	 */
 	WriteAssertionsExecute(request SdkClientWriteAssertionsRequestInterface) (*ClientWriteAssertionsResponse, error)
+
+	/*
+	 * SetAuthorizationModelId allows setting the Authorization Model ID for an OpenFGAClient.
+	 * @param string authorizationModelId - The Authorization Model ID to set.
+	 */
+	SetAuthorizationModelId(authorizationModelId string) error
+	/*
+	 * GetAuthorizationModelId retrieves the Authorization Model ID for an OpenFGAClient.
+	 * @return string
+	 */
+	GetAuthorizationModelId() (string, error)
+	/*
+	 * SetStoreId allows setting the Store ID for an OpenFGAClient.
+	 * @param string storeId - The Store ID to set.
+	 */
+	SetStoreId(storeId string) error
+	/*
+	 * GetStoreId retrieves the Store ID set in the OpenFGAClient.
+	 * @return string
+	 */
+	GetStoreId() (string, error)
 }
 
 func (client *OpenFgaClient) SetAuthorizationModelId(authorizationModelId string) error {


### PR DESCRIPTION
## Description

Backports the change to add getter/setter methods to the `SdkClient` interface

## References

https://github.com/openfga/go-sdk/pull/155

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

