### PR TITLE
fix(python-sdk): list relations should throw error

### DIFF
--- a/config/clients/python/template/src/client/client.py.mustache
+++ b/config/clients/python/template/src/client/client.py.mustache
@@ -110,6 +110,12 @@ def options_to_transaction_info(options: dict[str, int | str | dict[str, int | s
         return options["transaction"]
     return WriteTransactionOpts()
 
+def _check_errored(response: ClientBatchCheckClientResponse):
+    """
+    Helper function to return whether the response is errored
+    """
+    return response.error is not None
+
 def _check_allowed(response: ClientBatchCheckClientResponse):
     """
     Helper function to return whether the response is check is allowed
@@ -847,6 +853,13 @@ class OpenFgaClient:
 
         request_body = [construct_check_request(user=body.user, relation=i, object=body.object, contextual_tuples=body.contextual_tuples, context=body.context) for i in body.relations]
         result = {{#asyncio}}await {{/asyncio}}self.client_batch_check(request_body, options)
+
+        # filter out any errored responses and raise the first error
+        errored_result_iterator = filter(_check_errored, result)
+        errored_result_list = list(errored_result_iterator)
+        if len(errored_result_list) > 0:
+            raise errored_result_list[0].error
+
         # need to filter with the allowed response
         result_iterator = filter(_check_allowed, result)
         result_list = list(result_iterator)

--- a/config/clients/python/template/src/sync/client/client.py.mustache
+++ b/config/clients/python/template/src/sync/client/client.py.mustache
@@ -110,6 +110,12 @@ def options_to_transaction_info(options: dict[str, int | str | dict[str, int | s
         return options["transaction"]
     return WriteTransactionOpts()
 
+def _check_errored(response: ClientBatchCheckClientResponse):
+    """
+    Helper function to return whether the response is errored
+    """
+    return response.error is not None
+
 def _check_allowed(response: ClientBatchCheckClientResponse):
     """
     Helper function to return whether the response is check is allowed
@@ -821,6 +827,13 @@ class OpenFgaClient:
 
         request_body = [construct_check_request(user=body.user, relation=i, object=body.object, contextual_tuples=body.contextual_tuples, context=body.context) for i in body.relations]
         result = self.client_batch_check(request_body, options)
+
+        # filter out any errored responses and raise the first error
+        errored_result_iterator = filter(_check_errored, result)
+        errored_result_list = list(errored_result_iterator)
+        if len(errored_result_list) > 0:
+            raise errored_result_list[0].error
+
         # need to filter with the allowed response
         result_iterator = filter(_check_allowed, result)
         result_list = list(result_iterator)

--- a/config/clients/python/template/test/client/client_test.py.mustache
+++ b/config/clients/python/template/test/client/client_test.py.mustache
@@ -2815,6 +2815,27 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             await api_client.close()
 
     @patch.object(rest.RESTClientObject, "request")
+    async def test_list_relations_errored(self, mock_request):
+        """Test case for list relations with undefined exception"""
+
+        mock_request.side_effect = ValueError()
+        configuration = self.configuration
+        configuration.store_id = store_id
+        async with OpenFgaClient(configuration) as api_client:
+            with self.assertRaises(ValueError):
+                await api_client.list_relations(
+                    body=ClientListRelationsRequest(
+                        user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                        relations=["reader", "owner", "viewer"],
+                        object="document:2021-budget",
+                    ),
+                    options={"authorization_model_id": "01GXSA8YR785C4FYS3C0RTG7B1"},
+                )
+
+            mock_request.assert_called()
+            await api_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
     async def test_list_users(self, mock_request):
         """
         Test case for list_users

--- a/config/clients/python/template/test/sync/client/client_test.py.mustache
+++ b/config/clients/python/template/test/sync/client/client_test.py.mustache
@@ -2818,6 +2818,27 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             api_client.close()
 
     @patch.object(rest.RESTClientObject, "request")
+    def test_list_relations_errored(self, mock_request):
+        """Test case for list relations with undefined exception"""
+
+        mock_request.side_effect = ValueError()
+        configuration = self.configuration
+        configuration.store_id = store_id
+        with OpenFgaClient(configuration) as api_client:
+            with self.assertRaises(ValueError):
+                api_client.list_relations(
+                    body=ClientListRelationsRequest(
+                        user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                        relations=["reader", "owner", "viewer"],
+                        object="document:2021-budget",
+                    ),
+                    options={"authorization_model_id": "01GXSA8YR785C4FYS3C0RTG7B1"},
+                )
+
+            mock_request.assert_called()
+            api_client.close()
+
+    @patch.object(rest.RESTClientObject, "request")
     def test_list_users(self, mock_request):
         """
         Test case for list_users


### PR DESCRIPTION
ListRelations now throws the first error that occurs during one of the checks instead of swallowing the it.

## Description
- Added a new private method to determine if a check has an error (_check_error)
- The list_response method now has logic to filter out any errored check responses and throw the first error for both the async and the sync clients

## References
Part of https://github.com/openfga/sdk-generator/issues/183

closes https://github.com/openfga/python-sdk/issues/173

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

