### PR TITLE
Patch python SDK generator to read aiohttp response data

### DIFF
--- a/config/clients/python/template/src/rest.py.mustache
+++ b/config/clients/python/template/src/rest.py.mustache
@@ -266,6 +266,9 @@ class RESTClientObject:
         if 200 <= response.status <= 299:
             return
 
+        if isinstance(response, aiohttp.ClientResponse):
+            response.data  = await response.read()
+
         match response.status:
             case 400:
                 raise ValidationException(http_resp=response)

--- a/config/clients/python/template/src/rest.py.mustache
+++ b/config/clients/python/template/src/rest.py.mustache
@@ -266,8 +266,9 @@ class RESTClientObject:
         if 200 <= response.status <= 299:
             return
 
-        if isinstance(response, aiohttp.ClientResponse):
-            response.data  = await response.read()
+        if isinstance(response, aiohttp.ClientResponse) and not hasattr(response, "data"):
+            # Read the body once and expose it for downstream error handlers
+            response.data = await response.read()
 
         match response.status:
             case 400:

--- a/config/clients/python/template/test/rest_test.py.mustache
+++ b/config/clients/python/template/test/rest_test.py.mustache
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
+
 import pytest
 
 from {{packageName}}.exceptions import (
@@ -170,6 +172,31 @@ async def test_handle_response_exception_error(status, exc):
 
     with pytest.raises(exc):
         await client.handle_response_exception(mock_response)
+
+
+@pytest.mark.asyncio
+async def test_handle_response_exception_reads_data():
+    mock_config = MagicMock()
+    mock_config.ssl_ca_cert = None
+    mock_config.cert_file = None
+    mock_config.key_file = None
+    mock_config.verify_ssl = True
+    mock_config.connection_pool_maxsize = 4
+    mock_config.proxy = None
+    mock_config.proxy_headers = None
+    mock_config.timeout_millisec = 5000
+
+    client = RESTClientObject(configuration=mock_config)
+
+    mock_response = MagicMock(spec=aiohttp.ClientResponse)
+    mock_response.status = 400
+    mock_response.read = AsyncMock(return_value=b"{\"error\":\"bad\"}")
+
+    with pytest.raises(ValidationException):
+        await client.handle_response_exception(mock_response)
+
+    mock_response.read.assert_awaited_once()
+    assert mock_response.data == b"{\"error\":\"bad\"}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- ensure `handle_response_exception` awaits aiohttp responses so that the response body is available during error handling
- test that the response data is read when raising an exception

## Testing
- `make test-client-python` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ffad4696883229e03bdb7a6ff13ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured error responses include the full response body for improved error handling in the Python REST client.

- **Tests**
  - Added an asynchronous test to confirm proper reading and assignment of response data during error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->