### PR TITLE
release(java-sdk)!: release java-sdk v0.8.0

### DIFF
--- a/config/clients/java/CHANGELOG.md.mustache
+++ b/config/clients/java/CHANGELOG.md.mustache
@@ -2,11 +2,14 @@
 
 ## [Unreleased](https://github.com/openfga/java-sdk/compare/v{{packageVersion}}...HEAD)
 
-- feat!: add support for server-side `BatchCheck` method
-- feat: add support for `start_time` parameter in `ReadChanges` endpoint
+## v0.8.0
+
+### [0.8.0](https://github.com/openfga/java-sdk/compare/v0.7.2...v0.8.0) (2025-02-07)
+
+- feat!: add support for server-side `BatchCheck` method (#141) thanks @piotrooo!!
+- feat: add support for `start_time` parameter in `ReadChanges` endpoint (#137)
 
 BREAKING CHANGES:
-
 - Usage of the existing `batchCheck` method should now use the `clientBatchCheck` method.
 
 ## v0.7.2

--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -3,7 +3,7 @@
   "gitRepoId": "java-sdk",
   "artifactId": "openfga-sdk",
   "groupId": "dev.openfga",
-  "packageVersion": "0.7.2",
+  "packageVersion": "0.8.0",
   "apiPackage": "dev.openfga.sdk.api",
   "authPackage": "dev.openfga.sdk.api.auth",
   "clientPackage": "dev.openfga.sdk.api.client",


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Release v0.8.0

## Description
<!-- Provide a detailed description of the changes -->

- feat!: add support for server-side `BatchCheck` method (#141) thanks to @piotrooo !
- feat: add support for `start_time` parameter in `ReadChanges` endpoint (#137)

> [!WARNING]  
> This release contains a breaking change to the `batchCheck` method. See the [documentation](https://github.com/openfga/java-sdk/blob/main/README.md#batch-check) to use the updated, server-side batch check method, or replace usages with `clientBatchCheck`.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

https://github.com/openfga/java-sdk/pull/144

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

