### PR TITLE
chore(java-sdk): sync back deps bumps

### DIFF
--- a/config/clients/java/template/build.gradle.mustache
+++ b/config/clients/java/template/build.gradle.mustache
@@ -4,7 +4,7 @@ plugins {
     // Quality
     id 'jacoco'
     id 'jvm-test-suite'
-    id 'com.diffplug.spotless' version '7.0.2'
+    id 'com.diffplug.spotless' version '7.0.3'
 
     // IDE
     id 'idea'
@@ -61,7 +61,7 @@ ext {
     {{#swagger2AnnotationLibrary}}
     swagger_annotations_version = "2.2.9"
     {{/swagger2AnnotationLibrary}}
-    jackson_version = "2.18.2"
+    jackson_version = "2.19.0"
     {{#hasFormParamsInSpec}}
     httpmime_version = "4.5.13"
     {{/hasFormParamsInSpec}}
@@ -80,7 +80,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.6"
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.46.0")
+    implementation platform("io.opentelemetry:opentelemetry-bom:1.49.0")
     implementation "io.opentelemetry:opentelemetry-api"
     {{#hasFormParamsInSpec}}
     implementation "org.apache.httpcomponents:httpmime:$httpmime_version"
@@ -93,9 +93,9 @@ testing {
             useJUnitJupiter()
             dependencies {
                 implementation 'org.assertj:assertj-core:3.27.3'
-                implementation 'org.mockito:mockito-core:5.16.1'
-                implementation 'org.junit.jupiter:junit-jupiter:5.12.1'
-                implementation 'org.wiremock:wiremock:3.12.1'
+                implementation 'org.mockito:mockito-core:5.17.0'
+                implementation 'org.junit.jupiter:junit-jupiter:5.12.2'
+                implementation 'org.wiremock:wiremock:3.13.0'
 
                 runtimeOnly 'org.junit.platform:junit-platform-launcher'
 
@@ -124,8 +124,8 @@ testing {
             dependencies {
                 implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"
                 implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
-                implementation "org.testcontainers:junit-jupiter:1.20.4"
-                implementation "org.testcontainers:openfga:1.20.4"
+                implementation "org.testcontainers:junit-jupiter:1.21.0"
+                implementation "org.testcontainers:openfga:1.21.0"
                 implementation project()
             }
 

--- a/config/clients/java/template/example/example1/build.gradle.mustache
+++ b/config/clients/java/template/example/example1/build.gradle.mustache
@@ -1,7 +1,7 @@
 plugins {
     id 'application'
-    id 'com.diffplug.spotless' version '7.0.2'
-    id 'org.jetbrains.kotlin.jvm' version '2.1.10'
+    id 'com.diffplug.spotless' version '7.0.3'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.20'
 }
 
 application {
@@ -19,7 +19,7 @@ repositories {
 }
 
 ext {
-    jacksonVersion = "2.18.2"
+    jacksonVersion = "2.19.0"
 }
 
 dependencies {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Sync back dependency updates in java-sdk to generator.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

