### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/sdk-generator/security/code-scanning/6](https://github.com/openfga/sdk-generator/security/code-scanning/6)

To fix the problem, add a `permissions` block at the root of the workflow file (`.github/workflows/main.yaml`), specifying the minimal required permissions for all jobs. In this case, the jobs only need to read repository contents, so set `contents: read`. This change should be made near the top of the file, after the `name:` and before the `on:` block. No other changes are required, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
