### PR TITLE
chore(java): Migrate CI to sonatype central portal

### DIFF
--- a/config/clients/java/template/publish.gradle.mustache
+++ b/config/clients/java/template/publish.gradle.mustache
@@ -51,10 +51,10 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri('https://s01.oss.sonatype.org/service/local/'))
-            snapshotRepositoryUrl.set(uri('https://s01.oss.sonatype.org/content/repositories/snapshots/'))
-            username.set(System.getenv('MAVEN_USERNAME'))
-            password.set(System.getenv('MAVEN_PASSWORD'))
+            nexusUrl.set(uri('https://central.sonatype.com/'))
+            snapshotRepositoryUrl.set(uri('https://central.sonatype.com/'))
+            username.set(System.getenv('MAVEN_CENTRAL_USERNAME'))
+            password.set(System.getenv('MAVEN_CENTRAL_TOKEN'))
         }
     }
 }

--- a/config/clients/java/template/publish.gradle.mustache
+++ b/config/clients/java/template/publish.gradle.mustache
@@ -54,7 +54,7 @@ nexusPublishing {
             nexusUrl.set(uri('https://ossrh-staging-api.central.sonatype.com/service/local/'))
             snapshotRepositoryUrl.set(uri('https://central.sonatype.com/repository/maven-snapshots/'))
             username.set(System.getenv('MAVENL_USERNAME'))
-            password.set(System.getenv('MAVENL_PASSWORD'))
+            password.set(System.getenv('MAVEN_PASSWORD'))
         }
     }
 }

--- a/config/clients/java/template/publish.gradle.mustache
+++ b/config/clients/java/template/publish.gradle.mustache
@@ -51,10 +51,10 @@ signing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri('https://central.sonatype.com/'))
-            snapshotRepositoryUrl.set(uri('https://central.sonatype.com/'))
-            username.set(System.getenv('MAVEN_CENTRAL_USERNAME'))
-            password.set(System.getenv('MAVEN_CENTRAL_TOKEN'))
+            nexusUrl.set(uri('https://ossrh-staging-api.central.sonatype.com/service/local/'))
+            snapshotRepositoryUrl.set(uri('https://central.sonatype.com/repository/maven-snapshots/'))
+            username.set(System.getenv('MAVENL_USERNAME'))
+            password.set(System.getenv('MAVENL_PASSWORD'))
         }
     }
 }

--- a/config/clients/java/template/publish.gradle.mustache
+++ b/config/clients/java/template/publish.gradle.mustache
@@ -53,7 +53,7 @@ nexusPublishing {
         sonatype {
             nexusUrl.set(uri('https://ossrh-staging-api.central.sonatype.com/service/local/'))
             snapshotRepositoryUrl.set(uri('https://central.sonatype.com/repository/maven-snapshots/'))
-            username.set(System.getenv('MAVENL_USERNAME'))
+            username.set(System.getenv('MAVEN_USERNAME'))
             password.set(System.getenv('MAVEN_PASSWORD'))
         }
     }


### PR DESCRIPTION
## Description
Migration of java sdk publishing from OSSRH to Sonatype Central Portal.

Sonatype has announced that the legacy OSSRH service ([oss.sonatype.org](http://oss.sonatype.org/)) will reach end-of-life in June 2025. The openfga/java-sdk currently publishes to Maven Central via OSSRH. To avoid disruptions, we need to migrate publishing to the Central Portal ([central.sonatype.com](http://central.sonatype.com/)).

Note:  Prior to committing these changes to the java-sdk repository the MAVEN_CENTRAL_USERNAME and MAVEN_CENTRAL_TOKEN needed for publishing will need to be configured in GitHub so the values are available for the workflow.

## References


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated repository URLs for improved publishing to Sonatype Central.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->