### PR TITLE
fix(go-sdk): resolve server-side BatchCheck stalling

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -9,6 +9,7 @@ import (
 	_nethttp "net/http"
 	"time"
 
+	"github.com/sourcegraph/conc/pool"
 	"golang.org/x/sync/errgroup"
 
 	fgaSdk "{{gitHost}}/{{gitUserId}}/{{gitRepoId}}"
@@ -2213,82 +2214,34 @@ func (client *OpenFgaClient) BatchCheckExecute(request SdkClientBatchCheckReques
 	}
 
 	chunks := chunkClientBatchCheckItems(body.Checks, int(maxBatchSize))
-
-	ctx, cancel := _context.WithCancel(ctx)
-	defer cancel()
-
-	resultChan := make(chan *fgaSdk.BatchCheckResponse, len(chunks))
-	errorChan := make(chan error, 1)
-
-	var wg errgroup.Group
-	wg.SetLimit(int(maxParallelRequests))
-
+	
+	p := pool.NewWithResults[*fgaSdk.BatchCheckResponse]().WithContext(ctx).WithMaxGoroutines(int(maxParallelRequests))
+	
 	for _, chunk := range chunks {
 		chunkCopy := chunk
-
-		wg.Go(func() error {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-			}
-
+		
+		p.Go(func(ctx _context.Context) (*fgaSdk.BatchCheckResponse, error) {
 			batchCheckRequest := createBatchCheckRequest(chunkCopy, authorizationModelId, options.Consistency)
-
-			response, err := client.singleBatchCheck(ctx, batchCheckRequest, options)
-			if err != nil {
-				select {
-				case errorChan <- err:
-					cancel()
-				default:
-				}
-				return err
-			}
-
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case resultChan <- response:
-				return nil
-			}
+			return client.singleBatchCheck(ctx, batchCheckRequest, options)
 		})
 	}
-
-	go func() {
-		_ = wg.Wait()
-		close(resultChan)
-		close(errorChan)
-	}()
-
-	var results []*fgaSdk.BatchCheckResponse
-	var firstError error
-
-	select {
-	case err := <-errorChan:
-		firstError = err
-	default:
+	
+	responses, err := p.Wait()
+	if err != nil {
+		return nil, err
 	}
-
-	// Collect all results
-	for response := range resultChan {
-		results = append(results, response)
-	}
-
-	if firstError != nil {
-		return nil, firstError
-	}
-
+	
 	combinedResult := make(map[string]fgaSdk.BatchCheckSingleResult)
-
-	for _, response := range results {
+	
+	for _, response := range responses {
 		for correlationID, result := range response.GetResult() {
 			combinedResult[correlationID] = result
 		}
 	}
-
+	
 	combinedResponse := fgaSdk.NewBatchCheckResponse()
 	combinedResponse.SetResult(combinedResult)
-
+	
 	return combinedResponse, nil
 }
 

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -2214,8 +2214,11 @@ func (client *OpenFgaClient) BatchCheckExecute(request SdkClientBatchCheckReques
 
 	chunks := chunkClientBatchCheckItems(body.Checks, int(maxBatchSize))
 
-	resultChan := make(chan *fgaSdk.BatchCheckResponse)
-	errorChan := make(chan error)
+	ctx, cancel := _context.WithCancel(ctx)
+	defer cancel()
+
+	resultChan := make(chan *fgaSdk.BatchCheckResponse, len(chunks))
+	errorChan := make(chan error, 1)
 
 	var wg errgroup.Group
 	wg.SetLimit(int(maxParallelRequests))
@@ -2224,40 +2227,55 @@ func (client *OpenFgaClient) BatchCheckExecute(request SdkClientBatchCheckReques
 		chunkCopy := chunk
 
 		wg.Go(func() error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
 			batchCheckRequest := createBatchCheckRequest(chunkCopy, authorizationModelId, options.Consistency)
 
 			response, err := client.singleBatchCheck(ctx, batchCheckRequest, options)
 			if err != nil {
-				errorChan <- err
+				select {
+				case errorChan <- err:
+					cancel()
+				default:
+				}
 				return err
 			}
 
-			resultChan <- response
-			return nil
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case resultChan <- response:
+				return nil
+			}
 		})
 	}
 
 	go func() {
-		err := wg.Wait()
-		if err != nil {
-			errorChan <- err
-		}
+		_ = wg.Wait()
 		close(resultChan)
 		close(errorChan)
 	}()
 
 	var results []*fgaSdk.BatchCheckResponse
+	var firstError error
+
+	select {
+	case err := <-errorChan:
+		firstError = err
+	default:
+	}
+
+	// Collect all results
 	for response := range resultChan {
 		results = append(results, response)
 	}
 
-	select {
-	case err := <-errorChan:
-		if err != nil {
-			return nil, err
-		}
-	default:
-		// No error
+	if firstError != nil {
+		return nil, firstError
 	}
 
 	combinedResult := make(map[string]fgaSdk.BatchCheckSingleResult)

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -390,15 +390,6 @@ type SdkClient interface {
 	BatchCheckExecute(request SdkClientBatchCheckRequestInterface) (*fgaSdk.BatchCheckResponse, error)
 
 	/*
-	 * singleBatchCheck Run a single batch check on the server.
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @param body BatchCheckRequest - the request to send to the server.
-	 * @param options *BatchCheckOptions - options for the request.
-	 * @return *BatchCheckResponse
-	 */
-	singleBatchCheck(ctx _context.Context, body fgaSdk.BatchCheckRequest, options *BatchCheckOptions) (*fgaSdk.BatchCheckResponse, error)
-
-	/*
 	 * Expand Expands the relationships in userset tree format.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return SdkClientExpandRequestInterface

--- a/config/clients/go/template/client/client_test.mustache
+++ b/config/clients/go/template/client/client_test.mustache
@@ -3489,54 +3489,99 @@ func Test{{appShortName}}Client(t *testing.T) {
 			},
 		)
 		
-		items := []ClientBatchCheckItem{
-			{
-				User:          "user:1",
+		// Create basic item template
+		createItem := func(i int) ClientBatchCheckItem {
+			return ClientBatchCheckItem{
+				User:          fmt.Sprintf("user:%d", i),
 				Relation:      "viewer",
-				Object:        "document:1",
-				CorrelationId: "test1",
-			},
-			{
-				User:          "user:2",
-				Relation:      "viewer",
-				Object:        "document:2",
-				CorrelationId: "test2",
-			},
-			{
-				User:          "user:3",
-				Relation:      "viewer",
-				Object:        "document:3",
-				CorrelationId: "test3",
-			},
-		}
-		
-		requestBody := ClientBatchCheckRequest{
-			Checks: items,
+				Object:        fmt.Sprintf("document:%d", i),
+				CorrelationId: fmt.Sprintf("test%d", i),
+			}
 		}
 
-		options := BatchCheckOptions{
-			MaxBatchSize: openfga.PtrInt32(1),
-		}
+		t.Run("Simple case with MaxBatchSize=1", func(t *testing.T) {
+			callCountMu.Lock()
+			callCount = 0
+			callCountMu.Unlock()
+			
+			items := []ClientBatchCheckItem{
+				createItem(1),
+				createItem(2),
+				createItem(3),
+			}
+			
+			requestBody := ClientBatchCheckRequest{
+				Checks: items,
+			}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		defer cancel()
+			options := BatchCheckOptions{
+				MaxBatchSize: openfga.PtrInt32(1),
+			}
 
-		_, err = fgaClient.BatchCheck(ctx).
-			Body(requestBody).
-			Options(options).
-			Execute()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
 
-		if err != nil {
-			t.Fatalf("BatchCheck error: %v", err)
-		}
+			_, err = fgaClient.BatchCheck(ctx).
+				Body(requestBody).
+				Options(options).
+				Execute()
 
-		expectedCallCount := len(items) // With MaxBatchSize=1, we expect one call per item
-		callCountMu.Lock()
-		actualCallCount := callCount
-		callCountMu.Unlock()
-		if actualCallCount != expectedCallCount {
-			t.Errorf("Expected exactly %d API calls with MaxBatchSize=1, got %d", expectedCallCount, actualCallCount)
-		}
+			if err != nil {
+				t.Fatalf("BatchCheck error: %v", err)
+			}
+
+			expectedCallCount := len(items) // With MaxBatchSize=1, we expect one call per item
+			callCountMu.Lock()
+			actualCallCount := callCount
+			callCountMu.Unlock()
+			if actualCallCount != expectedCallCount {
+				t.Errorf("Expected exactly %d API calls with MaxBatchSize=1, got %d", expectedCallCount, actualCallCount)
+			}
+		})
+
+		t.Run("Edge case where MaxParallelRequests * MaxBatchSize < len(items)", func(t *testing.T) {
+			callCountMu.Lock()
+			callCount = 0
+			callCountMu.Unlock()
+			
+			// Create 101 items
+			var items []ClientBatchCheckItem
+			for i := 1; i <= 101; i++ {
+				items = append(items, createItem(i))
+			}
+			
+			requestBody := ClientBatchCheckRequest{
+				Checks: items,
+			}
+
+			options := BatchCheckOptions{
+				MaxParallelRequests: openfga.PtrInt32(2),  // 2 parallel requests
+				MaxBatchSize:        openfga.PtrInt32(50), // 50 items per batch
+			}
+			// Total capacity: 2*50 = 100, but we have 101 items
+
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			_, err = fgaClient.BatchCheck(ctx).
+				Body(requestBody).
+				Options(options).
+				Execute()
+
+			if err != nil {
+				t.Fatalf("BatchCheck error with MaxParallelRequests=2, MaxBatchSize=50, Items=101: %v", err)
+			}
+
+			// We expect 3 API calls (2 batches of 50 + 1 batch of 1)
+			expectedCallCount := 3
+			callCountMu.Lock()
+			actualCallCount := callCount
+			callCountMu.Unlock()
+			if actualCallCount != expectedCallCount {
+				t.Errorf("Expected exactly %d API calls with MaxParallelRequests=2, MaxBatchSize=50, Items=101, got %d", 
+				          expectedCallCount, actualCallCount)
+			}
+		})
 	})
 }
 

--- a/config/clients/go/template/go.mod.mustache
+++ b/config/clients/go/template/go.mod.mustache
@@ -6,6 +6,7 @@ toolchain go1.24.0
 
 require (
 	github.com/jarcoal/httpmock v1.3.1
+	github.com/sourcegraph/conc v0.3.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/metric v1.35.0
 	golang.org/x/sync v0.12.0


### PR DESCRIPTION
## Description
- Resolves issue where if number of checks exceeds MaxParallelRequests * MaxBatchSize a stall occurs.  Ensures that all checks are processed
- Added additional test coverage related to this issue to prevent recurrence of similar issues.
- remove private method from interface to allow mocking

## References
- https://github.com/openfga/go-sdk/issues/191
- https://github.com/openfga/go-sdk/issues/192

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

