### PR TITLE
docs: update readChanges startTime docs to reflect inclusion in body

### DIFF
--- a/config/clients/go/template/README_calling_api.mustache
+++ b/config/clients/go/template/README_calling_api.mustache
@@ -205,13 +205,13 @@ Reads the list of historical relationship tuple writes and deletes.
 ```golang
 body := ClientReadChangesRequest{
     Type: "document",
+    StartTime: {{packageName}}.PtrString("2022-01-01T00:00:00Z"),
 }
 options := ClientReadChangesOptions{
     PageSize: {{packageName}}.PtrInt32(10),
     ContinuationToken: {{packageName}}.PtrString("eyJwayI6IkxBVEVTVF9OU0NPTkZJR19hdXRoMHN0b3JlIiwic2siOiIxem1qbXF3MWZLZExTcUoyN01MdTdqTjh0cWgifQ=="),
     // You can rely on the store id set in the configuration or override it for this specific request
     StoreId: {{packageName}}.PtrString("01FQH7V8BEG3GPQW93KTRFR8JB"), 
-    StartTime: {{packageName}}.PtrString("2022-01-01T00:00:00Z"),
 }
 data, err := fgaClient.ReadChanges(context.Background()).Body(body).Options(options).Execute()
 


### PR DESCRIPTION
## Description
Resolves README issue for ReadChanges where StartTime was included in Options rather than Body

## References
Addresses documentation portion of: https://github.com/openfga/sdk-generator/issues/483

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

