### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/sdk-generator/security/code-scanning/7](https://github.com/openfga/sdk-generator/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow file. The best way to do this is to add the block at the top level of the workflow (just below the `name:` and before `on:`), so that all jobs inherit the minimal permissions unless they explicitly override them. The minimal required permission for most CI jobs is `contents: read`, which allows the workflow to check out code but not to write to the repository. This change does not affect existing functionality, as none of the jobs shown require write access.

**What to change:**  
- Edit `.github/workflows/main.yaml`.
- Insert the following block after the `name:` line and before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
