### PR TITLE
fix: use provided axios instance in credentials refresh

### DIFF
--- a/config/clients/js/CHANGELOG.md.mustache
+++ b/config/clients/js/CHANGELOG.md.mustache
@@ -4,6 +4,7 @@
 ## [Unreleased](https://github.com/openfga/js-sdk/compare/v{{packageVersion}}...HEAD)
 
 - fix: error correctly if apiUrl is not provided (#161)
+- fix: use provided axios instance in credentials refresh (#193)
 - feat: add support for `start_time` parameter in `ReadChanges` endpoint
 - BREAKING: As of this release, the min node version required by the SDK is now v16.15.0
 

--- a/config/clients/js/template/baseApi.mustache
+++ b/config/clients/js/template/baseApi.mustache
@@ -37,7 +37,7 @@ export class BaseAPI {
     }
     this.configuration.isValid();
 
-    this.credentials = Credentials.init(this.configuration);
+    this.credentials = Credentials.init(this.configuration, this.axios);
 
     if (!this.axios) {
       const httpAgent = new http.Agent({ keepAlive: true });

--- a/config/clients/js/template/credentials/credentials.ts.mustache
+++ b/config/clients/js/template/credentials/credentials.ts.mustache
@@ -15,8 +15,8 @@ export class Credentials {
   private accessToken?: string;
   private accessTokenExpiryDate?: Date;
 
-  public static init(configuration: { credentials: AuthCredentialsConfig, telemetry: TelemetryConfiguration, baseOptions?: any }): Credentials {
-    return new Credentials(configuration.credentials, globalAxios, configuration.telemetry, configuration.baseOptions);
+  public static init(configuration: { credentials: AuthCredentialsConfig, telemetry: TelemetryConfiguration, baseOptions?: any }, axios: AxiosInstance = globalAxios): Credentials {
+    return new Credentials(configuration.credentials, axios, configuration.telemetry, configuration.baseOptions);
   }
 
   public constructor(private authConfig: AuthCredentialsConfig, private axios: AxiosInstance = globalAxios, private telemetryConfig: TelemetryConfiguration, private baseOptions?: any) {
@@ -144,7 +144,7 @@ export class Credentials {
       }, {
         maxRetry: 3,
         minWaitInMs: 100,
-      }, globalAxios);
+      }, this.axios);
 
       const response = wrappedResponse?.response;
       if (response) {


### PR DESCRIPTION
## Description

Ports fix for using axios instance in credentials requests

## References

https://github.com/openfga/js-sdk/pull/193

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

