### PR TITLE
fix(dotnet-sdk): Fix broken rate limit handling

### DIFF
--- a/config/clients/dotnet/template/Exceptions_Parsers_RateLimitParser.mustache
+++ b/config/clients/dotnet/template/Exceptions_Parsers_RateLimitParser.mustache
@@ -77,13 +77,14 @@ public class RateLimitParser {
     /// <returns>Instance of <see cref="RateLimitParser"/> containing parsed rate limit headers.</returns>
     public static RateLimitParser Parse(HttpHeaders headers, HttpMethod method, string? apiName = null) {
         var reset = GetHeaderValue(headers, RateLimitHeader.LimitResetIn);
+        var resetTimespan = ComputeResetTimespan(reset);
         var limitUnit = GetRateLimitPeriodUnitValue(apiName);
         return new RateLimitParser {
             Limit = GetHeaderValue(headers, RateLimitHeader.LimitTotalInPeriod),
             Remaining = GetHeaderValue(headers, RateLimitHeader.LimitRemaining),
             LimitUnit = limitUnit,
-            ResetInMs = reset,
-            Reset = reset == 0 ? null : AddResetToCurrentTime(limitUnit, reset),
+            ResetInMs = resetTimespan?.Milliseconds,
+            Reset = resetTimespan == null ? null : DateTimeOffset.UtcNow.Add(resetTimespan.Value),
             Method = method,
             ApiName = apiName ?? "",
         };
@@ -105,11 +106,11 @@ public class RateLimitParser {
         };
     }
 
-    private static DateTimeOffset? AddResetToCurrentTime(PeriodUnit limitUnit, long reset) {
-        return limitUnit switch {
-            PeriodUnit.Second => DateTimeOffset.UtcNow.AddSeconds(reset),
-            PeriodUnit.Minute => DateTimeOffset.UtcNow.AddMinutes(reset),
-            _ => null
-        };
+    private static TimeSpan? ComputeResetTimespan(long reset) {
+        if (reset == 0)
+            return null;
+        
+        var retryAt = DateTimeOffset.FromUnixTimeSeconds(reset);
+        return retryAt - DateTimeOffset.UtcNow;
     }
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This unhelpfully deadlocked my test pipeline today. This code hasn't been touched for 3 years and has always been broken as far as I can tell. The tests in the dotnet repo also made the incorrect assumption about the header shape and will need to be updated.

## References
Closes https://github.com/openfga/dotnet-sdk/issues/76

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

