### PR TITLE
chore(dotnet-sdk): remove dependecy on OpenTelemetry.Api

### DIFF
--- a/config/clients/dotnet/template/netcore_project.mustache
+++ b/config/clients/dotnet/template/netcore_project.mustache
@@ -35,8 +35,4 @@
     <None Include="../../README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.9.0"/>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
As the SDK is not using features from OpenTelemetry Api the dependency is not needed. The instrumentation of the SDK is done via dotnet mechanism (System.Diagnostic). The appliction which use the SDK should manage and configure the OpenTelemetry packages

Backport of https://github.com/openfga/dotnet-sdk/pull/100 by @m4tchl0ck

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

