### PR TITLE
fix(go-sdk): backport start time variable read fix from go-sdk

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -1220,8 +1220,11 @@ func (client *{{appShortName}}Client) ReadChangesExecute(request SdkClientReadCh
 		req = req.ContinuationToken(*continuationToken)
 	}
 	requestBody := request.GetBody()
-	if requestBody != nil {
+	if requestBody.Type != "" {
 		req = req.Type_(requestBody.Type)
+	}
+	if !requestBody.StartTime.IsZero() {
+		req = req.StartTime(requestBody.StartTime)
 	}
 
 	data, _, err := req.Execute()

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -1220,10 +1220,10 @@ func (client *{{appShortName}}Client) ReadChangesExecute(request SdkClientReadCh
 		req = req.ContinuationToken(*continuationToken)
 	}
 	requestBody := request.GetBody()
-	if requestBody.Type != "" {
+	if requestBody != nil &&  requestBody.Type != "" {
 		req = req.Type_(requestBody.Type)
 	}
-	if !requestBody.StartTime.IsZero() {
+	if requestBody != nil &&  !requestBody.StartTime.IsZero() {
 		req = req.StartTime(requestBody.StartTime)
 	}
 


### PR DESCRIPTION
## Description
Backport of the fix in go-sdk to resolve https://github.com/openfga/sdk-generator/issues/483


## References
https://github.com/openfga/go-sdk/pull/166

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

