### PR TITLE
docs(go-sdk): Add BatchCheck example - fix typo in readme

### DIFF
--- a/config/clients/go/template/README_calling_api.mustache
+++ b/config/clients/go/template/README_calling_api.mustache
@@ -414,7 +414,8 @@ options := BatchCheckOptions{
     MaxParallelRequests: {{packageName}}.PtrInt32(5), // Max number of requests to issue in parallel, defaults to 10
 }
 
-body := BatchCheckBody{ {
+body := ClientBatchCheckRequest{
+	Items: []openfga.ClientBatchCheckItem{ {
     User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
     Relation: "viewer",
     Object:   "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
@@ -441,8 +442,9 @@ body := BatchCheckBody{ {
     Relation: "deleter",
     Object:   "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
 } }
+}
 
-data, err := fgaClient.BatchCheck(context.Background()).Body(requestBody).Options(options).Execute()
+data, err := fgaClient.BatchCheck(context.Background()).Body(body).Options(options).Execute()
 
 /*
 data = [{

--- a/config/clients/go/template/example/example1/example1.go
+++ b/config/clients/go/template/example/example1/example1.go
@@ -244,6 +244,36 @@ func mainInner() error {
 	}
 	fmt.Printf("Allowed: %v\n", checkResponse.Allowed)
 
+	// BatchCheck
+	fmt.Println("Batch checking for access")
+	batchCheckResponse, err := fgaClient.BatchCheck(ctx).Body(client.ClientBatchCheckRequest{
+		Items: []client.ClientBatchCheckItem{
+			{
+				TupleKey: client.ClientTupleKey{
+					User:     "user:anne",
+					Relation: "viewer",
+					Object:   "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+				},
+				Context: &map[string]interface{}{"ViewCount": 100},
+			},
+			{
+				TupleKey: client.ClientTupleKey{
+					User:     "user:bob",
+					Relation: "viewer",
+					Object:   "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+				},
+				Context: &map[string]interface{}{"ViewCount": 100},
+			},
+		},
+	}).Execute()
+	if err != nil {
+		return err
+	}
+	fmt.Println("BatchCheck results:")
+	for i, response := range batchCheckResponse.Responses {
+		fmt.Printf("Item %d - Allowed: %v\n", i, response.Allowed)
+	}
+
 	// ListObjects
 	fmt.Println("Listing objects user has access to")
 	listObjectsResponse, err := fgaClient.ListObjects(ctx).Body(client.ClientListObjectsRequest{


### PR DESCRIPTION
## Description
- Fix typo on function name in README for Batch Check
- Add BatchCheck example to examples/example1.go

## References
https://github.com/openfga/go-sdk/issues/190

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

