### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   semgrep:
     name: Scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/sdk-generator/security/code-scanning/2](https://github.com/openfga/sdk-generator/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or the specific job to restrict the `GITHUB_TOKEN` to the least privilege required. In this case, since the job only checks out code and runs Semgrep, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the job level (under `semgrep:`), which will ensure that the token cannot be used for any write operations. This change should be made directly under the job definition (after `name: Scan` and before `runs-on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
