### PR TITLE
Fix Java batchCheck authorization model id

### DIFF
--- a/config/clients/java/template/libraries/native/api.mustache
+++ b/config/clients/java/template/libraries/native/api.mustache
@@ -265,6 +265,12 @@ public class OpenFgaApi {
             if (body instanceof BatchCheckRequest) {
                 BatchCheckRequest batchCheckRequest = (BatchCheckRequest) body;
 
+                if (!isNullOrWhitespace(batchCheckRequest.getAuthorizationModelId())) {
+                    telemetryAttributes.put(
+                            Attributes.FGA_CLIENT_REQUEST_MODEL_ID,
+                            batchCheckRequest.getAuthorizationModelId());
+                }
+
                 if (batchCheckRequest.getChecks() != null) {
                     telemetryAttributes.put(
                             Attributes.FGA_CLIENT_REQUEST_BATCH_CHECK_SIZE,

--- a/config/clients/java/template/src/main/api/client/OpenFgaClient.java.mustache
+++ b/config/clients/java/template/src/main/api/client/OpenFgaClient.java.mustache
@@ -695,8 +695,20 @@ public class OpenFgaClient {
 
         var override = new ConfigurationOverride().addHeaders(options);
 
-        Consumer<List<BatchCheckItem>> singleBatchCheckRequest = request -> call(() ->
-                        api.batchCheck(configuration.getStoreId(), new BatchCheckRequest().checks(request), override))
+        Consumer<List<BatchCheckItem>> singleBatchCheckRequest = request -> call(() -> {
+                    BatchCheckRequest body = new BatchCheckRequest().checks(request);
+                    if (options.getConsistency() != null) {
+                        body.consistency(options.getConsistency());
+                    }
+
+                    // Set authorizationModelId from options if available; otherwise, use the default from configuration
+                    String authorizationModelId = !isNullOrWhitespace(options.getAuthorizationModelId())
+                            ? options.getAuthorizationModelId()
+                            : configuration.getAuthorizationModelId();
+                    body.authorizationModelId(authorizationModelId);
+
+                    return api.batchCheck(configuration.getStoreId(), body, override);
+                })
                 .handleAsync((batchCheckResponseApiResponse, throwable) -> {
                     Map<String, BatchCheckSingleResult> response =
                             batchCheckResponseApiResponse.getData().getResult();

--- a/config/clients/java/template/src/test/api/client/OpenFgaClientTest.java.mustache
+++ b/config/clients/java/template/src/test/api/client/OpenFgaClientTest.java.mustache
@@ -2025,6 +2025,38 @@ public class OpenFgaClientTest {
         assertEquals("relation not found", response3.getError().getMessage());
     }
 
+    @Test
+    public void batchCheck_withOptions() throws Exception {
+        // Given
+        String postUrl = String.format("https://api.fga.example/stores/%s/batch-check", DEFAULT_STORE_ID);
+        String expectedBody = String.format(
+                "{\"checks\":[{\"tuple_key\":{\"user\":\"%s\",\"relation\":\"%s\",\"object\":\"%s\"},\"contextual_tuples\":null,\"context\":null,\"correlation_id\":\"cor-1\"}],\"authorization_model_id\":\"%s\",\"consistency\":\"%s\"}",
+                DEFAULT_USER,
+                DEFAULT_RELATION,
+                DEFAULT_OBJECT,
+                DEFAULT_AUTH_MODEL_ID,
+                ConsistencyPreference.MINIMIZE_LATENCY);
+        mockHttpClient.onPost(postUrl).withBody(is(expectedBody)).doReturn(200, "{\"result\":{}}");
+
+        ClientBatchCheckItem item = new ClientBatchCheckItem()
+                .user(DEFAULT_USER)
+                .relation(DEFAULT_RELATION)
+                ._object(DEFAULT_OBJECT)
+                .correlationId("cor-1");
+        ClientBatchCheckRequest request = new ClientBatchCheckRequest().checks(List.of(item));
+        ClientBatchCheckOptions options = new ClientBatchCheckOptions()
+                .authorizationModelId(DEFAULT_AUTH_MODEL_ID)
+                .consistency(ConsistencyPreference.MINIMIZE_LATENCY);
+
+        // When
+        ClientBatchCheckResponse response = fga.batchCheck(request, options).join();
+
+        // Then
+        mockHttpClient.verify().post(postUrl).withBody(is(expectedBody)).called(1);
+        assertNotNull(response);
+        assertTrue(response.getResult().isEmpty());
+    }
+
     /**
      * Expand all relationships in userset tree format, and following userset rewrite rules.  Useful to reason
      * about and debug a certain relationship.


### PR DESCRIPTION
## Summary
- add Authorization Model ID telemetry for Java batchCheck
- include options' authorizationModelId in batchCheck requests
- test passing authorizationModelId via batchCheck options

## Testing
- `make test-client-java` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b74224688322925a10d153f3fca5