### PR TITLE
chore(java-sdk): cleanup tests

### DIFF
--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -477,8 +477,16 @@
       "destinationFilename": "src/test/java/dev/openfga/sdk/telemetry/TelemetryTest.java",
       "templateType": "SupportingFiles"
     },
+    "src/test/util/PairTest.java.mustache": {
+      "destinationFilename": "src/test/java/dev/openfga/sdk/util/PairTest.java",
+      "templateType": "SupportingFiles"
+    },
     "src/test/util/StringUtilTest.java.mustache": {
       "destinationFilename": "src/test/java/dev/openfga/sdk/util/StringUtilTest.java",
+      "templateType": "SupportingFiles"
+    },
+    "src/test/util/ValidationTest.java.mustache": {
+      "destinationFilename": "src/test/java/dev/openfga/sdk/util/ValidationTest.java",
       "templateType": "SupportingFiles"
     },
     "src/test-integration/api/OpenFgaApiIntegrationTest.java.mustache": {

--- a/config/clients/java/template/build.gradle.mustache
+++ b/config/clients/java/template/build.gradle.mustache
@@ -92,13 +92,13 @@ testing {
     suites {
         test {
             useJUnitJupiter()
-
             dependencies {
-                implementation project()
-                implementation "org.junit.jupiter:junit-jupiter:$junit_version"
-                implementation "org.mockito:mockito-core:5.15.2"
-                runtimeOnly "org.junit.platform:junit-platform-launcher"
-                implementation "org.wiremock:wiremock:3.11.0"
+                implementation 'org.assertj:assertj-core:3.27.3'
+                implementation 'org.mockito:mockito-core:5.16.1'
+                implementation 'org.junit.jupiter:junit-jupiter:5.12.1'
+                implementation 'org.wiremock:wiremock:3.12.1'
+
+                runtimeOnly 'org.junit.platform:junit-platform-launcher'
 
                 // This test-only dependency is convenient but not widely used.
                 // Review project activity before updating the version here.
@@ -117,6 +117,7 @@ testing {
                 }
             }
         }
+
         integration(JvmTestSuite) {
             testType = TestSuiteType.INTEGRATION_TEST
             useJUnitJupiter()

--- a/config/clients/java/template/libraries/native/ApiClient.mustache
+++ b/config/clients/java/template/libraries/native/ApiClient.mustache
@@ -15,7 +15,6 @@ import {{configPackage}}.Configuration;
 import {{errorsPackage}}.FgaInvalidParameterException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
@@ -29,8 +28,6 @@ import java.util.List;
 import java.util.StringJoiner;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Configuration and utility class for API clients.
@@ -161,16 +158,6 @@ public class ApiClient {
       }
 
       return builder;
-  }
-
-  /**
-   * URL encode a string in the UTF-8 encoding.
-   *
-   * @param s String to encode.
-   * @return URL-encoded representation of the input string.
-   */
-  public static String urlEncode(String s) {
-    return URLEncoder.encode(s, UTF_8).replaceAll("\\+", "%20");
   }
 
   protected ObjectMapper createDefaultObjectMapper() {

--- a/config/clients/java/template/libraries/native/api.mustache
+++ b/config/clients/java/template/libraries/native/api.mustache
@@ -1,7 +1,6 @@
 {{>licenseInfo}}
 package {{package}};
 
-import static {{clientPackage}}.ApiClient.urlEncode;
 import static {{utilPackage}}.StringUtil.isNullOrWhitespace;
 import static {{utilPackage}}.Validation.assertParamExists;
 
@@ -12,6 +11,7 @@ import {{telemetryPackage}}.Attribute;
 import {{telemetryPackage}}.Attributes;
 import {{telemetryPackage}}.Telemetry;
 import {{utilPackage}}.Pair;
+import {{utilPackage}}.StringUtil;
 import {{errorsPackage}}.*;
 
 {{#imports}}
@@ -172,7 +172,7 @@ public class OpenFgaApi {
     assertParamExists({{paramName}}, "{{paramName}}", "{{operationId}}");
     {{/required}}{{/allParams}}
 
-    String path = "{{{path}}}"{{#pathParams}}.replace({{=<% %>=}}"{<%baseName%>}"<%={{ }}=%>, ApiClient.urlEncode({{{paramName}}}.toString())){{/pathParams}};
+    String path = "{{{path}}}"{{#pathParams}}.replace({{=<% %>=}}"{<%baseName%>}"<%={{ }}=%>, StringUtil.urlEncode({{{paramName}}}.toString())){{/pathParams}};
     {{#hasQueryParams}}
     path = pathWithParams(path, {{#queryParams}}"{{baseName}}", {{paramName}}{{^-last}}, {{/-last}}{{/queryParams}});
     {{/hasQueryParams}}

--- a/config/clients/java/template/src/main/telemetry/Attribute.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Attribute.java.mustache
@@ -1,3 +1,4 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 /**

--- a/config/clients/java/template/src/main/telemetry/Attributes.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Attributes.java.mustache
@@ -1,3 +1,4 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 import static {{utilPackage}}.StringUtil.isNullOrWhitespace;
@@ -17,7 +18,6 @@ import java.util.Optional;
  * This class represents a collection of attributes used for telemetry purposes.
  */
 public class Attributes {
-
     /**
      * The client ID used in the request, if applicable.
      */

--- a/config/clients/java/template/src/main/telemetry/Counter.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Counter.java.mustache
@@ -1,3 +1,4 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 /**

--- a/config/clients/java/template/src/main/telemetry/Counters.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Counters.java.mustache
@@ -1,3 +1,4 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 /**
@@ -10,4 +11,6 @@ public class Counters {
     public static final Counter CREDENTIALS_REQUEST = new Counter(
             "fga-client.credentials.request",
             "The total number of times new access tokens have been requested using ClientCredentials.");
+
+    private Counters() {} // Instantiation prevented.
 }

--- a/config/clients/java/template/src/main/telemetry/Histogram.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Histogram.java.mustache
@@ -1,3 +1,4 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 /**

--- a/config/clients/java/template/src/main/telemetry/Histograms.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Histograms.java.mustache
@@ -1,3 +1,4 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 /**
@@ -17,4 +18,6 @@ public class Histograms {
     public static final Histogram QUERY_DURATION = new Histogram(
             "fga-client.query.duration",
             "The total time it took (in milliseconds) for the FGA server to process and evaluate the request.");
+
+    private Histograms() {} // Instantiation prevented.
 }

--- a/config/clients/java/template/src/main/telemetry/Metric.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Metric.java.mustache
@@ -1,8 +1,9 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 public class Metric {
-    protected final String name;
-    protected final String description;
+    private final String name;
+    private final String description;
 
     /**
      * Constructs a new metric with the specified name and description.

--- a/config/clients/java/template/src/main/telemetry/Metrics.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Metrics.java.mustache
@@ -1,3 +1,4 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 import {{configPackage}}.Configuration;
@@ -13,18 +14,13 @@ import java.util.Map;
  * The Metrics class provides methods for creating and publishing metrics using OpenTelemetry.
  */
 public class Metrics {
-
     private final Meter meter;
     private final Map<String, LongCounter> counters;
     private final Map<String, DoubleHistogram> histograms;
     private final Configuration configuration;
 
     public Metrics() {
-        this.meter = OpenTelemetry.noop().getMeterProvider().get("{{artifactId}}");
-        this.counters = new HashMap<>();
-        this.histograms = new HashMap<>();
-        this.configuration = new Configuration();
-        this.configuration.telemetryConfiguration(new TelemetryConfiguration());
+        this(new Configuration());
     }
 
     public Metrics(Configuration configuration) {

--- a/config/clients/java/template/src/main/telemetry/Telemetry.java.mustache
+++ b/config/clients/java/template/src/main/telemetry/Telemetry.java.mustache
@@ -1,3 +1,4 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
 import {{configPackage}}.Configuration;
@@ -19,7 +20,7 @@ public class Telemetry {
      */
     public Metrics metrics() {
         if (metrics == null) {
-            metrics = new Metrics(this.configuration);
+            metrics = new Metrics(configuration);
         }
 
         return metrics;

--- a/config/clients/java/template/src/main/util/Pair.mustache
+++ b/config/clients/java/template/src/main/util/Pair.mustache
@@ -1,60 +1,50 @@
 {{>licenseInfo}}
 package {{utilPackage}};
 
-import static {{clientPackage}}.ApiClient.urlEncode;
-import static {{utilPackage}}.StringUtil.isNullOrWhitespace;
+import static {{utilPackage}}.StringUtil.*;
 
 import java.util.Optional;
 
+/**
+ * A convenient class to hold name-value pairs used when creating elements of a query string.
+ */
 public class Pair {
-    private String name = "";
-    private String value = "";
+    private final String name;
+    private final String value;
 
-    public Pair (String name, String value) {
-        setName(name);
-        setValue(value);
+    public Pair(String name, String value) {
+        this.name = name != null ? name : EMPTY;
+        this.value = value != null ? value : EMPTY;
     }
 
+    /**
+     * Get the name of the pair.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Get the value of the pair.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Return the pair as a query url encoded string pair.
+     */
+    public String asQueryStringPair() {
+        return String.format("%s=%s", urlEncode(name), urlEncode(value));
+    }
+
+    /**
+     * Return the {@link Optional#empty()} if the name or value is invalid, otherwise return the optional of {@link Pair}.
+     */
     public static Optional<Pair> of(String name, Object value) {
         if (isNullOrWhitespace(name) || value == null) {
             return Optional.empty();
         }
         return Optional.of(new Pair(name, value.toString()));
-    }
-
-    public String asQueryStringPair() {
-        return urlEncode(name) + "=" + urlEncode(value);
-    }
-
-    private void setName(String name) {
-        if (!isValidString(name)) {
-            return;
-        }
-
-        this.name = name;
-    }
-
-    private void setValue(String value) {
-        if (!isValidString(value)) {
-            return;
-        }
-
-        this.value = value;
-    }
-
-    public String getName() {
-        return this.name;
-    }
-
-    public String getValue() {
-        return this.value;
-    }
-
-    private boolean isValidString(String arg) {
-        if (arg == null) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/config/clients/java/template/src/main/util/StringUtil.java.mustache
+++ b/config/clients/java/template/src/main/util/StringUtil.java.mustache
@@ -1,23 +1,52 @@
 {{>licenseInfo}}
 package {{utilPackage}};
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.URLEncoder;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+/**
+ * Operations on {@link String}.
+ */
 public class StringUtil {
-    private StringUtil() {} // Instantiation prevented for utility class.
-
-    private static final Predicate<String> NULL_OR_WS =
-            Pattern.compile("^\\s*$").asMatchPredicate();
+    /**
+     * The empty String {@code ""}.
+     */
+    public static final String EMPTY = "";
 
     /**
-     * Returns true when the String is null, empty or contains only whitespace
-     * characters.
-     *
-     * @param str The String being tested.
-     * @return true iff str is null, empty or contains only whitespace.
+     * A predicate that matches when a string contains only whitespace characters.
      */
-    public static boolean isNullOrWhitespace(String str) {
-        return str == null || NULL_OR_WS.test(str);
+    private static final Predicate<String> NULL_OR_WHITESPACE =
+            Pattern.compile("^\\s*$").asMatchPredicate();
+
+    private StringUtil() {} // Instantiation prevented for utility class.
+
+    /**
+     * Returns {@code true} when the string is:
+     * <ul>
+     *     <li>{@code null}</li>
+     *     <li>empty</li>
+     *     <li>contains <b>only</b> whitespace characters</li>
+     * </ul>
+     * otherwise {@code false}.
+     *
+     * @param string the string being tested
+     * @return true if string is {@code null}, empty or contains <b>only</b> whitespace(s)
+     */
+    public static boolean isNullOrWhitespace(String string) {
+        return string == null || NULL_OR_WHITESPACE.test(string);
+    }
+
+    /**
+     * URL encode a string in the UTF-8 encoding.
+     *
+     * @param string the string to encode
+     * @return URL-encoded representation of the input string
+     */
+    public static String urlEncode(String string) {
+        return URLEncoder.encode(string, UTF_8).replace("+", "%20");
     }
 }

--- a/config/clients/java/template/src/test/telemetry/AttributeTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/AttributeTest.java.mustache
@@ -1,21 +1,21 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 class AttributeTest {
-
     @Test
-    void testGetName() {
-        // Arrange
+    void shouldGetName() {
+        // given
         String attributeName = "testAttribute";
         Attribute attribute = new Attribute(attributeName);
 
-        // Act
+        // when
         String result = attribute.getName();
 
-        // Assert
-        assertEquals(attributeName, result, "The name should match the one provided in the constructor.");
+        // then
+        assertThat(result).isEqualTo(attributeName);
     }
 }

--- a/config/clients/java/template/src/test/telemetry/AttributesTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/AttributesTest.java.mustache
@@ -1,6 +1,8 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,37 +20,32 @@ import java.util.*;
 import org.junit.jupiter.api.Test;
 
 class AttributesTest {
-
     @Test
-    void testPrepare() {
-        // Arrange
-        Map<Attribute, String> attributes = new HashMap<>();
-        attributes.put(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID, "client-id-value");
-         Metric metric = Histograms.QUERY_DURATION;
+    void shouldPrepareAttributes() {
+        // given
+        Map<Attribute, String> attributes = Map.of(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID, "client-id-value");
+        Metric metric = Histograms.QUERY_DURATION;
 
-        Map<Metric, Map<Attribute, Optional<Object>>> metricsMap = new HashMap<>();
-        Map<Attribute, Optional<Object>> attributeMap = new HashMap<>();
-        attributeMap.put(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID, Optional.of("config-value"));
-        metricsMap.put(metric, attributeMap);
+        Map<Attribute, Optional<Object>> attributeMap =
+                Map.of(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID, Optional.of("config-value"));
+        Map<Metric, Map<Attribute, Optional<Object>>> metricsMap = Map.of(metric, attributeMap);
+
         TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(metricsMap);
+        Configuration configuration = new Configuration().telemetryConfiguration(telemetryConfiguration);
 
-        Configuration configuration = new Configuration();
-        configuration.telemetryConfiguration(telemetryConfiguration);
-
-        // Act
+        // when
         io.opentelemetry.api.common.Attributes result = Attributes.prepare(attributes, metric, configuration);
 
-        // Assert
-        AttributesBuilder builder = io.opentelemetry.api.common.Attributes.builder();
-        builder.put(AttributeKey.stringKey(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID.getName()), "client-id-value");
-        io.opentelemetry.api.common.Attributes expected = builder.build();
-
-        assertEquals(expected, result);
+        // then
+        io.opentelemetry.api.common.Attributes expected = io.opentelemetry.api.common.Attributes.builder()
+                .put(stringKey(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID.getName()), "client-id-value")
+                .build();
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
-    void testPrepare_filtersAttributesFromDefaults() {
-        // Arrange
+    void shouldPrepareFiltersAttributesFromDefaults() {
+        // given
 
         // sent by default
         Map<Attribute, String> defaultAttributes = new HashMap<>();
@@ -58,8 +55,7 @@ class AttributesTest {
         }
 
         // not sent by default
-        Map<Attribute, String> nonDefaultAttributes = new HashMap<>();
-        nonDefaultAttributes.put(Attributes.FGA_CLIENT_USER, "user-value");
+        Map<Attribute, String> nonDefaultAttributes = Map.of(Attributes.FGA_CLIENT_USER, "user-value");
 
         Map<Attribute, String> attributes = new HashMap<>();
         attributes.putAll(defaultAttributes);
@@ -70,22 +66,22 @@ class AttributesTest {
         Configuration configuration = new Configuration();
         configuration.telemetryConfiguration(new TelemetryConfiguration());
 
-        // Act
+        // when
         io.opentelemetry.api.common.Attributes result = Attributes.prepare(attributes, metric, configuration);
 
-        // Assert
+        // then
         AttributesBuilder builder = io.opentelemetry.api.common.Attributes.builder();
         for (Map.Entry<Attribute, String> entry : defaultAttributes.entrySet()) {
-            builder.put(AttributeKey.stringKey(entry.getKey().getName()), entry.getValue());
+            builder.put(stringKey(entry.getKey().getName()), entry.getValue());
         }
         io.opentelemetry.api.common.Attributes expected = builder.build();
 
-        assertEquals(expected, result);
+        assertThat(result).isEqualTo(expected);
     }
 
     @Test
-    void testFromHttpResponse() {
-        // Arrange
+    void shouldConvertAttributesFromHttpResponse() {
+        // given
         HttpResponse<?> response = mock(HttpResponse.class);
         HttpHeaders headers = mock(HttpHeaders.class);
         when(response.headers()).thenReturn(headers);
@@ -98,21 +94,19 @@ class AttributesTest {
         when(credentials.getClientCredentials()).thenReturn(clientCredentials);
         when(clientCredentials.getClientId()).thenReturn("client-id-value");
 
-        // Act
+        // when
         Map<Attribute, String> result = Attributes.fromHttpResponse(response, credentials);
 
-        // Assert
-        Map<Attribute, String> expected = new HashMap<>();
-        expected.put(Attributes.HTTP_RESPONSE_STATUS_CODE, "200");
-        expected.put(Attributes.FGA_CLIENT_RESPONSE_MODEL_ID, "model-id-value");
-        expected.put(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID, "client-id-value");
-
-        assertEquals(expected, result);
+        // then
+        assertThat(result)
+                .containsEntry(Attributes.HTTP_RESPONSE_STATUS_CODE, "200")
+                .containsEntry(Attributes.FGA_CLIENT_RESPONSE_MODEL_ID, "model-id-value")
+                .containsEntry(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID, "client-id-value");
     }
 
     @Test
-    void testFromApiResponse() {
-        // Arrange
+    void shouldConvertAttributesFromApiResponse() {
+        // given
         ApiResponse<?> response = mock(ApiResponse.class);
         Map<String, List<String>> headers = new HashMap<>();
         headers.put("openfga-authorization-model-id", Collections.singletonList("model-id-value"));
@@ -125,15 +119,13 @@ class AttributesTest {
         when(credentials.getClientCredentials()).thenReturn(clientCredentials);
         when(clientCredentials.getClientId()).thenReturn("client-id-value");
 
-        // Act
+        // when
         Map<Attribute, String> result = Attributes.fromApiResponse(response, credentials);
 
-        // Assert
-        Map<Attribute, String> expected = new HashMap<>();
-        expected.put(Attributes.HTTP_RESPONSE_STATUS_CODE, "200");
-        expected.put(Attributes.FGA_CLIENT_RESPONSE_MODEL_ID, "model-id-value");
-        expected.put(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID, "client-id-value");
-
-        assertEquals(expected, result);
+        // then
+        assertThat(result)
+                .containsEntry(Attributes.HTTP_RESPONSE_STATUS_CODE, "200")
+                .containsEntry(Attributes.FGA_CLIENT_RESPONSE_MODEL_ID, "model-id-value")
+                .containsEntry(Attributes.FGA_CLIENT_REQUEST_CLIENT_ID, "client-id-value");
     }
 }

--- a/config/clients/java/template/src/test/telemetry/CounterTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/CounterTest.java.mustache
@@ -1,25 +1,22 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 class CounterTest {
-
     @Test
-    void testCounterConstructor() {
-        // Arrange
+    void shouldCreateCounter() {
+        // given
         String name = "testCounter";
         String description = "A counter for testing";
 
-        // Act
+        // when
         Counter counter = new Counter(name, description);
 
-        // Assert
-        assertEquals(name, counter.getName(), "The name should match the one provided in the constructor.");
-        assertEquals(
-                description,
-                counter.getDescription(),
-                "The description should match the one provided in the constructor.");
+        // then
+        assertThat(counter.getName()).isEqualTo(name);
+        assertThat(counter.getDescription()).isEqualTo(description);
     }
 }

--- a/config/clients/java/template/src/test/telemetry/CountersTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/CountersTest.java.mustache
@@ -1,23 +1,23 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 class CountersTest {
-
     @Test
-    void testCredentialsRequestCounter() {
-        // Arrange
+    void shouldCreateCredentialsRequestCounter() {
+        // given
         String expectedName = "fga-client.credentials.request";
         String expectedDescription =
                 "The total number of times new access tokens have been requested using ClientCredentials.";
 
-        // Act
+        // when
         Counter counter = Counters.CREDENTIALS_REQUEST;
 
-        // Assert
-        assertEquals(expectedName, counter.getName(), "The name should match the expected value.");
-        assertEquals(expectedDescription, counter.getDescription(), "The description should match the expected value.");
+        // then
+        assertThat(counter.getName()).isEqualTo(expectedName);
+        assertThat(counter.getDescription()).isEqualTo(expectedDescription);
     }
 }

--- a/config/clients/java/template/src/test/telemetry/HistogramTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/HistogramTest.java.mustache
@@ -1,45 +1,39 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 class HistogramTest {
-
     @Test
-    void testHistogramConstructorWithUnit() {
-        // Arrange
+    void shouldCreateHistogramWithUnit() {
+        // given
         String name = "testHistogram";
         String unit = "seconds";
         String description = "A histogram for testing";
 
-        // Act
+        // when
         Histogram histogram = new Histogram(name, unit, description);
 
-        // Assert
-        assertEquals(name, histogram.getName(), "The name should match the one provided in the constructor.");
-        assertEquals(unit, histogram.getUnit(), "The unit should match the one provided in the constructor.");
-        assertEquals(
-                description,
-                histogram.getDescription(),
-                "The description should match the one provided in the constructor.");
+        // then
+        assertThat(histogram.getName()).isEqualTo(name);
+        assertThat(histogram.getDescription()).isEqualTo(description);
+        assertThat(histogram.getUnit()).isEqualTo(unit);
     }
 
     @Test
-    void testHistogramConstructorWithoutUnit() {
-        // Arrange
+    void shouldCreateHistogramWithDefaultMillisecondsUnit() {
+        // given
         String name = "testHistogram";
         String description = "A histogram for testing";
 
-        // Act
+        // when
         Histogram histogram = new Histogram(name, description);
 
-        // Assert
-        assertEquals(name, histogram.getName(), "The name should match the one provided in the constructor.");
-        assertEquals("milliseconds", histogram.getUnit(), "The default unit should be 'milliseconds'.");
-        assertEquals(
-                description,
-                histogram.getDescription(),
-                "The description should match the one provided in the constructor.");
+        // then
+        assertThat(histogram.getName()).isEqualTo(name);
+        assertThat(histogram.getDescription()).isEqualTo(description);
+        assertThat(histogram.getUnit()).isEqualTo("milliseconds");
     }
 }

--- a/config/clients/java/template/src/test/telemetry/HistogramsTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/HistogramsTest.java.mustache
@@ -1,42 +1,40 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 class HistogramsTest {
-
     @Test
-    void testRequestDurationHistogram() {
-        // Arrange
+    void shouldCreateRequestDurationHistogram() {
+        // given
         String expectedName = "fga-client.request.duration";
         String expectedDescription =
                 "The total time (in milliseconds) it took for the request to complete, including the time it took to send the request and receive the response.";
 
-        // Act
+        // when
         Histogram histogram = Histograms.REQUEST_DURATION;
 
-        // Assert
-        assertEquals(expectedName, histogram.getName(), "The name should match the expected value.");
-        assertEquals("milliseconds", histogram.getUnit(), "The default unit should be 'milliseconds'.");
-        assertEquals(
-                expectedDescription, histogram.getDescription(), "The description should match the expected value.");
+        // then
+        assertThat(histogram.getName()).isEqualTo(expectedName);
+        assertThat(histogram.getUnit()).isEqualTo("milliseconds");
+        assertThat(histogram.getDescription()).isEqualTo(expectedDescription);
     }
 
     @Test
-    void testQueryDurationHistogram() {
-        // Arrange
+    void shouldCreateQueryDurationHistogram() {
+        // given
         String expectedName = "fga-client.query.duration";
         String expectedDescription =
                 "The total time it took (in milliseconds) for the FGA server to process and evaluate the request.";
 
-        // Act
+        // when
         Histogram histogram = Histograms.QUERY_DURATION;
 
-        // Assert
-        assertEquals(expectedName, histogram.getName(), "The name should match the expected value.");
-        assertEquals("milliseconds", histogram.getUnit(), "The default unit should be 'milliseconds'.");
-        assertEquals(
-                expectedDescription, histogram.getDescription(), "The description should match the expected value.");
+        // then
+        assertThat(histogram.getName()).isEqualTo(expectedName);
+        assertThat(histogram.getUnit()).isEqualTo("milliseconds");
+        assertThat(histogram.getDescription()).isEqualTo(expectedDescription);
     }
 }

--- a/config/clients/java/template/src/test/telemetry/MetricTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/MetricTest.java.mustache
@@ -1,25 +1,22 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 class MetricTest {
-
     @Test
-    void testMetricConstructor() {
-        // Arrange
+    void shouldCreateMetric() {
+        // given
         String name = "testMetric";
         String description = "A metric for testing";
 
-        // Act
+        // when
         Metric metric = new Metric(name, description);
 
-        // Assert
-        assertEquals(name, metric.getName(), "The name should match the one provided in the constructor.");
-        assertEquals(
-                description,
-                metric.getDescription(),
-                "The description should match the one provided in the constructor.");
+        // then
+        assertThat(metric.getName()).isEqualTo(name);
+        assertThat(metric.getDescription()).isEqualTo(description);
     }
 }

--- a/config/clients/java/template/src/test/telemetry/MetricsTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/MetricsTest.java.mustache
@@ -1,6 +1,7 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -16,201 +17,184 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MetricsTest {
+    @Test
+    void shouldConstructorWithConfiguration() {
+        // when
+        Metrics metricsWithConfig = new Metrics(new Configuration());
 
-    private Metrics metrics;
-    private Configuration configuration;
-
-    @BeforeEach
-    void setUp() {
-        configuration = mock(Configuration.class);
-        metrics = new Metrics(configuration);
-
-        when(configuration.getTelemetryConfiguration()).thenReturn(new TelemetryConfiguration());
+        // then
+        assertThat(metricsWithConfig.getMeter()).isNotNull();
     }
 
     @Test
-    void testConstructorWithConfiguration() {
-        // Act
-        Metrics metricsWithConfig = new Metrics(configuration);
-
-        // Assert
-        assertNotNull(metricsWithConfig.getMeter(), "The Meter object should not be null.");
-    }
-
-    @Test
-    void testConstructorWithoutConfiguration() {
-        // Act
+    void shouldConstructorWithoutConfiguration() {
+        // when
         Metrics metricsWithoutConfig = new Metrics();
 
-        // Assert
-        assertNotNull(metricsWithoutConfig.getMeter(), "The Meter object should not be null.");
+        // then
+        assertThat(metricsWithoutConfig.getMeter()).isNotNull();
     }
 
     @Test
-    void testGetMeter() {
-        // Act
+    void shouldGetMeter() {
+        // given
+        Metrics metrics = new Metrics();
+
+        // when
         Meter meter = metrics.getMeter();
 
-        // Assert
-        assertNotNull(meter, "The Meter object should not be null.");
+        // then
+        assertThat(meter).isNotNull();
     }
 
     @Test
-    void testGetCounter() {
-        // Arrange
+    void shouldGetCounter() {
+        // given
         Counter counter = Counters.CREDENTIALS_REQUEST;
         Long value = 10L;
-        Map<Attribute, String> attributes = new HashMap<>();
+        Map<Attribute, String> attributes = Map.of();
+        Metrics metrics = new Metrics();
 
-        // Act
+        // when
         LongCounter longCounter = metrics.getCounter(counter, value, attributes);
 
-        // Assert
-        assertNotNull(longCounter, "The LongCounter object should not be null.");
+        // then
+        assertThat(longCounter).isNotNull();
     }
 
     @Test
-    void testGetHistogram() {
-        // Arrange
+    void shouldGetHistogram() {
+        // given
         Histogram histogram = Histograms.REQUEST_DURATION;
         Double value = 100.0;
-        Map<Attribute, String> attributes = new HashMap<>();
+        Map<Attribute, String> attributes = Map.of();
+        Metrics metrics = new Metrics();
 
-        // Act
+        // when
         DoubleHistogram doubleHistogram = metrics.getHistogram(histogram, value, attributes);
 
-        // Assert
-        assertNotNull(doubleHistogram, "The DoubleHistogram object should not be null.");
+        // then
+        assertThat(doubleHistogram).isNotNull();
     }
 
     @Test
-    void testCredentialsRequest() {
-        // Arrange
+    void shouldCredentialsRequest() {
+        // given
         Long value = 5L;
-        Map<Attribute, String> attributes = new HashMap<>();
+        Map<Attribute, String> attributes = Map.of();
+        Metrics metrics = new Metrics();
 
-        // Act
+        // when
         LongCounter longCounter = metrics.credentialsRequest(value, attributes);
 
-        // Assert
-        assertNotNull(longCounter, "The LongCounter object should not be null.");
+        // then
+        assertThat(longCounter).isNotNull();
     }
 
     @Test
-    void testRequestDuration() {
-        // Arrange
+    void shouldRequestDuration() {
+        // given
         Double value = 200.0;
-        Map<Attribute, String> attributes = new HashMap<>();
+        Map<Attribute, String> attributes = Map.of();
+        Metrics metrics = new Metrics();
 
-        // Act
+        // when
         DoubleHistogram doubleHistogram = metrics.requestDuration(value, attributes);
 
-        // Assert
-        assertNotNull(doubleHistogram, "The DoubleHistogram object should not be null.");
+        // then
+        assertThat(doubleHistogram).isNotNull();
     }
 
     @Test
-    void testQueryDuration() {
-        // Arrange
+    void shouldQueryDuration() {
+        // given
         Double value = 150.0;
-        Map<Attribute, String> attributes = new HashMap<>();
+        Map<Attribute, String> attributes = Map.of();
+        Metrics metrics = new Metrics();
 
-        // Act
+        // when
         DoubleHistogram doubleHistogram = metrics.queryDuration(value, attributes);
 
-        // Assert
-        assertNotNull(doubleHistogram, "The DoubleHistogram object should not be null.");
+        // then
+        assertThat(doubleHistogram).isNotNull();
     }
 
     @Test
-    void testMetricsNotSentIfNotConfigured() {
-        Map<Attribute, Optional<Object>> attributes = new HashMap<>();
-        attributes.put(Attributes.FGA_CLIENT_REQUEST_METHOD, Optional.empty());
-        Map<Metric, Map<Attribute, Optional<Object>>> metrics = new HashMap<>();
-        metrics.put(Histograms.QUERY_DURATION, attributes);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(metrics);
+    void shouldNotSentMetricsIfNotConfigured() {
+        // given
+        Map<Attribute, Optional<Object>> attributes = Map.of(Attributes.FGA_CLIENT_REQUEST_METHOD, Optional.empty());
+        Map<Metric, Map<Attribute, Optional<Object>>> metrics = Map.of(Histograms.QUERY_DURATION, attributes);
 
-        Configuration config = new Configuration();
-        config.telemetryConfiguration(telemetryConfiguration);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(metrics);
+        Configuration config = new Configuration().telemetryConfiguration(telemetryConfiguration);
 
         Metrics configuredMetrics = new Metrics(config);
 
-        DoubleHistogram requestDuration =
-                configuredMetrics.getHistogram(Histograms.REQUEST_DURATION, 10.0, new HashMap<>());
-        assertNull(requestDuration, "Unconfigured histograms should not be sent.");
+        // when
+        DoubleHistogram requestDuration = configuredMetrics.getHistogram(Histograms.REQUEST_DURATION, 10.0, Map.of());
+        DoubleHistogram queryDuration = configuredMetrics.getHistogram(Histograms.QUERY_DURATION, 10.0, Map.of());
+        LongCounter credentialRequest = configuredMetrics.getCounter(Counters.CREDENTIALS_REQUEST, 10L, Map.of());
 
-        DoubleHistogram queryDuration =
-                configuredMetrics.getHistogram(Histograms.QUERY_DURATION, 10.0, new HashMap<>());
-        assertNotNull(queryDuration, "Configured histograms should be sent.");
-
-        LongCounter credsRequestCounter =
-                configuredMetrics.getCounter(Counters.CREDENTIALS_REQUEST, 10L, new HashMap<>());
-        assertNull(credsRequestCounter, "Unconfigured counters should not be sent.");
+        // then
+        assertThat(requestDuration).isNull();
+        assertThat(queryDuration).isNotNull();
+        assertThat(credentialRequest).isNull();
     }
 
     @Test
-    void testCountersNotSentIfNotConfigured() {
-        Map<Attribute, Optional<Object>> attributes = new HashMap<>();
-        attributes.put(Attributes.FGA_CLIENT_REQUEST_METHOD, Optional.empty());
-        Map<Metric, Map<Attribute, Optional<Object>>> metrics = new HashMap<>();
-        metrics.put(Counters.CREDENTIALS_REQUEST, attributes);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(metrics);
+    void shouldNotSentCountersIfNotConfigured() {
+        // given
+        Map<Attribute, Optional<Object>> attributes = Map.of(Attributes.FGA_CLIENT_REQUEST_METHOD, Optional.empty());
+        Map<Metric, Map<Attribute, Optional<Object>>> metrics = Map.of(Counters.CREDENTIALS_REQUEST, attributes);
 
-        Configuration config = new Configuration();
-        config.telemetryConfiguration(telemetryConfiguration);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(metrics);
+        Configuration config = new Configuration().telemetryConfiguration(telemetryConfiguration);
 
         Metrics configuredMetrics = new Metrics(config);
 
-        DoubleHistogram requestDuration =
-                configuredMetrics.getHistogram(Histograms.REQUEST_DURATION, 10.0, new HashMap<>());
-        assertNull(requestDuration, "Unconfigured histograms should not be sent.");
+        // when
+        DoubleHistogram requestDuration = configuredMetrics.getHistogram(Histograms.REQUEST_DURATION, 10.0, Map.of());
+        DoubleHistogram queryDuration = configuredMetrics.getHistogram(Histograms.QUERY_DURATION, 10.0, Map.of());
+        LongCounter credentialRequest = configuredMetrics.getCounter(Counters.CREDENTIALS_REQUEST, 10L, Map.of());
 
-        DoubleHistogram queryDuration =
-                configuredMetrics.getHistogram(Histograms.QUERY_DURATION, 10.0, new HashMap<>());
-        assertNull(queryDuration, "Unconfigured histograms should not be sent.");
-
-        LongCounter credsCounter = configuredMetrics.getCounter(Counters.CREDENTIALS_REQUEST, 10L, new HashMap<>());
-        assertNotNull(credsCounter, "Configured counter should be sent.");
+        // then
+        assertThat(requestDuration).isNull();
+        assertThat(queryDuration).isNull();
+        assertThat(credentialRequest).isNotNull();
     }
 
     @Test
-    void testDefaultMetricsEnabled() {
-        // Arrange
+    void shouldDefaultMetricsEnabled() {
+        // given
         Configuration config = new Configuration();
 
-        // Act
+        // when
         Metrics metrics = new Metrics(config);
 
-        // Assert
-        assertNotNull(
-                metrics.getCounter(Counters.CREDENTIALS_REQUEST, 10L, new HashMap<>()), "The counter should be sent.");
-        assertNotNull(
-                metrics.getHistogram(Histograms.QUERY_DURATION, 10.0, new HashMap<>()),
-                "The query duration histogram should be sent.");
-        assertNotNull(
-                metrics.getHistogram(Histograms.REQUEST_DURATION, 10.0, new HashMap<>()),
-                "The request duration histogram should be sent.");
+        // then
+        assertThat(metrics.getCounter(Counters.CREDENTIALS_REQUEST, 10L, Map.of()))
+                .isNotNull();
+        assertThat(metrics.getHistogram(Histograms.QUERY_DURATION, 10.0, Map.of()))
+                .isNotNull();
+        assertThat(metrics.getHistogram(Histograms.REQUEST_DURATION, 10.0, Map.of()))
+                .isNotNull();
     }
 
     @Test
-    void testMetricsWithNullMetricsConfig() {
-        // Arrange
+    void shouldMetricsWithNullMetricsConfig() {
+        // given
         TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(null);
-        Configuration config = new Configuration();
-        config.telemetryConfiguration(telemetryConfiguration);
+        Configuration config = new Configuration().telemetryConfiguration(telemetryConfiguration);
 
-        // Act
+        // when
         Metrics metrics = new Metrics(config);
 
-        // Assert
-        assertNull(
-                metrics.getCounter(Counters.CREDENTIALS_REQUEST, 10L, new HashMap<>()),
-                "The counter should not be sent.");
-        assertNull(
-                metrics.getHistogram(Histograms.QUERY_DURATION, 10.0, new HashMap<>()),
-                "The query duration histogram should not be sent.");
-        assertNull(
-                metrics.getHistogram(Histograms.REQUEST_DURATION, 10.0, new HashMap<>()),
-                "The request duration histogram should not be sent.");
+        // then
+        assertThat(metrics.getCounter(Counters.CREDENTIALS_REQUEST, 10L, Map.of()))
+                .isNull();
+        assertThat(metrics.getHistogram(Histograms.QUERY_DURATION, 10.0, Map.of()))
+                .isNull();
+        assertThat(metrics.getHistogram(Histograms.REQUEST_DURATION, 10.0, Map.of()))
+                .isNull();
     }
 }

--- a/config/clients/java/template/src/test/telemetry/TelemetryTest.java.mustache
+++ b/config/clients/java/template/src/test/telemetry/TelemetryTest.java.mustache
@@ -1,25 +1,22 @@
+{{>licenseInfo}}
 package {{telemetryPackage}};
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import {{configPackage}}.Configuration;
 import org.junit.jupiter.api.Test;
 
 class TelemetryTest {
-
     @Test
-    void testMetricsInitialization() {
-        // Arrange
-        Configuration configuration = mock(Configuration.class);
-        Telemetry telemetry = new Telemetry(configuration);
+    void shouldBeASingletonMetricsInitialization() {
+        // given
+        Telemetry telemetry = new Telemetry(new Configuration());
 
-        // Act
+        // when
         Metrics firstCall = telemetry.metrics();
         Metrics secondCall = telemetry.metrics();
 
-        // Assert
-        assertNotNull(firstCall, "The Metrics object should not be null after initialization.");
-        assertSame(firstCall, secondCall, "The same Metrics object should be returned on subsequent calls.");
+        // then
+        assertThat(firstCall).isNotNull().isSameAs(secondCall);
     }
 }

--- a/config/clients/java/template/src/test/util/PairTest.java.mustache
+++ b/config/clients/java/template/src/test/util/PairTest.java.mustache
@@ -1,0 +1,72 @@
+{{>licenseInfo}}
+package {{utilPackage}};
+
+import static dev.openfga.sdk.util.StringUtil.EMPTY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class PairTest {
+    @Test
+    void shouldCreatePair() {
+        // when
+        Pair pair = new Pair("name", "value");
+
+        // then
+        assertThat(pair.getName()).isEqualTo("name");
+        assertThat(pair.getValue()).isEqualTo("value");
+    }
+
+    @Test
+    void shouldCreatePairWithEmptyNameAndValueWhenNameAndValueAreNull() {
+        // when
+        Pair pair = new Pair(null, null);
+
+        // then
+        assertThat(pair.getName()).isEmpty();
+        assertThat(pair.getValue()).isEmpty();
+    }
+
+    @Test
+    void shouldUrlEncodeNameAndValue() {
+        // given
+        Pair pair = new Pair("name_with_+_char", "value_with_=_char");
+
+        // when
+        String queryStringPair = pair.asQueryStringPair();
+
+        // then
+        assertThat(queryStringPair).isEqualTo("name_with_%2B_char=value_with_%3D_char");
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenNameIsNullOrWhitespace() {
+        // when
+        Optional<Pair> pair = Pair.of(EMPTY, "value");
+
+        // then
+        assertThat(pair).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyOptionalWhenValueIsNull() {
+        // when
+        Optional<Pair> pair = Pair.of("name", null);
+
+        // then
+        assertThat(pair).isEmpty();
+    }
+
+    @Test
+    void shouldReturnOptionalWithPair() {
+        // when
+        Optional<Pair> pair = Pair.of("name", "value");
+
+        // then
+        assertThat(pair).isPresent().hasValueSatisfying(p -> {
+            assertThat(p.getName()).isEqualTo("name");
+            assertThat(p.getValue()).isEqualTo("value");
+        });
+    }
+}

--- a/config/clients/java/template/src/test/util/StringUtilTest.java.mustache
+++ b/config/clients/java/template/src/test/util/StringUtilTest.java.mustache
@@ -1,39 +1,51 @@
 {{>licenseInfo}}
 package {{utilPackage}};
 
-import org.junit.jupiter.api.Test;
-
 import static {{utilPackage}}.StringUtil.isNullOrWhitespace;
-import static org.junit.jupiter.api.Assertions.*;
+import static {{utilPackage}}.StringUtil.urlEncode;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class StringUtilTest {
     @Test
-    public void isNullOrWhitespace_someContent_false() {
-        assertFalse(isNullOrWhitespace("abc"));
+    void shouldReturnFalseWhenStringIsNotNullNorWhitespace() {
+        // when
+        boolean nullOrWhitespace = isNullOrWhitespace("abc");
+
+        // then
+        assertThat(nullOrWhitespace).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "  ", " \t\n"})
+    @NullSource
+    void shouldReturnTrueWhenStringIsNullOrWhitespace(String string) {
+        // when
+        boolean nullOrWhitespace = isNullOrWhitespace(string);
+
+        // then
+        assertThat(nullOrWhitespace).isTrue();
     }
 
     @Test
-    public void isNullOrWhitespace_null_true() {
-        assertTrue(isNullOrWhitespace(null));
+    void shouldUrlEncodeString() {
+        // when
+        String urlEncode = urlEncode("name_with_=_char");
+
+        // then
+        assertThat(urlEncode).isEqualTo("name_with_%3D_char");
     }
 
     @Test
-    public void isNullOrWhitespace_empty_true() {
-        assertTrue(isNullOrWhitespace(""));
-    }
+    void shouldUrlEncodeStringWithSpaceCharacter() {
+        // when
+        String urlEncode = urlEncode("name_ with_ _char");
 
-    @Test
-    public void isNullOrWhitespace_singleSpace_true() {
-        assertTrue(isNullOrWhitespace(" "));
-    }
-
-    @Test
-    public void isNullOrWhitespace_multipleSpace_true() {
-        assertTrue(isNullOrWhitespace(" "));
-    }
-
-    @Test
-    public void isNullOrWhitespace_multipleOtherWhitespace_true() {
-        assertTrue(isNullOrWhitespace(" \t\r\n"));
+        // then
+        assertThat(urlEncode).isEqualTo("name_%20with_%20_char");
     }
 }

--- a/config/clients/java/template/src/test/util/ValidationTest.java.mustache
+++ b/config/clients/java/template/src/test/util/ValidationTest.java.mustache
@@ -1,0 +1,42 @@
+{{>licenseInfo}}
+package dev.openfga.sdk.util;
+
+import static {{utilPackage}}.Validation.assertParamExists;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+
+import dev.openfga.sdk.errors.FgaInvalidParameterException;
+import org.junit.jupiter.api.Test;
+
+class ValidationTest {
+    @Test
+    void shouldDoNotThrowFgaInvalidParameterException() {
+        // when
+        ThrowingCallable throwingCallable = () -> assertParamExists("some-store-id", "storeId", "batchCheck");
+
+        // then
+        assertThatCode(throwingCallable).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldThrowFgaInvalidParameterExceptionWhenObjectIsNull() {
+        // when
+        ThrowingCallable throwingCallable = () -> assertParamExists(null, "storeId", "batchCheck");
+
+        // then
+        assertThatCode(throwingCallable)
+                .isInstanceOf(FgaInvalidParameterException.class)
+                .hasMessage("Required parameter storeId was invalid when calling batchCheck.");
+    }
+
+    @Test
+    void shouldThrowFgaInvalidParameterExceptionWhenObjectIsEmpty() {
+        // when
+        ThrowingCallable throwingCallable = () -> assertParamExists("", "storeId", "batchCheck");
+
+        // then
+        assertThatCode(throwingCallable)
+                .isInstanceOf(FgaInvalidParameterException.class)
+                .hasMessage("Required parameter storeId was invalid when calling batchCheck.");
+    }
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This is the first phase of refactoring tests in the Java SDK. Upcoming PRs will introduce support for Testcontainers and focus on testing API clients.

### General

* Introduced BDD test style with `given/when/then` sections and naming with the should prefix
* Added missing license clauses

### Dependencies
* Introduced `org.assertj:assertj-core:3.27.3`
* Updated:
  * `org.mockito:mockito-core` → `5.16.1`
  * `org.junit.jupiter:junit-jupiter` → `5.12.1`
  * `org.wiremock:wiremock` → `3.12.1`
* Sorted test dependencies alphabetically

### `Validation` Class

* Added missing test

### `Pair` Class

* Simplified logic
* Added Javadocs
* Added missing tests

### `StringUtil` Class

* Cleaned up code
* Added Javadocs
* Reorganized tests
* Moved `ApiClient.urlEncode()` method to `StringUtil` class (breaking change?).

## References
Ref: https://github.com/openfga/sdk-generator/issues/476

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
