### PR TITLE
Remove redundant fga_client.close in python

### DIFF
--- a/config/clients/python/template/README_initializing.mustache
+++ b/config/clients/python/template/README_initializing.mustache
@@ -17,8 +17,7 @@ async def main():
     # Enter a context with an instance of the OpenFgaClient
     async with OpenFgaClient(configuration) as fga_client:
         api_response = await fga_client.read_authorization_models()
-        await fga_client.close()
-        return api_response
+    return api_response
 ```
 
 #### API Token
@@ -43,8 +42,7 @@ async def main():
     # Enter a context with an instance of the OpenFgaClient
     async with OpenFgaClient(configuration) as fga_client:
         api_response = await fga_client.read_authorization_models()
-        await fga_client.close()
-        return api_response
+    return api_response
 ```
 
 #### Client Credentials
@@ -72,8 +70,7 @@ async def main():
     # Enter a context with an instance of the OpenFgaClient
     async with OpenFgaClient(configuration) as fga_client:
         api_response = await fga_client.read_authorization_models()
-        await fga_client.close()
-        return api_response
+    return api_response
 ```
 
 #### Synchronous Client
@@ -96,5 +93,5 @@ def main():
     # Enter a context with an instance of the OpenFgaClient
     with OpenFgaClient(configuration) as fga_client:
         api_response = fga_client.read_authorization_models()
-        return api_response
+    return api_response
 ```


### PR DESCRIPTION
## Description

`fga_client.close()` is handled by the context manager so it isn't needed, as discussed in https://github.com/openfga/python-sdk/issues/191

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected