### PR TITLE
feat(java-sdk)!: support server-side batch check endpoint

### DIFF
--- a/config/clients/java/CHANGELOG.md.mustache
+++ b/config/clients/java/CHANGELOG.md.mustache
@@ -2,7 +2,12 @@
 
 ## [Unreleased](https://github.com/openfga/java-sdk/compare/v{{packageVersion}}...HEAD)
 
+- feat!: add support for server-side `BatchCheck` method
 - feat: add support for `start_time` parameter in `ReadChanges` endpoint
+
+BREAKING CHANGES:
+
+- Usage of the existing `batchCheck` method should now use the `clientBatchCheck` method.
 
 ## v0.7.2
 

--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -49,8 +49,24 @@
       "destinationFilename": "src/main/java/dev/openfga/sdk/api/client/ClientAssertion.java",
       "templateType": "SupportingFiles"
     },
+    "client-ClientBatchCheckClientResponse.java.mustache": {
+      "destinationFilename": "src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckClientResponse.java",
+      "templateType": "SupportingFiles"
+    },
+    "client-ClientBatchCheckItem.java.mustache": {
+      "destinationFilename": "src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckItem.java",
+      "templateType": "SupportingFiles"
+    },
+    "client-ClientBatchCheckRequest.java.mustache": {
+      "destinationFilename": "src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckRequest.java",
+      "templateType": "SupportingFiles"
+    },
     "client-ClientBatchCheckResponse.java.mustache": {
       "destinationFilename": "src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckResponse.java",
+      "templateType": "SupportingFiles"
+    },
+    "client-ClientBatchCheckSingleResponse.java.mustache": {
+      "destinationFilename": "src/main/java/dev/openfga/sdk/api/client/model/ClientBatchCheckSingleResponse.java",
       "templateType": "SupportingFiles"
     },
     "client-ClientCheckRequest.java.mustache": {
@@ -221,8 +237,12 @@
       "destinationFilename": "src/main/java/dev/openfga/sdk/api/configuration/BaseConfiguration.java",
       "templateType": "SupportingFiles"
     },
