### PR TITLE
feat(dotnet-sdk): configurable client credentials token url

### DIFF
--- a/config/clients/dotnet/template/Client_OAuth2Client.mustache
+++ b/config/clients/dotnet/template/Client_OAuth2Client.mustache
@@ -64,6 +64,7 @@ public class OAuth2Client {
     private AuthToken _authToken = new();
     private IDictionary<string, string> _authRequest { get; }
     private string _apiTokenIssuer { get; }
+    private string _apiTokenPath { get; }
     private readonly RetryParams _retryParams;
 
     #endregion
@@ -95,7 +96,9 @@ public class OAuth2Client {
         }
 
         _httpClient = httpClient;
-        _apiTokenIssuer = credentialsConfig.Config.ApiTokenIssuer;
+        var tokenEndpoint = BuildTokenEndpointUrl(credentialsConfig.Config.ApiTokenIssuer);
+        _apiTokenIssuer = tokenEndpoint.BasePath;
+        _apiTokenPath = tokenEndpoint.Path;
         _authRequest = new Dictionary<string, string> {
             { "client_id", credentialsConfig.Config.ClientId },
             { "client_secret", credentialsConfig.Config.ClientSecret },
@@ -118,8 +121,8 @@ public class OAuth2Client {
     private async Task ExchangeTokenAsync(CancellationToken cancellationToken = default) {
         var requestBuilder = new RequestBuilder<IDictionary<string, string>> {
             Method = HttpMethod.Post,
-            BasePath = $"https://{_apiTokenIssuer}",
-            PathTemplate = "/oauth/token",
+            BasePath = _apiTokenIssuer,
+            PathTemplate = _apiTokenPath,
             Body = _authRequest,
             ContentType = "application/x-www-form-urlencode"
         };
@@ -173,6 +176,13 @@ public class OAuth2Client {
                 await Task.Delay(waitInMs);
             }
         }
+    }
+
+    private static (string BasePath, string Path) BuildTokenEndpointUrl(string issuer) {
+        var uri = new Uri(issuer);
+        return uri.AbsolutePath.Equals("/") 
+            ? ($"{uri.Scheme}://{uri.Host}", "/oauth/token") 
+            : ($"{uri.Scheme}://{uri.Host}", uri.AbsolutePath);
     }
 
     /// <summary>

--- a/config/clients/dotnet/template/Configuration_Credentials.mustache
+++ b/config/clients/dotnet/template/Configuration_Credentials.mustache
@@ -63,12 +63,24 @@ public interface IClientCredentialsConfig {
 
 public interface ICredentialsConfig: IClientCredentialsConfig, IApiTokenConfig {}
 
-public struct CredentialsConfig : ICredentialsConfig {
-    public string? ClientId { get; set; }
-    public string? ClientSecret { get; set; }
-    public string? ApiTokenIssuer { get; set; }
-    public string? ApiAudience { get; set; }
-    public string? ApiToken { get; set; }
+public struct CredentialsConfig : ICredentialsConfig, IClientCredentialsConfig, IApiTokenConfig
+{
+	private string? _tokenIssuer;
+
+	public string? ClientId { get; set; }
+
+	public string? ClientSecret { get; set; }
+
+	public string? ApiTokenIssuer {
+		get => _tokenIssuer;
+		set => _tokenIssuer = (!value?.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ?? false) && (!value?.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ?? false)
+				? $"https://{value}"
+				: value;
+	}
+
+	public string? ApiAudience { get; set; }
+
+	public string? ApiToken { get; set; }
 }
 
 public interface IAuthCredentialsConfig {
@@ -125,9 +137,8 @@ public class Credentials: IAuthCredentialsConfig {
                     throw new FgaRequiredParamError("Configuration", nameof(Config.ApiAudience));
                 }
 
-                if (!string.IsNullOrWhiteSpace(Config?.ApiTokenIssuer) && !IsWellFormedUriString($"https://{Config.ApiTokenIssuer}")) {
-                    throw new FgaValidationError(
-                        $"Configuration.ApiTokenIssuer does not form a valid URI (https://{Config.ApiTokenIssuer})");
+                if (!IsWellFormedUriString(Config.ApiTokenIssuer)) {
+                    throw new FgaValidationError($"Configuration.ApiTokenIssuer does not form a valid URI ({Config.ApiTokenIssuer})");
                 }
 
                 break;

--- a/config/clients/dotnet/template/api_test.mustache
+++ b/config/clients/dotnet/template/api_test.mustache
@@ -118,11 +118,30 @@ namespace {{testPackageName}}.Api {
                 exceptionMissingApiToken.Message);
         }
 
-        // /// <summary>
-        // /// Test that the provided api token issuer is well-formed
-        // /// </summary>
+        /// <summary>
+        /// Test that api token issuer value is normalized
+        /// </summary>
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("tokenissuer.fga.example", "https://tokenissuer.fga.example")]
+        [InlineData("http://tokenissuer.fga.example", "http://tokenissuer.fga.example")]
+        [InlineData("https://tokenissuer.fga.example", "https://tokenissuer.fga.example")]
+        public void ApiTokenIssuerIsNormalized(string issuer, string expected) {
+            var config = new CredentialsConfig() {
+                ClientId = "some-id",
+                ClientSecret = "some-secret",
+                ApiTokenIssuer = issuer,
+                ApiAudience = "some-audience",
+            };
+
+            Assert.Equal(expected, config.ApiTokenIssuer);
+        }
+
+        /// <summary>
+        /// Test that providing malformed token issuer should error
+        /// </summary>
         [Fact]
-        public void ValidApiTokenIssuerWellFormed() {
+        public void ApiTokenIssuerIsMalformed() {
             var config = new Configuration.Configuration() {
                 ApiHost = _host,
                 Credentials = new Credentials() {
@@ -130,16 +149,39 @@ namespace {{testPackageName}}.Api {
                     Config = new CredentialsConfig() {
                         ClientId = "some-id",
                         ClientSecret = "some-secret",
-                        ApiTokenIssuer = "https://tokenissuer.{{sampleApiDomain}}",
+                        ApiTokenIssuer = "file://tokenissuer.fga.example",
                         ApiAudience = "some-audience",
                     }
                 }
             };
             void ActionMalformedApiTokenIssuer() => config.EnsureValid();
             var exception = Assert.Throws<FgaValidationError>(ActionMalformedApiTokenIssuer);
-            Assert.Equal("Configuration.ApiTokenIssuer does not form a valid URI (https://https://tokenissuer.{{sampleApiDomain}})", exception.Message);
+            Assert.Equal("Configuration.ApiTokenIssuer does not form a valid URI (https://file://tokenissuer.fga.example)", exception.Message);
         }
 
+        /// <summary>
+        /// Test that the provided api token issuer is well-formed
+        /// </summary>
+        [Theory]
+        [InlineData("tokenissuer.fga.example")]
+        [InlineData("http://tokenissuer.fga.example")]
+        [InlineData("https://tokenissuer.fga.example")]
+        public void ValidApiTokenIssuerWellFormed(string issuer) {
+            var config = new Configuration.Configuration() {
+                ApiHost = _host,
+                Credentials = new Credentials() {
+                    Method = CredentialsMethod.ClientCredentials,
+                    Config = new CredentialsConfig() {
+                        ClientId = "some-id",
+                        ClientSecret = "some-secret",
+                        ApiTokenIssuer = issuer,
+                        ApiAudience = "some-audience",
+                    }
+                }
+            };
+            config.EnsureValid();
+        }
+        
         /// <summary>
         /// Test that the authorization header is being sent
         /// </summary>
@@ -295,7 +337,7 @@ namespace {{testPackageName}}.Api {
                 .SetupSequence<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.Is<HttpRequestMessage>(req =>
-                        req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
+                        req.RequestUri == new Uri($"{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
                         req.Method == HttpMethod.Post &&
                         req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                     ItExpr.IsAny<CancellationToken>()
@@ -350,7 +392,7 @@ namespace {{testPackageName}}.Api {
                 "SendAsync",
                 Times.Exactly(1),
                 ItExpr.Is<HttpRequestMessage>(req =>
-                    req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
+                    req.RequestUri == new Uri($"{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
                     req.Method == HttpMethod.Post &&
                     req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                 ItExpr.IsAny<CancellationToken>()
@@ -394,7 +436,7 @@ namespace {{testPackageName}}.Api {
                 .SetupSequence<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.Is<HttpRequestMessage>(req =>
-                        req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
+                        req.RequestUri == new Uri($"{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
                         req.Method == HttpMethod.Post &&
                         req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                     ItExpr.IsAny<CancellationToken>()
@@ -449,7 +491,7 @@ namespace {{testPackageName}}.Api {
                 "SendAsync",
                 Times.Exactly(2),
                 ItExpr.Is<HttpRequestMessage>(req =>
-                    req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
+                    req.RequestUri == new Uri($"{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
                     req.Method == HttpMethod.Post &&
                     req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                 ItExpr.IsAny<CancellationToken>()
@@ -493,7 +535,7 @@ namespace {{testPackageName}}.Api {
                 .SetupSequence<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.Is<HttpRequestMessage>(req =>
-                        req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
+                        req.RequestUri == new Uri($"{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
                         req.Method == HttpMethod.Post &&
                         req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                     ItExpr.IsAny<CancellationToken>()
@@ -545,7 +587,7 @@ namespace {{testPackageName}}.Api {
                 "SendAsync",
                 Times.Exactly(3),
                 ItExpr.Is<HttpRequestMessage>(req =>
-                    req.RequestUri == new Uri($"https://{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
+                    req.RequestUri == new Uri($"{config.Credentials.Config.ApiTokenIssuer}/oauth/token") &&
                     req.Method == HttpMethod.Post &&
                     req.Content.Headers.ContentType.ToString().Equals("application/x-www-form-urlencoded")),
                 ItExpr.IsAny<CancellationToken>()


### PR DESCRIPTION
## Description
Makes token endpoint configurable.

## References
https://github.com/openfga/sdk-generator/issues/238


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

