### PR TITLE
Fix .NET docs snippet for ListRelations

### DIFF
--- a/config/clients/dotnet/template/README_calling_api.mustache
+++ b/config/clients/dotnet/template/README_calling_api.mustache
@@ -487,8 +487,8 @@ var response = await fgaClient.ListObjects(body, options);
 List the relations a user has on an object.
 
 ```csharp
-ListRelationsRequest body =
-    new ListRelationsRequest() {
+ClientListRelationsRequest body =
+    new ClientListRelationsRequest() {
         User = "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
         Object = "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
         Relations = new List<string> {"can_view", "can_edit", "can_delete", "can_rename"},


### PR DESCRIPTION
## Summary
- fix `ClientListRelationsRequest` name in dotnet README template

## Testing
- `make test-client-dotnet` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bc67ba748322835061809e0bed0a