### PR TITLE
Fix .NET README ListUsers example

### DIFF
--- a/config/clients/dotnet/template/README_calling_api.mustache
+++ b/config/clients/dotnet/template/README_calling_api.mustache
@@ -512,39 +512,30 @@ List the users who have a certain relation to a particular type.
 [API Documentation](https://openfga.dev/api/service#/Relationship%20Queries/ListUsers)
 
 ```csharp
-const options = {};
-
-// To override the authorization model id for this request
-options.authorization_model_id = "1uHxCSuTP0VKPYSnkq1pbb1jeZw";
-
-// Only a single filter is allowed for the time being
-const userFilters = [{type: "user"}];
-// user filters can also be of the form
-// const userFilters = [{type: "team", relation: "member"}];
-
-const response = await fgaClient.listUsers({
-  object: {
-    type: "document",
-    id: "roadmap"
-  },
-  relation: "can_read",
-  user_filters: userFilters,
-  context: {
-    "view_count": 100
-  },
-  contextualTuples:
-    [{
-      user: "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
-      relation: "editor",
-      object: "folder:product"
-    }, {
-      user: "folder:product",
-      relation: "parent",
-      object: "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a"
-    }]
-}, options);
-
-// response.users = [{object: {type: "user", id: "81684243-9356-4421-8fbf-a4f8d36aa31b"}}, {userset: { type: "user" }}, ...]
+var body = new ClientListUsersRequest()
+{
+    Object = new FgaObject()
+    {
+        Type = "document",
+        Id = "roadmap"
+    },
+    Relation = "can_read",
+    UserFilters = new List<UserTypeFilter>
+    {
+        new UserTypeFilter()
+        {
+            Type = "user"
+        }
+    },
+    ContextualTuples = new List<ClientTupleKey>() {
+        new ClientTupleKey {
+            User = "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+            Relation = "editor",
+            Object = "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+        }
+    }
+};
+var response = await fgaClient.ListUsers(body);
 ```
 
 #### Assertions


### PR DESCRIPTION
## Summary
- correct ListUsers example in the .NET README

## Testing
- `make test-client-dotnet` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846bab2d3848322ab659592a60eb774