### PR TITLE
chore(go-sdk): sync changes

### DIFF
--- a/config/clients/go/CHANGELOG.md.mustache
+++ b/config/clients/go/CHANGELOG.md.mustache
@@ -2,7 +2,8 @@
 
 ## [Unreleased](https://github.com/openfga/go-sdk/compare/v{{packageVersion}}...HEAD)
 
-- feat: add support for `start_time` parameter in `ReadChanges` endpoint
+- feat: add support for `start_time` parameter in `ReadChanges` endpoint (#158)
+- fix: correctly set request level storeId in non-transactional write (#162)
 
 ## v0.6.3
 

--- a/config/clients/go/CHANGELOG.md.mustache
+++ b/config/clients/go/CHANGELOG.md.mustache
@@ -4,6 +4,7 @@
 
 - feat: add support for `start_time` parameter in `ReadChanges` endpoint (#158)
 - fix: correctly set request level storeId in non-transactional write (#162)
+- fix: api client should set default telemetry if not specified (#160)
 
 ## v0.6.3
 

--- a/config/clients/go/config.overrides.json
+++ b/config/clients/go/config.overrides.json
@@ -44,6 +44,10 @@
       "destinationFilename": "client/errors.go",
       "templateType": "SupportingFiles"
     },
+    "api_client_test.mustache": {
+      "destinationFilename": "api_client_test.go",
+      "templateType": "SupportingFiles"
+    },
     "api_client.mustache": {
       "destinationFilename": "api_client.go",
       "templateType": "SupportingFiles"

--- a/config/clients/go/template/api_client.mustache
+++ b/config/clients/go/template/api_client.mustache
@@ -65,6 +65,9 @@ type service struct {
 // NewAPIClient creates a new API client. Requires a userAgent string describing your application.
 // optionally a custom http.Client to allow for advanced features such as caching.
 func NewAPIClient(cfg *Configuration) *APIClient {
+	if cfg.Telemetry == nil {
+		cfg.Telemetry = telemetry.DefaultTelemetryConfiguration()
+	}
 	if cfg.HTTPClient == nil {
 		if cfg.Credentials == nil {
 			cfg.HTTPClient = http.DefaultClient

--- a/config/clients/go/template/api_client_test.mustache
+++ b/config/clients/go/template/api_client_test.mustache
@@ -1,0 +1,25 @@
+{{>partial_header}}
+package {{packageName}}
+
+
+import (
+	"{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/telemetry"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestApiClientCreatedWithDefaultTelemetry(t *testing.T) {
+	cfg := Configuration{
+		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+		ApiUrl:     "http://localhost:8080/",
+	}
+	_ = NewAPIClient(&cfg)
+
+	telemetry1 := telemetry.Get(telemetry.TelemetryFactoryParameters{Configuration: cfg.Telemetry})
+	telemetry2 := telemetry.Get(telemetry.TelemetryFactoryParameters{Configuration: cfg.Telemetry})
+
+	if telemetry1 != telemetry2 {
+		t.Fatalf("Telemetry instance should be the same")
+	}
+}

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -1593,6 +1593,7 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 				},
 				options: &ClientWriteOptions{
 					AuthorizationModelId: authorizationModelId,
+					StoreId:              request.GetStoreIdOverride(),
 				},
 			})
 
@@ -1636,6 +1637,7 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 				},
 				options: &ClientWriteOptions{
 					AuthorizationModelId: authorizationModelId,
+					StoreId:              request.GetStoreIdOverride(),
 				},
 			})
 

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -1481,6 +1481,38 @@ func Test{{appShortName}}Client(t *testing.T) {
 				t.Fatalf("%v", err)
 			}
 		}
+
+		// store can be overridden
+		storeOverrideOptions := ClientWriteOptions{
+			AuthorizationModelId: openfga.PtrString(authModelId),
+			Transaction: &TransactionOptions{
+				Disable:             true,
+				MaxParallelRequests: 5,
+				MaxPerChunk:         1,
+			},
+			StoreId: openfga.PtrString("7777HCE4YVKPQEKZQHT2R89MQV"),
+		}
+		httpmock.Reset()
+		httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", fgaClient.GetConfig().ApiUrl, *storeOverrideOptions.StoreId, test.RequestPath),
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+				if err != nil {
+					return httpmock.NewStringResponse(http.StatusInternalServerError, ""), nil
+				}
+				return resp, nil
+			},
+		)
+		data, err = fgaClient.Write(context.Background()).Body(requestBody).Options(storeOverrideOptions).Execute()
+		if err != nil {
+			t.Fatalf("%v", data)
+		}
+
+		for index := 0; index < len(data.Writes); index++ {
+			response := data.Writes[index]
+			if response.Error != nil {
+				t.Fatalf("OpenFgaClient.%v()|%d/ %v", test.Name, index, response.Error)
+			}
+		}
 	})
 
 	t.Run("Write with invalid auth", func(t *testing.T) {


### PR DESCRIPTION
## Description

Syncs a couple PRs over from go-sdk

## References

https://github.com/openfga/go-sdk/pull/162
https://github.com/openfga/go-sdk/pull/160

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