-    "config-ClientBatchCheckOptions.java.mustache": {
-      "destinationFilename": "src/main/java/dev/openfga/sdk/api/configuration/ClientBatchCheckOptions.java",
+    "config-ClientBatchCheckClientRequestOptions.java.mustache": {
+      "destinationFilename": "src/main/java/dev/openfga/sdk/api/configuration/ClientBatchCheckClientRequestOptions.java",
+      "templateType": "SupportingFiles"
+    },
+    "config-ClientBatchCheckRequestOptions.java.mustache": {
+      "destinationFilename": "src/main/java/dev/openfga/sdk/api/configuration/ClientBatchCheckRequestOptions.java",
       "templateType": "SupportingFiles"
     },
     "config-ClientCheckOptions.java.mustache": {
@@ -371,6 +391,10 @@
     },
     "errors-FgaInvalidParameterException.java.mustache": {
       "destinationFilename": "src/main/java/dev/openfga/sdk/errors/FgaInvalidParameterException.java",
+      "templateType": "SupportingFiles"
+    },
+    "errors-FgaValidationError.java.mustache": {
+      "destinationFilename": "src/main/java/dev/openfga/sdk/errors/FgaValidationError.java",
       "templateType": "SupportingFiles"
     },
     "errors-HttpStatusCode.java.mustache": {

--- a/config/clients/java/template/README_calling_api.mustache
+++ b/config/clients/java/template/README_calling_api.mustache
@@ -359,7 +359,7 @@ var response = fgaClient.check(request, options).get();
 Run a set of [checks](#check). Batch Check will return `allowed: false` if it encounters an error, and will return the error in the body.
 If 429s or 5xxs are encountered, the underlying check will retry up to {{defaultMaxRetry}} times before giving up.
 
-> Passing `ClientBatchCheckOptions` is optional. All fields of `ClientBatchCheckOptions` are optional.
+> Passing `ClientBatchCheckClientRequestOptions` is optional. All fields of `ClientBatchCheckClientRequestOptions` are optional.
 
 ```java
 var request = List.of(
@@ -392,7 +392,7 @@ var request = List.of(
         .relation("deleter")
         ._object("document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a")
 );
-var options = new ClientBatchCheckOptions()
+var options = new ClientBatchCheckClientRequestOptions()
     .additionalHeaders(Map.of("Some-Http-Header", "Some value"))
     // You can rely on the model id set in the configuration or override it for this specific request
     .authorizationModelId("01GXSA8YR785C4FYS3C0RTG7B1")

--- a/config/clients/java/template/client-ClientBatchCheckClientResponse.java.mustache
+++ b/config/clients/java/template/client-ClientBatchCheckClientResponse.java.mustache
@@ -1,0 +1,92 @@
+{{>licenseInfo}}
+package {{clientPackage}}.model;
+
+import {{modelPackage}}.CheckResponse;
+import {{errorsPackage}}.FgaError;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public class ClientBatchCheckClientResponse extends CheckResponse {
+    private final ClientCheckRequest request;
+    private final Throwable throwable;
+    private final Integer statusCode;
+    private final Map<String, List<String>> headers;
+    private final String rawResponse;
+
+    public ClientBatchCheckClientResponse(
+            ClientCheckRequest request, ClientCheckResponse clientCheckResponse, Throwable throwable) {
+        this.request = request;
+        this.throwable = throwable;
+
+        if (clientCheckResponse != null) {
+            this.statusCode = clientCheckResponse.getStatusCode();
+            this.headers = clientCheckResponse.getHeaders();
+            this.rawResponse = clientCheckResponse.getRawResponse();
+            this.setAllowed(clientCheckResponse.getAllowed());
+            this.setResolution(clientCheckResponse.getResolution());
+        } else if (throwable instanceof FgaError) {
+            FgaError error = (FgaError) throwable;
+            this.statusCode = error.getStatusCode();
+            this.headers = error.getResponseHeaders().map();
+            this.rawResponse = error.getResponseData();
+        } else {
+            // Should be unreachable, but required for type completion
+            this.statusCode = null;
+            this.headers = null;
+            this.rawResponse = null;
+        }
+    }
+
+    public ClientCheckRequest getRequest() {
+        return request;
+    }
+
+    /**
+     * Returns the result of the check.
+     * <p>
+     * If the HTTP request was unsuccessful, this result will be null. If this is the case, you can examine the
+     * original request with {@link ClientBatchCheckClientResponse#getRequest()} and the exception with
+     * {@link ClientBatchCheckClientResponse#getThrowable()}.
+     *
+     * @return the check result. Is null if the HTTP request was unsuccessful.
+     */
+    @Override
+    public Boolean getAllowed() {
+        return super.getAllowed();
+    }
+
+    /**
+     * Returns the caught exception if the HTTP request was unsuccessful.
+     * <p>
+     * If the HTTP request was unsuccessful, this result will be null. If this is the case, you can examine the
+     * original request with {@link ClientBatchCheckClientResponse#getRequest()} and the exception with
+     * {@link ClientBatchCheckClientResponse#getThrowable()}.
+     *
+     * @return the caught exception. Is null if the HTTP request was successful.
+     */
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public String getRawResponse() {
+        return rawResponse;
+    }
+
+    public String getRelation() {
+        return request == null ? null : request.getRelation();
+    }
+
+    public static BiFunction<ClientCheckResponse, Throwable, ClientBatchCheckClientResponse> asyncHandler(
+            ClientCheckRequest request) {
+        return (response, throwable) -> new ClientBatchCheckClientResponse(request, response, throwable);
+    }
+}

--- a/config/clients/java/template/client-ClientBatchCheckItem.java.mustache
+++ b/config/clients/java/template/client-ClientBatchCheckItem.java.mustache
@@ -1,0 +1,67 @@
+{{>licenseInfo}}
+package {{invokerPackage}}.model;
+
+import java.util.List;
+
+public class ClientBatchCheckItem {
+    private String user;
+    private String relation;
+    private String _object;
+    private List<ClientTupleKey> contextualTuples;
+    private Object context;
+    private String correlationId;
+
+    public ClientBatchCheckItem user(String user) {
+        this.user = user;
+        return this;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public ClientBatchCheckItem relation(String relation) {
+        this.relation = relation;
+        return this;
+    }
+
+    public String getRelation() {
+        return relation;
+    }
+
+    public ClientBatchCheckItem _object(String _object) {
+        this._object = _object;
+        return this;
+    }
+
+    public String getObject() {
+        return _object;
+    }
+
+    public ClientBatchCheckItem contextualTuples(List<ClientTupleKey> contextualTuples) {
+        this.contextualTuples = contextualTuples;
+        return this;
+    }
+
+    public List<ClientTupleKey> getContextualTuples() {
+        return contextualTuples;
+    }
+
+    public ClientBatchCheckItem context(Object context) {
+        this.context = context;
+        return this;
+    }
+
+    public Object getContext() {
+        return context;
+    }
+
+    public ClientBatchCheckItem correlationId(String correlationId) {
+        this.correlationId = correlationId;
+        return this;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+}

--- a/config/clients/java/template/client-ClientBatchCheckRequest.java.mustache
+++ b/config/clients/java/template/client-ClientBatchCheckRequest.java.mustache
@@ -1,0 +1,21 @@
+{{>licenseInfo}}
+package {{invokerPackage}}.model;
+
+import java.util.List;
+
+public class ClientBatchCheckRequest {
+    private List<ClientBatchCheckItem> checks;
+
+    public static ClientBatchCheckRequest ofChecks(List<ClientBatchCheckItem> checks) {
+        return new ClientBatchCheckRequest().checks(checks);
+    }
+
+    public ClientBatchCheckRequest checks(List<ClientBatchCheckItem> checks) {
+        this.checks = checks;
+        return this;
+    }
+
+    public List<ClientBatchCheckItem> getChecks() {
+        return checks;
+    }
+}

--- a/config/clients/java/template/client-ClientBatchCheckResponse.java.mustache
+++ b/config/clients/java/template/client-ClientBatchCheckResponse.java.mustache
@@ -1,92 +1,16 @@
 {{>licenseInfo}}
 package {{clientPackage}}.model;
 
-import {{modelPackage}}.CheckResponse;
-import {{errorsPackage}}.FgaError;
 import java.util.List;
-import java.util.Map;
-import java.util.function.BiFunction;
 
-public class ClientBatchCheckResponse extends CheckResponse {
-    private final ClientCheckRequest request;
-    private final Throwable throwable;
-    private final Integer statusCode;
-    private final Map<String, List<String>> headers;
-    private final String rawResponse;
+public class ClientBatchCheckResponse {
+    private final List<ClientBatchCheckSingleResponse> result;
 
-    public ClientBatchCheckResponse(
-            ClientCheckRequest request, ClientCheckResponse clientCheckResponse, Throwable throwable) {
-        this.request = request;
-        this.throwable = throwable;
-
-        if (clientCheckResponse != null) {
-            this.statusCode = clientCheckResponse.getStatusCode();
-            this.headers = clientCheckResponse.getHeaders();
-            this.rawResponse = clientCheckResponse.getRawResponse();
-            this.setAllowed(clientCheckResponse.getAllowed());
-            this.setResolution(clientCheckResponse.getResolution());
-        } else if (throwable instanceof FgaError) {
-            FgaError error = (FgaError) throwable;
-            this.statusCode = error.getStatusCode();
-            this.headers = error.getResponseHeaders().map();
-            this.rawResponse = error.getResponseData();
-        } else {
-            // Should be unreachable, but required for type completion
-            this.statusCode = null;
-            this.headers = null;
-            this.rawResponse = null;
-        }
+    public ClientBatchCheckResponse(List<ClientBatchCheckSingleResponse> result) {
+        this.result = result;
     }
 
-    public ClientCheckRequest getRequest() {
-        return request;
-    }
-
-    /**
-     * Returns the result of the check.
-     * <p>
-     * If the HTTP request was unsuccessful, this result will be null. If this is the case, you can examine the
-     * original request with {@link ClientBatchCheckResponse#getRequest()} and the exception with
-     * {@link ClientBatchCheckResponse#getThrowable()}.
-     *
-     * @return the check result. Is null if the HTTP request was unsuccessful.
-     */
-    @Override
-    public Boolean getAllowed() {
-        return super.getAllowed();
-    }
-
-    /**
-     * Returns the caught exception if the HTTP request was unsuccessful.
-     * <p>
-     * If the HTTP request was unsuccessful, this result will be null. If this is the case, you can examine the
-     * original request with {@link ClientBatchCheckResponse#getRequest()} and the exception with
-     * {@link ClientBatchCheckResponse#getThrowable()}.
-     *
-     * @return the caught exception. Is null if the HTTP request was successful.
-     */
-    public Throwable getThrowable() {
-        return throwable;
-    }
-
-    public int getStatusCode() {
-        return statusCode;
-    }
-
-    public Map<String, List<String>> getHeaders() {
-        return headers;
-    }
-
-    public String getRawResponse() {
-        return rawResponse;
-    }
-
-    public String getRelation() {
-        return request == null ? null : request.getRelation();
-    }
-
-    public static BiFunction<ClientCheckResponse, Throwable, ClientBatchCheckResponse> asyncHandler(
-            ClientCheckRequest request) {
-        return (response, throwable) -> new ClientBatchCheckResponse(request, response, throwable);
+    public List<ClientBatchCheckSingleResponse> getResult() {
+        return result;
     }
 }

--- a/config/clients/java/template/client-ClientBatchCheckSingleResponse.java.mustache
+++ b/config/clients/java/template/client-ClientBatchCheckSingleResponse.java.mustache
@@ -1,0 +1,34 @@
+{{>licenseInfo}}
+package {{clientPackage}}.model;
+
+import dev.openfga.sdk.api.model.CheckError;
+
+public class ClientBatchCheckSingleResponse {
+    private final boolean allowed;
+    private final ClientBatchCheckItem request;
+    private final String correlationId;
+    private final CheckError error;
+
+    public ClientBatchCheckSingleResponse(boolean allowed, ClientBatchCheckItem request, String correlationId, CheckError error) {
+        this.allowed = allowed;
+        this.request = request;
+        this.correlationId = correlationId;
+        this.error = error;
+    }
+
+    public boolean isAllowed() {
+        return allowed;
+    }
+
+    public ClientBatchCheckItem getRequest() {
+        return request;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public CheckError getError() {
+        return error;
+    }
+}

--- a/config/clients/java/template/client-ClientListRelationsResponse.java.mustache
+++ b/config/clients/java/template/client-ClientListRelationsResponse.java.mustache
@@ -15,7 +15,7 @@ public class ClientListRelationsResponse {
         return relations;
     }
 
-    public static ClientListRelationsResponse fromBatchCheckResponses(List<ClientBatchCheckResponse> responses)
+    public static ClientListRelationsResponse fromBatchCheckResponses(List<ClientBatchCheckClientResponse> responses)
             throws Throwable {
         // If any response ultimately failed (with retries) we throw the first exception encountered.
         var failedResponse = responses.stream()
@@ -26,8 +26,8 @@ public class ClientListRelationsResponse {
         }
 
         var relations = responses.stream()
-                .filter(ClientBatchCheckResponse::getAllowed)
-                .map(ClientBatchCheckResponse::getRelation)
+                .filter(ClientBatchCheckClientResponse::getAllowed)
+                .map(ClientBatchCheckClientResponse::getRelation)
                 .collect(Collectors.toList());
         return new ClientListRelationsResponse(relations);
     }

--- a/config/clients/java/template/client-OpenFgaClient.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClient.java.mustache
@@ -12,9 +12,11 @@ import {{errorsPackage}}.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class OpenFgaClient {
@@ -25,6 +27,7 @@ public class OpenFgaClient {
     private static final String CLIENT_BULK_REQUEST_ID_HEADER = "{{clientBulkRequestIdHeader}}";
     private static final String CLIENT_METHOD_HEADER = "{{clientMethodHeader}}";
     private static final int DEFAULT_MAX_METHOD_PARALLEL_REQS = {{clientMaxMethodParallelRequests}};
+    private static final int DEFAULT_MAX_BATCH_SIZE = 50;
 
    public OpenFgaClient(ClientConfiguration configuration) throws FgaInvalidParameterException {
         this(configuration, new ApiClient());
@@ -558,9 +561,9 @@ public class OpenFgaClient {
      *
      * @throws FgaInvalidParameterException When the Store ID is null, empty, or whitespace
      */
-    public CompletableFuture<List<ClientBatchCheckResponse>> batchCheck(List<ClientCheckRequest> requests)
+    public CompletableFuture<List<ClientBatchCheckClientResponse>> clientBatchCheck(List<ClientCheckRequest> requests)
             throws FgaInvalidParameterException {
-        return batchCheck(requests, null);
+        return clientBatchCheck(requests, null);
     }
 
     /**
@@ -568,19 +571,19 @@ public class OpenFgaClient {
      *
      * @throws FgaInvalidParameterException When the Store ID is null, empty, or whitespace
      */
-    public CompletableFuture<List<ClientBatchCheckResponse>> batchCheck(
-            List<ClientCheckRequest> requests, ClientBatchCheckOptions batchCheckOptions)
+    public CompletableFuture<List<ClientBatchCheckClientResponse>> clientBatchCheck(
+            List<ClientCheckRequest> requests, ClientBatchCheckClientRequestOptions batchCheckOptions)
             throws FgaInvalidParameterException {
         configuration.assertValid();
         configuration.assertValidStoreId();
 
         var options = batchCheckOptions != null
                 ? batchCheckOptions
-                : new ClientBatchCheckOptions().maxParallelRequests(DEFAULT_MAX_METHOD_PARALLEL_REQS);
+                : new ClientBatchCheckClientRequestOptions().maxParallelRequests(DEFAULT_MAX_METHOD_PARALLEL_REQS);
         if (options.getAdditionalHeaders() == null) {
             options.additionalHeaders(new HashMap<>());
         }
-        options.getAdditionalHeaders().putIfAbsent(CLIENT_METHOD_HEADER, "BatchCheck");
+        options.getAdditionalHeaders().putIfAbsent(CLIENT_METHOD_HEADER, "ClientBatchCheck");
         options.getAdditionalHeaders()
                 .putIfAbsent(CLIENT_BULK_REQUEST_ID_HEADER, randomUUID().toString());
 
@@ -590,13 +593,13 @@ public class OpenFgaClient {
         var executor = Executors.newScheduledThreadPool(maxParallelRequests);
         var latch = new CountDownLatch(requests.size());
 
-        var responses = new ConcurrentLinkedQueue<ClientBatchCheckResponse>();
+        var responses = new ConcurrentLinkedQueue<ClientBatchCheckClientResponse>();
 
         final var clientCheckOptions = options.asClientCheckOptions();
 
         Consumer<ClientCheckRequest> singleClientCheckRequest =
                 request -> call(() -> this.check(request, clientCheckOptions))
-                        .handleAsync(ClientBatchCheckResponse.asyncHandler(request))
+                        .handleAsync(ClientBatchCheckClientResponse.asyncHandler(request))
                         .thenAccept(responses::add)
                         .thenRun(latch::countDown);
 
@@ -604,6 +607,116 @@ public class OpenFgaClient {
             requests.forEach(request -> executor.execute(() -> singleClientCheckRequest.accept(request)));
             latch.await();
             return CompletableFuture.completedFuture(new ArrayList<>(responses));
+        } catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * BatchCheck - Run a set of checks (evaluates)
+     *
+     * @throws FgaInvalidParameterException When the Store ID is null, empty, or whitespace
+     */
+    public CompletableFuture<ClientBatchCheckResponse> batchCheck(ClientBatchCheckRequest request)
+            throws FgaInvalidParameterException, FgaValidationError {
+        return batchCheck(request, null);
+    }
+
+    /**
+     * BatchCheck - Run a set of checks (evaluates)
+     *
+     * @throws FgaInvalidParameterException When the Store ID is null, empty, or whitespace
+     */
+    public CompletableFuture<ClientBatchCheckResponse> batchCheck(
+            ClientBatchCheckRequest requests, ClientBatchCheckRequestOptions batchCheckOptions)
+            throws FgaInvalidParameterException, FgaValidationError {
+        configuration.assertValid();
+        configuration.assertValidStoreId();
+
+        var options = batchCheckOptions != null
+                ? batchCheckOptions
+                : new ClientBatchCheckRequestOptions()
+                        .maxParallelRequests(DEFAULT_MAX_METHOD_PARALLEL_REQS)
+                        .maxBatchSize(DEFAULT_MAX_BATCH_SIZE);
+        if (options.getAdditionalHeaders() == null) {
+            options.additionalHeaders(new HashMap<>());
+        }
+        options.getAdditionalHeaders().putIfAbsent(CLIENT_METHOD_HEADER, "BatchCheck");
+        options.getAdditionalHeaders()
+                .putIfAbsent(CLIENT_BULK_REQUEST_ID_HEADER, randomUUID().toString());
+
+        Map<String, ClientBatchCheckItem> correlationIdToCheck = new HashMap<>();
+
+        List<BatchCheckItem> collect = new ArrayList<>();
+        for (ClientBatchCheckItem check : requests.getChecks()) {
+            String correlationId = check.getCorrelationId();
+            correlationId = correlationId == null || correlationId.isBlank()
+                    ? randomUUID().toString()
+                    : correlationId;
+
+            BatchCheckItem batchCheckItem = new BatchCheckItem()
+                    .tupleKey(new CheckRequestTupleKey()
+                            .user(check.getUser())
+                            .relation(check.getRelation())
+                            ._object(check.getObject()))
+                    .context(check.getContext())
+                    .correlationId(correlationId);
+
+            List<ClientTupleKey> contextualTuples = check.getContextualTuples();
+            if (contextualTuples != null && !contextualTuples.isEmpty()) {
+                batchCheckItem.contextualTuples(ClientTupleKey.asContextualTupleKeys(contextualTuples));
+            }
+
+            collect.add(batchCheckItem);
+
+            if (correlationIdToCheck.containsKey(correlationId)) {
+                throw new FgaValidationError("correlationId", "When calling batchCheck, correlation IDs must be unique");
+            }
+
+            correlationIdToCheck.put(correlationId, check);
+        }
+
+        int maxBatchSize = options.getMaxBatchSize() != null ? options.getMaxBatchSize() : DEFAULT_MAX_BATCH_SIZE;
+        List<List<BatchCheckItem>> batchedChecks = IntStream.range(
+                        0, (collect.size() + maxBatchSize - 1) / maxBatchSize)
+                .mapToObj(i -> collect.subList(i * maxBatchSize, Math.min((i + 1) * maxBatchSize, collect.size())))
+                .collect(Collectors.toList());
+
+        int maxParallelRequests = options.getMaxParallelRequests() != null
+                ? options.getMaxParallelRequests()
+                : DEFAULT_MAX_METHOD_PARALLEL_REQS;
+        var executor = Executors.newScheduledThreadPool(maxParallelRequests);
+        var latch = new CountDownLatch(batchedChecks.size());
+
+        var responses = new ConcurrentLinkedQueue<ClientBatchCheckSingleResponse>();
+
+        var override = new ConfigurationOverride().addHeaders(options);
+
+        Consumer<List<BatchCheckItem>> singleBatchCheckRequest = request -> call(() ->
+                        api.batchCheck(configuration.getStoreId(), new BatchCheckRequest().checks(request), override))
+                .handleAsync((batchCheckResponseApiResponse, throwable) -> {
+                    Map<String, BatchCheckSingleResult> response =
+                            batchCheckResponseApiResponse.getData().getResult();
+
+                    List<ClientBatchCheckSingleResponse> batchResults = new ArrayList<>();
+                    response.forEach((key, result) -> {
+                        boolean allowed = Boolean.TRUE.equals(result.getAllowed());
+                        ClientBatchCheckItem checkItem = correlationIdToCheck.get(key);
+                        var singleResponse =
+                                new ClientBatchCheckSingleResponse(allowed, checkItem, key, result.getError());
+                        batchResults.add(singleResponse);
+                    });
+                    return batchResults;
+                })
+                .thenAccept(responses::addAll)
+                .thenRun(latch::countDown);
+
+        try {
+            batchedChecks.forEach(batch -> executor.execute(() -> singleBatchCheckRequest.accept(batch)));
+            latch.await();
+            return CompletableFuture.completedFuture(new ClientBatchCheckResponse(new ArrayList<>(responses)));
         } catch (Exception e) {
             return CompletableFuture.failedFuture(e);
         } finally {
@@ -748,7 +861,7 @@ public class OpenFgaClient {
                         .context(request.getContext()))
                 .collect(Collectors.toList());
 
-        return this.batchCheck(batchCheckRequests, options.asClientBatchCheckOptions())
+        return this.clientBatchCheck(batchCheckRequests, options.asClientBatchCheckClientRequestOptions())
                 .thenCompose(responses -> call(() -> ClientListRelationsResponse.fromBatchCheckResponses(responses)));
     }
 

--- a/config/clients/java/template/client-OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/client-OpenFgaClientTest.java.mustache
@@ -35,10 +35,16 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 
 /**
  * API tests for OpenFgaClient.
  */
+@WireMockTest
 public class OpenFgaClientTest {
     private static final String DEFAULT_STORE_ID = "01YCP46JKYM8FJCQ37NMBYHE5X";
     private static final String DEFAULT_STORE_NAME = "test_store";
@@ -1663,7 +1669,7 @@ public class OpenFgaClientTest {
      * Check whether a user is authorized to access an object.
      */
     @Test
-    public void batchCheck() throws Exception {
+    public void clientBatchCheck() throws Exception {
         // Given
         String postUrl = String.format("https://api.fga.example/stores/%s/check", DEFAULT_STORE_ID);
         String expectedBody = String.format(
@@ -1672,27 +1678,27 @@ public class OpenFgaClientTest {
         mockHttpClient
                 .onPost(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .doReturn(200, "{\"allowed\":true}");
         ClientCheckRequest request = new ClientCheckRequest()
                 ._object(DEFAULT_OBJECT)
                 .relation(DEFAULT_RELATION)
                 .user(DEFAULT_USER);
-        ClientBatchCheckOptions options = new ClientBatchCheckOptions()
+        ClientBatchCheckClientRequestOptions options = new ClientBatchCheckClientRequestOptions()
                 .authorizationModelId(DEFAULT_AUTH_MODEL_ID)
                 .consistency(ConsistencyPreference.MINIMIZE_LATENCY);
 
         // When
-        List<ClientBatchCheckResponse> response =
-                fga.batchCheck(List.of(request), options).get();
+        List<ClientBatchCheckClientResponse> response =
+                fga.clientBatchCheck(List.of(request), options).get();
 
         // Then
         mockHttpClient
                 .verify()
                 .post(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .called(1);
         assertEquals(Boolean.TRUE, response.get(0).getAllowed());
@@ -1721,12 +1727,12 @@ public class OpenFgaClientTest {
                     ._object(DEFAULT_OBJECT)
                     .relation(DEFAULT_RELATION)
                     .user(DEFAULT_USER);
-            ClientBatchCheckOptions options = new ClientBatchCheckOptions()
+            ClientBatchCheckClientRequestOptions options = new ClientBatchCheckClientRequestOptions()
                     .authorizationModelId(DEFAULT_AUTH_MODEL_ID)
                     .consistency(ConsistencyPreference.MINIMIZE_LATENCY);
 
             // When
-            fga.batchCheck(List.of(request), options).get();
+            fga.clientBatchCheck(List.of(request), options).get();
 
             // Then
             verify(mockExecutor).shutdown();
@@ -1734,7 +1740,7 @@ public class OpenFgaClientTest {
     }
 
     @Test
-    public void batchCheck_twentyTimes() throws Exception {
+    public void clientBatchCheck_twentyTimes() throws Exception {
         // Given
         String postUrl = String.format("https://api.fga.example/stores/%s/check", DEFAULT_STORE_ID);
         String expectedBody = String.format(
@@ -1743,7 +1749,7 @@ public class OpenFgaClientTest {
         mockHttpClient
                 .onPost(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .doReturn(200, "{\"allowed\":true}");
         List<ClientCheckRequest> requests = IntStream.range(0, 20)
@@ -1752,29 +1758,29 @@ public class OpenFgaClientTest {
                         .relation(DEFAULT_RELATION)
                         .user(DEFAULT_USER))
                 .collect(Collectors.toList());
-        ClientBatchCheckOptions options = new ClientBatchCheckOptions().authorizationModelId(DEFAULT_AUTH_MODEL_ID);
+        ClientBatchCheckClientRequestOptions options = new ClientBatchCheckClientRequestOptions().authorizationModelId(DEFAULT_AUTH_MODEL_ID);
 
         // When
-        fga.batchCheck(requests, options).get();
+        fga.clientBatchCheck(requests, options).get();
 
         // Then
         mockHttpClient
                 .verify()
                 .post(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .called(20);
     }
 
     @Test
-    public void batchCheck_storeIdRequired() {
+    public void clientBatchCheck_storeIdRequired() {
         // Given
         clientConfiguration.storeId(null);
 
         // When
-        var exception = assertThrows(FgaInvalidParameterException.class, () -> fga.batchCheck(
-                        List.of(new ClientCheckRequest()), new ClientBatchCheckOptions())
+        var exception = assertThrows(FgaInvalidParameterException.class, () -> fga.clientBatchCheck(
+                        List.of(new ClientCheckRequest()), new ClientBatchCheckClientRequestOptions())
                 .get());
 
         // Then
@@ -1783,7 +1789,7 @@ public class OpenFgaClientTest {
     }
 
     @Test
-    public void batchCheck_400() throws Exception {
+    public void clientBatchCheck_400() throws Exception {
         // Given
         String postUrl = String.format("https://api.fga.example/stores/%s/check", DEFAULT_STORE_ID);
         mockHttpClient
@@ -1791,8 +1797,8 @@ public class OpenFgaClientTest {
                 .doReturn(400, "{\"code\":\"validation_error\",\"message\":\"Generic validation error\"}");
 
         // When
-        List<ClientBatchCheckResponse> response = fga.batchCheck(
-                        List.of(new ClientCheckRequest()), new ClientBatchCheckOptions())
+        List<ClientBatchCheckClientResponse> response = fga.clientBatchCheck(
+                        List.of(new ClientCheckRequest()), new ClientBatchCheckClientRequestOptions())
                 .join();
 
         // Then
@@ -1809,7 +1815,7 @@ public class OpenFgaClientTest {
     }
 
     @Test
-    public void batchCheck_404() throws Exception {
+    public void clientBatchCheck_404() throws Exception {
         // Given
         String postUrl = String.format("https://api.fga.example/stores/%s/check", DEFAULT_STORE_ID);
         mockHttpClient
@@ -1817,8 +1823,8 @@ public class OpenFgaClientTest {
                 .doReturn(404, "{\"code\":\"undefined_endpoint\",\"message\":\"Endpoint not enabled\"}");
 
         // When
-        List<ClientBatchCheckResponse> response = fga.batchCheck(
-                        List.of(new ClientCheckRequest()), new ClientBatchCheckOptions())
+        List<ClientBatchCheckClientResponse> response = fga.clientBatchCheck(
+                        List.of(new ClientCheckRequest()), new ClientBatchCheckClientRequestOptions())
                 .join();
 
         // Then
@@ -1834,7 +1840,7 @@ public class OpenFgaClientTest {
     }
 
     @Test
-    public void batchCheck_500() throws Exception {
+    public void clientBatchCheck_500() throws Exception {
         // Given
         String postUrl = String.format("https://api.fga.example/stores/%s/check", DEFAULT_STORE_ID);
         mockHttpClient
@@ -1842,8 +1848,8 @@ public class OpenFgaClientTest {
                 .doReturn(500, "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}");
 
         // When
-        List<ClientBatchCheckResponse> response = fga.batchCheck(
-                        List.of(new ClientCheckRequest()), new ClientBatchCheckOptions())
+        List<ClientBatchCheckClientResponse> response = fga.clientBatchCheck(
+                        List.of(new ClientCheckRequest()), new ClientBatchCheckClientRequestOptions())
                 .join();
 
         // Then
@@ -1856,6 +1862,167 @@ public class OpenFgaClientTest {
         assertEquals(500, exception.getStatusCode());
         assertEquals(
                 "{\"code\":\"internal_error\",\"message\":\"Internal Server Error\"}", exception.getResponseData());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenCorrelationIdsAreDuplicated() {
+        // Given
+        ClientBatchCheckItem item1 = new ClientBatchCheckItem()
+                .user("user:81684243-9356-4421-8fbf-a4f8d36aa31b")
+                .relation("viewer")
+                ._object("workspace:1")
+                .correlationId("cor-id");
+        ClientBatchCheckItem item2 = new ClientBatchCheckItem()
+                .user("user:91284243-9356-4421-8fbf-a4f8d36aa31b")
+                .relation("viewer")
+                ._object("workspace:2")
+                .correlationId("cor-id");
+        ClientBatchCheckRequest request = new ClientBatchCheckRequest().checks(List.of(item1, item2));
+
+        // When
+        FgaValidationError error = assertThrows(FgaValidationError.class, () -> fga.batchCheck(request).join());
+
+        // Then
+        assertEquals("correlationId", error.getField());
+        assertEquals("When calling batchCheck, correlation IDs must be unique", error.getMessage());
+    }
+
+    @Test
+    public void shouldReturnEmptyResultsWhenEmptyChecksAreSpecified() throws Exception {
+        // Given
+        ClientBatchCheckRequest request = new ClientBatchCheckRequest().checks(List.of());
+
+        // When
+        ClientBatchCheckResponse response = fga.batchCheck(request).join();
+
+        // Then
+        assertEquals(0, response.getResult().size());
+    }
+
+    @Test
+    public void shouldHandleSingleBatchSuccessfully() throws Exception {
+        // Given
+        String postUrl = String.format("https://api.fga.example/stores/%s/batch-check", DEFAULT_STORE_ID);
+        mockHttpClient
+                .onPost(postUrl)
+                .doReturn(200, "{\"result\": {\"cor-1\": {\"allowed\": true, \"error\": null}, \"cor-2\": {\"allowed\": false, \"error\": null}}}");
+
+        ClientBatchCheckItem item1 = new ClientBatchCheckItem()
+                .user("user:81684243-9356-4421-8fbf-a4f8d36aa31b")
+                .relation("can_read")
+                ._object("document")
+                .contextualTuples(List.of(
+                        new ClientTupleKey()
+                                .user("user:81684243-9356-4421-8fbf-a4f8d36aa31b")
+                                .relation("editor")
+                                ._object("folder:product"),
+                        new ClientTupleKey()
+                                .user("folder:product")
+                                .relation("parent")
+                                ._object("document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a")
+                ))
+                .correlationId("cor-1");
+        ClientBatchCheckItem item2 = new ClientBatchCheckItem()
+                .user("folder:product")
+                .relation("parent")
+                ._object("document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a")
+                .correlationId("cor-2");
+        ClientBatchCheckRequest request = new ClientBatchCheckRequest().checks(List.of(item1, item2));
+
+        // When
+        ClientBatchCheckResponse response = fga.batchCheck(request).join();
+
+        // Then
+        mockHttpClient.verify().post(postUrl).called(1);
+
+        assertNotNull(response);
+        assertEquals(2, response.getResult().size());
+        assertTrue(response.getResult().get(0).isAllowed());
+        assertFalse(response.getResult().get(1).isAllowed());
+    }
+
+    @Test
+    public void shouldSplitBatchesSuccessfully(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        // Given
+        String httpBaseUrl = wireMockRuntimeInfo.getHttpBaseUrl();
+        var fga = new OpenFgaClient(clientConfiguration.apiUrl(httpBaseUrl), new ApiClient());
+        String postUrl = String.format("/stores/%s/batch-check", DEFAULT_STORE_ID);
+
+        WireMock.stubFor(WireMock.post(postUrl)
+                .withRequestBody(matchingJsonPath("$.checks[0].correlation_id", WireMock.equalTo("cor-1")))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withBody("{\"result\": {\"cor-1\": {\"allowed\": true, \"error\": null}, \"cor-2\": {\"allowed\": false, \"error\": null}}}"))
+        );
+
+        WireMock.stubFor(WireMock.post(postUrl)
+                .withRequestBody(matchingJsonPath("$.checks[0].correlation_id", WireMock.equalTo("cor-3")))
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withBody("{\"result\": {\"cor-3\": {\"allowed\": false, \"error\": {\"input_error\": \"relation_not_found\", \"message\": \"relation not found\"}}}}}"))
+        );
+
+        ClientBatchCheckItem item1 = new ClientBatchCheckItem()
+                .user("user:81684243-9356-4421-8fbf-a4f8d36aa31b")
+                .relation("can_read")
+                ._object("document")
+                .contextualTuples(List.of(
+                        new ClientTupleKey()
+                                .user("user:81684243-9356-4421-8fbf-a4f8d36aa31b")
+                                .relation("editor")
+                                ._object("folder:product"),
+                        new ClientTupleKey()
+                                .user("folder:product")
+                                .relation("parent")
+                                ._object("document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a")
+                ))
+                .correlationId("cor-1");
+        ClientBatchCheckItem item2 = new ClientBatchCheckItem()
+                .user("folder:product")
+                .relation("parent")
+                ._object("document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a")
+                .correlationId("cor-2");
+        ClientBatchCheckItem item3 = new ClientBatchCheckItem()
+                .user("folder:product")
+                .relation("parent")
+                ._object("document:9992ab2a-d83f-756d-9397-c5ed9f3cj8a4")
+                .correlationId("cor-3");
+        ClientBatchCheckRequest request = new ClientBatchCheckRequest().checks(List.of(item1, item2, item3));
+
+        ClientBatchCheckRequestOptions options = new ClientBatchCheckRequestOptions().maxBatchSize(2);
+
+        // When
+        ClientBatchCheckResponse response = fga.batchCheck(request, options).join();
+
+        // Then
+        ClientBatchCheckSingleResponse response1 = response.getResult()
+                .stream()
+                .filter(r -> r.getCorrelationId().equals("cor-1"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(response1);
+        assertTrue(response1.isAllowed());
+        assertEquals("user:81684243-9356-4421-8fbf-a4f8d36aa31b", response1.getRequest().getUser());
+
+        ClientBatchCheckSingleResponse response2 = response.getResult()
+                .stream()
+                .filter(r -> r.getCorrelationId().equals("cor-2"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(response2);
+        assertFalse(response2.isAllowed());
+        assertEquals("folder:product", response2.getRequest().getUser());
+
+        ClientBatchCheckSingleResponse response3 = response.getResult()
+                .stream()
+                .filter(r -> r.getCorrelationId().equals("cor-3"))
+                .findFirst()
+                .orElse(null);
+        assertNotNull(response3);
+        assertFalse(response3.isAllowed());
+        assertEquals("folder:product", response3.getRequest().getUser());
+        assertEquals(ErrorCode.RELATION_NOT_FOUND, response3.getError().getInputError());
+        assertEquals("relation not found", response3.getError().getMessage());
     }
 
     /**
@@ -2118,7 +2285,7 @@ public class OpenFgaClientTest {
         mockHttpClient
                 .onPost(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .doReturn(200, "{\"allowed\":true}");
         ClientListRelationsRequest request = new ClientListRelationsRequest()
@@ -2138,7 +2305,7 @@ public class OpenFgaClientTest {
                 .verify()
                 .post(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .called(1);
         assertNotNull(response);
@@ -2157,7 +2324,7 @@ public class OpenFgaClientTest {
         mockHttpClient
                 .onPost(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .doReturn(200, "{\"allowed\":false}");
         ClientListRelationsRequest request = new ClientListRelationsRequest()
@@ -2176,7 +2343,7 @@ public class OpenFgaClientTest {
                 .verify()
                 .post(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .called(1);
         assertNotNull(response);
@@ -2344,7 +2511,7 @@ public class OpenFgaClientTest {
         mockHttpClient
                 .onPost(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .doReturn(200, "{\"allowed\":false}");
         ClientListRelationsRequest request = new ClientListRelationsRequest()
@@ -2368,7 +2535,7 @@ public class OpenFgaClientTest {
                 .verify()
                 .post(postUrl)
                 .withBody(is(expectedBody))
-                .withHeader(CLIENT_METHOD_HEADER, "BatchCheck")
+                .withHeader(CLIENT_METHOD_HEADER, "ClientBatchCheck")
                 .withHeader(CLIENT_BULK_REQUEST_ID_HEADER, anyValidUUID())
                 .called(1);
         assertNotNull(response);

--- a/config/clients/java/template/config-ClientBatchCheckClientRequestOptions.java.mustache
+++ b/config/clients/java/template/config-ClientBatchCheckClientRequestOptions.java.mustache
@@ -4,13 +4,13 @@ package {{configPackage}};
 import dev.openfga.sdk.api.model.ConsistencyPreference;
 import java.util.Map;
 
-public class ClientBatchCheckOptions implements AdditionalHeadersSupplier {
+public class ClientBatchCheckClientRequestOptions implements AdditionalHeadersSupplier {
     private Map<String, String> additionalHeaders;
     private Integer maxParallelRequests;
     private String authorizationModelId;
     private ConsistencyPreference consistency;
 
-    public ClientBatchCheckOptions additionalHeaders(Map<String, String> additionalHeaders) {
+    public ClientBatchCheckClientRequestOptions additionalHeaders(Map<String, String> additionalHeaders) {
         this.additionalHeaders = additionalHeaders;
         return this;
     }
@@ -20,7 +20,7 @@ public class ClientBatchCheckOptions implements AdditionalHeadersSupplier {
         return this.additionalHeaders;
     }
 
-    public ClientBatchCheckOptions maxParallelRequests(Integer maxParallelRequests) {
+    public ClientBatchCheckClientRequestOptions maxParallelRequests(Integer maxParallelRequests) {
         this.maxParallelRequests = maxParallelRequests;
         return this;
     }
@@ -29,7 +29,7 @@ public class ClientBatchCheckOptions implements AdditionalHeadersSupplier {
         return maxParallelRequests;
     }
 
-    public ClientBatchCheckOptions authorizationModelId(String authorizationModelId) {
+    public ClientBatchCheckClientRequestOptions authorizationModelId(String authorizationModelId) {
         this.authorizationModelId = authorizationModelId;
         return this;
     }
@@ -38,7 +38,7 @@ public class ClientBatchCheckOptions implements AdditionalHeadersSupplier {
         return authorizationModelId;
     }
 
-    public ClientBatchCheckOptions consistency(ConsistencyPreference consistency) {
+    public ClientBatchCheckClientRequestOptions consistency(ConsistencyPreference consistency) {
         this.consistency = consistency;
         return this;
     }

--- a/config/clients/java/template/config-ClientBatchCheckRequestOptions.java.mustache
+++ b/config/clients/java/template/config-ClientBatchCheckRequestOptions.java.mustache
@@ -4,13 +4,14 @@ package {{configPackage}};
 import dev.openfga.sdk.api.model.ConsistencyPreference;
 import java.util.Map;
 
-public class ClientListRelationsOptions implements AdditionalHeadersSupplier {
+public class ClientBatchCheckRequestOptions implements AdditionalHeadersSupplier {
     private Map<String, String> additionalHeaders;
     private Integer maxParallelRequests;
+    private Integer maxBatchSize;
     private String authorizationModelId;
     private ConsistencyPreference consistency;
 
-    public ClientListRelationsOptions additionalHeaders(Map<String, String> additionalHeaders) {
+    public ClientBatchCheckRequestOptions additionalHeaders(Map<String, String> additionalHeaders) {
         this.additionalHeaders = additionalHeaders;
         return this;
     }
@@ -20,7 +21,7 @@ public class ClientListRelationsOptions implements AdditionalHeadersSupplier {
         return this.additionalHeaders;
     }
 
-    public ClientListRelationsOptions maxParallelRequests(Integer maxParallelRequests) {
+    public ClientBatchCheckRequestOptions maxParallelRequests(Integer maxParallelRequests) {
         this.maxParallelRequests = maxParallelRequests;
         return this;
     }
@@ -29,7 +30,16 @@ public class ClientListRelationsOptions implements AdditionalHeadersSupplier {
         return maxParallelRequests;
     }
 
-    public ClientListRelationsOptions authorizationModelId(String authorizationModelId) {
+    public ClientBatchCheckRequestOptions maxBatchSize(Integer maxBatchSize) {
+        this.maxBatchSize = maxBatchSize;
+        return this;
+    }
+
+    public Integer getMaxBatchSize() {
+        return maxBatchSize;
+    }
+
+    public ClientBatchCheckRequestOptions authorizationModelId(String authorizationModelId) {
         this.authorizationModelId = authorizationModelId;
         return this;
     }
@@ -38,7 +48,7 @@ public class ClientListRelationsOptions implements AdditionalHeadersSupplier {
         return authorizationModelId;
     }
 
-    public ClientListRelationsOptions consistency(ConsistencyPreference consistency) {
+    public ClientBatchCheckRequestOptions consistency(ConsistencyPreference consistency) {
         this.consistency = consistency;
         return this;
     }
@@ -46,11 +56,4 @@ public class ClientListRelationsOptions implements AdditionalHeadersSupplier {
     public ConsistencyPreference getConsistency() {
         return consistency;
     }
-
-     public ClientBatchCheckClientRequestOptions asClientBatchCheckClientRequestOptions() {
-        return new ClientBatchCheckClientRequestOptions()
-                .authorizationModelId(authorizationModelId)
-                .maxParallelRequests(maxParallelRequests)
-                .consistency(consistency);
-     }
 }

--- a/config/clients/java/template/errors-FgaValidationError.java.mustache
+++ b/config/clients/java/template/errors-FgaValidationError.java.mustache
@@ -1,0 +1,14 @@
+package {{errorsPackage}};
+
+public class FgaValidationError extends Exception {
+    private final String field;
+
+    public FgaValidationError(String field, String message) {
+        super(message);
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

> [!CAUTION]
> Breaking Change! This change renames the existing `batchCheck` method (which calls the /check API in parallel) to `clientBatchCheck`. 
> If you would like to continue to use the client-side batch check, replace your calls to `batchCheck` with `clientBatchCheck`, and reference the results using the result property (formerly was responses).

Implemented a [server-side batch check API](https://openfga.dev/api/service#/Relationship%20Queries/BatchCheck), as @jimmyjames mentioned [here](https://github.com/openfga/java-sdk/issues/127#issuecomment-2596348992).

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

