### PR TITLE
feat(js): allow setting default headers

### DIFF
--- a/config/clients/js/template/baseApi.mustache
+++ b/config/clients/js/template/baseApi.mustache
@@ -50,4 +50,24 @@ export class BaseAPI {
       });
     }
   }
+
+  public setDefaultHeader(headerName: string, headerValue: string) {
+    if (!this.configuration.baseOptions) {
+      this.configuration.baseOptions = { headers: {} };
+    }
+    if (!this.configuration.baseOptions.headers) {
+      this.configuration.baseOptions.headers = {};
+    }
+    this.configuration.baseOptions.headers[headerName] = headerValue;
+
+    if (this.axios) {
+      if (!this.axios.defaults.headers) {
+        this.axios.defaults.headers = {} as any;
+      }
+      if (!this.axios.defaults.headers.common) {
+        this.axios.defaults.headers.common = {} as any;
+      }
+      this.axios.defaults.headers.common[headerName] = headerValue;
+    }
+  }
 }

--- a/config/clients/js/template/tests/client.test.ts.mustache
+++ b/config/clients/js/template/tests/client.test.ts.mustache
@@ -74,6 +74,23 @@ describe("{{appTitleCaseName}} Client", () => {
         fgaClient.authorizationModelId = defaultConfiguration.authorizationModelId;
         expect(fgaClient.authorizationModelId).toBe(defaultConfiguration.authorizationModelId);
       });
+
+      it("should allow setting custom default headers", async () => {
+        const customClient = new {{appShortName}}Client({
+          apiUrl: defaultConfiguration.apiUrl,
+          credentials: { method: CredentialsMethod.None },
+        });
+        customClient.setDefaultHeader("Custom-Header", "custom value");
+
+        const scope = nock(defaultConfiguration.getBasePath(), {
+          reqheaders: { "Custom-Header": "custom value" }
+        })
+          .get("/stores")
+          .reply(200, { continuation_token: "", stores: [] });
+
+        await customClient.listStores();
+        expect(scope.isDone()).toBe(true);
+      });
     });
 
 


### PR DESCRIPTION
## Summary
- add `setDefaultHeader` helper to JS BaseAPI to apply custom HTTP headers to all requests
- test default header behavior in JS client
- Codex experiment to implement #569 

## Testing
- `make test-client-js` *(fails: `/bin/sh: 1: docker: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_689ad8c586b883308920e6952d58bdf4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to set custom default HTTP headers on the JavaScript client, applied to all subsequent API requests (including Axios defaults when used). This enables easier integration of headers such as auth, tracing, or feature flags.

* **Tests**
  * Added tests to verify that custom default headers set on the client are included in subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->