### PR TITLE
feat(java-sdk): Adjust sdk-generator to be compatible with java-sdk

### DIFF
--- a/config/clients/java/CHANGELOG.md.mustache
+++ b/config/clients/java/CHANGELOG.md.mustache
@@ -4,6 +4,12 @@
 
 - feat: add support for `start_time` parameter in `ReadChanges` endpoint
 
+## v0.7.2
+
+### [0.7.2](https://github.com/openfga/java-sdk/compare/v0.7.1...v0.7.2) (2024-12-18)
+
+- fix: Ensure executor is shutdown (#133)
+
 ## v0.7.1
 
 ### [0.7.1](https://github.com/openfga/java-sdk/compare/v0.7.0...v0.7.1) (2024-09-23)

--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -3,7 +3,7 @@
   "gitRepoId": "java-sdk",
   "artifactId": "openfga-sdk",
   "groupId": "dev.openfga",
-  "packageVersion": "0.7.1",
+  "packageVersion": "0.7.2",
   "apiPackage": "dev.openfga.sdk.api",
   "authPackage": "dev.openfga.sdk.api.auth",
   "clientPackage": "dev.openfga.sdk.api.client",

--- a/config/clients/java/template/build.gradle.mustache
+++ b/config/clients/java/template/build.gradle.mustache
@@ -61,8 +61,8 @@ ext {
     {{#swagger2AnnotationLibrary}}
     swagger_annotations_version = "2.2.9"
     {{/swagger2AnnotationLibrary}}
-    jackson_version = "2.17.2"
-    junit_version = "5.11.0"
+    jackson_version = "2.18.2"
+    junit_version = "5.11.4"
     {{#hasFormParamsInSpec}}
     httpmime_version = "4.5.13"
     {{/hasFormParamsInSpec}}
@@ -81,7 +81,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.6"
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.41.0")
+    implementation platform("io.opentelemetry:opentelemetry-bom:1.45.0")
     implementation "io.opentelemetry:opentelemetry-api"
     {{#hasFormParamsInSpec}}
     implementation "org.apache.httpcomponents:httpmime:$httpmime_version"
@@ -96,9 +96,9 @@ testing {
             dependencies {
                 implementation project()
                 implementation "org.junit.jupiter:junit-jupiter:$junit_version"
-                implementation "org.mockito:mockito-core:5.13.0"
+                implementation "org.mockito:mockito-core:5.14.2"
                 runtimeOnly "org.junit.platform:junit-platform-launcher"
-                implementation "org.wiremock:wiremock:3.9.1"
+                implementation "org.wiremock:wiremock:3.10.0"
 
                 // This test-only dependency is convenient but not widely used.
                 // Review project activity before updating the version here.
@@ -124,8 +124,8 @@ testing {
             dependencies {
                 implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
                 implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-                implementation "org.testcontainers:junit-jupiter:1.20.1"
-                implementation "org.testcontainers:openfga:1.20.1"
+                implementation "org.testcontainers:junit-jupiter:1.20.4"
+                implementation "org.testcontainers:openfga:1.20.4"
                 implementation project()
             }
 

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -607,7 +607,6 @@ public class OpenFgaClient {
         } catch (Exception e) {
             return CompletableFuture.failedFuture(e);
         } finally {
-            //dfsdfsd
             executor.shutdown();
         }
     }

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -606,6 +606,9 @@ public class OpenFgaClient {
             return CompletableFuture.completedFuture(new ArrayList<>(responses));
         } catch (Exception e) {
             return CompletableFuture.failedFuture(e);
+        } finally {
+            //dfsdfsd
+            executor.shutdown();
         }
     }
 

--- a/config/clients/java/template/client-OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClientTest.java.mustache
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -32,6 +34,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 /**
  * API tests for OpenFgaClient.
@@ -1693,6 +1696,41 @@ public class OpenFgaClientTest {
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .called(1);
         assertEquals(Boolean.TRUE, response.get(0).getAllowed());
+    }
+
+    @Test
+    public void shouldShutdownExecutorAfterBatchCheck() throws Exception {
+        // Given
+        ScheduledExecutorService mockExecutor = mock(ScheduledExecutorService.class);
+
+        try (MockedStatic<Executors> mockedExecutors = mockStatic(Executors.class)) {
+            mockedExecutors
+                    .when(() -> Executors.newScheduledThreadPool(anyInt()))
+                    .thenReturn(mockExecutor);
+
+            // mockExecutor needs to handle tasks submitted to it so latch can count down
+            doAnswer(invocation -> {
+                        Runnable task = invocation.getArgument(0);
+                        task.run();
+                        return null;
+                    })
+                    .when(mockExecutor)
+                    .execute(any(Runnable.class));
+
+            ClientCheckRequest request = new ClientCheckRequest()
+                    ._object(DEFAULT_OBJECT)
+                    .relation(DEFAULT_RELATION)
+                    .user(DEFAULT_USER);
+            ClientBatchCheckOptions options = new ClientBatchCheckOptions()
+                    .authorizationModelId(DEFAULT_AUTH_MODEL_ID)
+                    .consistency(ConsistencyPreference.MINIMIZE_LATENCY);
+
+            // When
+            fga.batchCheck(List.of(request), options).get();
+
+            // Then
+            verify(mockExecutor).shutdown();
+        }
     }
 
     @Test

--- a/config/clients/java/template/example/example1/build.gradle.mustache
+++ b/config/clients/java/template/example/example1/build.gradle.mustache
@@ -1,7 +1,7 @@
 plugins {
     id 'application'
     id 'com.diffplug.spotless' version '6.25.0'
-    id 'org.jetbrains.kotlin.jvm' version '2.0.20'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
 }
 
 application {
@@ -19,7 +19,7 @@ repositories {
 }
 
 ext {
-    jacksonVersion = "2.17.2"
+    jacksonVersion = "2.18.2"
 }
 
 dependencies {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
I started working on openfga/java-sdk#127, but I realized that the `java-sdk` repo contains manually changed files not generated through the `sdk-generator`. This leads me to first align the code between the `sdk-generator` and the `java-sdk`.

> [!TIP]
> I also believe that to prevent such modifications, all `*-sdk` repos should be set to read-only mode. As outlined in the contribution guides, all changes should be made thought the `sdk-generator`. As a very fist step, a GitHub Workflow could be introduced to manually generate SDKs.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

