### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,6 @@
 name: Run Tests
+permissions:
+  contents: read
 
 on:
   merge_group:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/sdk-generator/security/code-scanning/3](https://github.com/openfga/sdk-generator/security/code-scanning/3)

To fix the problem, add a `permissions` block at the top level of the workflow (just after the `name:` and before `on:`), which will apply to all jobs unless overridden. The minimal required permission for these jobs is `contents: read`, as they only need to check out code and run tests. No job in the provided snippet appears to require write access to the repository or other resources. The change should be made by inserting the following block:

```yaml
permissions:
  contents: read
```

immediately after the `name: Run Tests` line (line 1), before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
