### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/sdk-generator/security/code-scanning/4](https://github.com/openfga/sdk-generator/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file. The best way to do this is to add the `permissions` key at the top level of the workflow (just below the `name` and before `on`), so that all jobs inherit these minimal permissions unless they need more. For this workflow, the jobs only need to read repository contents, so set `permissions: contents: read`. No changes to the jobs themselves are required unless a specific job needs broader permissions (which is not evident from the provided code). Only the `.github/workflows/main.yaml` file needs to be edited, and only at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
