### PR TITLE
fix(python-sdk): REST client should not close after `stream` request

### DIFF
--- a/config/clients/python/template/src/rest.py.mustache
+++ b/config/clients/python/template/src/rest.py.mustache
@@ -397,9 +397,6 @@ class RESTClientObject:
             # Release the response object (required!)
             response.release()
 
-        # Release the connection back to the pool
-        await self.close()
-
     async def request(
         self,
         method: str,

--- a/config/clients/python/template/src/sync/rest.py.mustache
+++ b/config/clients/python/template/src/sync/rest.py.mustache
@@ -440,9 +440,6 @@ class RESTClientObject:
             # Release the response object (required!)
             response.release_conn()
 
-        # Release the connection back to the pool
-        self.close()
-
     def request(
         self,
         method: str,

--- a/config/clients/python/template/test/rest_test.py.mustache
+++ b/config/clients/python/template/test/rest_test.py.mustache
@@ -308,7 +308,6 @@ async def test_stream_happy_path():
 
     client.handle_response_exception.assert_awaited_once()
     mock_response.release.assert_called_once()
-    client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -353,7 +352,6 @@ async def test_stream_exception_in_chunks():
     assert results == []
     client.handle_response_exception.assert_awaited_once()
     mock_response.release.assert_called_once()
-    client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -400,4 +398,3 @@ async def test_stream_partial_chunks():
 
     client.handle_response_exception.assert_awaited_once()
     mock_response.release.assert_called_once()
-    client.close.assert_awaited_once()

--- a/config/clients/python/template/test/sync/rest_test.py.mustache
+++ b/config/clients/python/template/test/sync/rest_test.py.mustache
@@ -277,6 +277,7 @@ def test_close():
     client.pool_manager = mock_pool_manager
 
     client.close()
+
     mock_pool_manager.clear.assert_called_once()
 
 
@@ -322,7 +323,6 @@ def test_request_preload_content():
     assert isinstance(resp, RESTResponse)
     assert resp.status == 200
     assert resp.data == b'{"some":"data"}'
-    mock_pool_manager.clear.assert_called_once()
 
 
 def test_request_no_preload_content():
@@ -369,7 +369,6 @@ def test_request_no_preload_content():
     # We expect the raw HTTPResponse
     assert resp == mock_raw_response
     assert resp.status == 200
-    mock_pool_manager.clear.assert_called_once()
 
 
 def test_stream_happy_path():
@@ -420,7 +419,6 @@ def test_stream_happy_path():
 
     assert results == [{"foo": "bar"}, {"hello": "world"}]
     mock_pool_manager.request.assert_called_once()
-    mock_pool_manager.clear.assert_called_once()
 
 
 def test_stream_partial_chunks():
@@ -472,7 +470,6 @@ def test_stream_partial_chunks():
 
     assert results == [{"foo": "bar"}, {"hello": "world"}]
     mock_pool_manager.request.assert_called_once()
-    mock_pool_manager.clear.assert_called_once()
 
 
 def test_stream_exception_in_chunks():
@@ -523,4 +520,3 @@ def test_stream_exception_in_chunks():
     # Exception is logged, we yield nothing
     assert results == []
     mock_pool_manager.request.assert_called_once()
-    mock_pool_manager.clear.assert_called_once()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This is a minor bug fix to the new `stream` method added to the Python SDK's REST client in 0.9.1: the pool shouldn't close after the request concludes, as the same pool can continue to be used for future requests.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Generates https://github.com/openfga/python-sdk/pull/172

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

