### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/sdk-generator/security/code-scanning/1](https://github.com/openfga/sdk-generator/security/code-scanning/1)

To fix the problem, add a `permissions` block at the root of the workflow file (`.github/workflows/main.yaml`). This block should specify the minimal permissions required for all jobs. In this case, since the jobs only need to read repository contents (for checking out code and running tests), set `contents: read`. This change should be made near the top of the file, after the `name:` and before the `on:` block. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
