### PR TITLE
chore(docs): fix readme credentials section headings

### DIFF
--- a/config/clients/go/template/README_initializing.mustache
+++ b/config/clients/go/template/README_initializing.mustache
@@ -51,7 +51,7 @@ func main() {
 }
 ```
 
-#### Auth0 Client Credentials
+#### Client Credentials
 
 ```golang
 import (

--- a/config/clients/java/template/README_initializing.mustache
+++ b/config/clients/java/template/README_initializing.mustache
@@ -49,7 +49,7 @@ public class Example {
 }
 ```
 
-#### Auth0 Client Credentials
+#### Client Credentials
 
 ```java
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
## Summary
- clean up README templates
- fix credential titles for OAuth setup

## Testing
- `make test` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_685053a95eb4832280d734b3d6173a31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated section headings in the README templates from "Auth0 Client Credentials" to "Client Credentials" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->