### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/sdk-generator/security/code-scanning/5](https://github.com/openfga/sdk-generator/security/code-scanning/5)

To fix the problem, add a `permissions` block at the top level of the workflow file, immediately after the `name` and before the `on` key. This block should specify the minimal required permissions for the workflow, which in this case is `contents: read`. This ensures that all jobs in the workflow will only have read access to repository contents unless a job explicitly overrides this. No other changes are needed, and this will not affect existing functionality since none of the jobs appear to require write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
