### PR TITLE
Document batchCheck ordering

### DIFF
--- a/config/clients/dotnet/template/README_calling_api.mustache
+++ b/config/clients/dotnet/template/README_calling_api.mustache
@@ -345,6 +345,8 @@ var response = await fgaClient.Check(body, options);
 Run a set of [checks](#check). Batch Check will return `allowed: false` if it encounters an error, and will return the error in the body.
 If 429s or 5xxs are encountered, the underlying check will retry up to {{defaultMaxRetry}} times before giving up.
 
+> **Note**: The order of `BatchCheck` results is not guaranteed to match the order of the checks provided. Use `correlationId` to pair responses with requests.
+
 ```csharp
 var options = new ClientBatchCheckOptions {
     // You can rely on the model id set in the configuration or override it for this specific request

--- a/config/clients/go/template/README_calling_api.mustache
+++ b/config/clients/go/template/README_calling_api.mustache
@@ -401,6 +401,8 @@ Similar to [Check](#Check), but instead of checking a single user-object relatio
 
 [API Documentation](https://openfga.dev/api/service#/Relationship%20Queries/BatchCheck)
 
+> **Note**: The order of `BatchCheck` results is not guaranteed to match the order of the checks provided. Use `correlationId` to pair responses with requests.
+
 If you are using an OpenFGA version less than 1.8.0, you can use the `ClientBatchCheck` function, 
 which calls `check` in parallel. It will return `allowed: false` if it encounters an error, and will return the error in the body.
 If 429s or 5xxs are encountered, the underlying check will retry up to 3 times before giving up.

--- a/config/clients/java/template/README_calling_api.mustache
+++ b/config/clients/java/template/README_calling_api.mustache
@@ -360,6 +360,8 @@ Similar to [check](#check), but instead of checking a single user-object relatio
 
 [API Documentation](https://openfga.dev/api/service#/Relationship%20Queries/BatchCheck)
 
+> **Note**: The order of `batchCheck` results is not guaranteed to match the order of the checks provided. Use `correlationId` to pair responses with requests.
+
 > Passing `ClientBatchCheckOptions` is optional. All fields of `ClientBatchCheckOptions` are optional.
 
 ```java

--- a/config/clients/js/template/README_calling_api.mustache
+++ b/config/clients/js/template/README_calling_api.mustache
@@ -296,6 +296,8 @@ Similar to [check](#check), but instead of checking a single user-object relatio
 
 [API Documentation](https://openfga.dev/api/service#/Relationship%20Queries/BatchCheck)
 
+> **Note**: The order of `batchCheck` results is not guaranteed to match the order of the checks provided. Use `correlationId` to pair responses with requests.
+
 ```javascript
 const options = {
   // if you'd like to override the authorization model id for this request

--- a/config/clients/python/template/README_calling_api.mustache
+++ b/config/clients/python/template/README_calling_api.mustache
@@ -491,6 +491,8 @@ Similar to [check](#check), but instead of checking a single user-object relatio
 
 [API Documentation](https://openfga.dev/api/service#/Relationship%20Queries/BatchCheck)
 
+> **Note**: The order of `batch_check` results is not guaranteed to match the order of the checks provided. Use `correlation_id` to pair responses with requests.
+
 ```python
 # from openfga_sdk import OpenFgaClient
 # from openfga_sdk.client.models import (

--- a/docs/GENERATING-A-NEW-SDK.md
+++ b/docs/GENERATING-A-NEW-SDK.md
@@ -538,6 +538,8 @@ BatchCheck should set the following headers for all individual Check operations 
 ClientBatchCheckOptions should have a `maxParallelRequests` value, and the BatchCheck operation
 should restrict the number of individual Check operations in flight to this number.
 
+Note: The order of `BatchCheck` results is not guaranteed to match the order of the checks provided. Use `correlationId` to pair responses with requests.
+
 BatchCheck should return a future/promise/async of a List of ClientBatchCheckResponse.
 
 #### ListRelations


### PR DESCRIPTION
## Summary
- clarify batchCheck ordering note for all SDK README templates
- document the ordering behavior in GENERATING-A-NEW-SDK

## Testing
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b8ed65848322b3a2b3f770d43bfd