### PR TITLE
fix(python-sdk): remove urllib3 >= 2.2.2 restriction

### DIFF
--- a/config/clients/python/template/requirements.mustache
+++ b/config/clients/python/template/requirements.mustache
@@ -2,5 +2,5 @@ aiohttp >= 3.9.3, < 4
 python-dateutil >= 2.9.0, < 3
 setuptools >= 69.1.1
 build >= 1.2.1, < 2
-urllib3 >= 1.26.19, >= 2.2.2, < 3
+urllib3 >= 1.26.19, < 3
 opentelemetry-api >= 1.25.0, < 2


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

