### PR TITLE
feat: add per-request header support

### DIFF
--- a/config/clients/dotnet/template/Client/Client.mustache
+++ b/config/clients/dotnet/template/Client/Client.mustache
@@ -171,7 +171,7 @@ public class {{appShortName}}Client : IDisposable {
             GetStoreId(options),
             new ReadRequest {
                 TupleKey = tupleKey, PageSize = options?.PageSize, ContinuationToken = options?.ContinuationToken, Consistency = options?.Consistency,
-            }, cancellationToken);
+            }, options?.Headers, cancellationToken);
     }
 
     /**

--- a/config/clients/dotnet/template/Client/Client.mustache
+++ b/config/clients/dotnet/template/Client/Client.mustache
@@ -74,7 +74,7 @@ public class {{appShortName}}Client : IDisposable {
    */
     public async Task<ListStoresResponse> ListStores(IClientListStoresRequest? body, IClientListStoresOptions? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.ListStores(options?.PageSize, options?.ContinuationToken, body?.Name, cancellationToken);
+        await api.ListStores(options?.PageSize, options?.ContinuationToken, body?.Name, options?.Headers, cancellationToken);
 
     /**
    * CreateStore - Initialize a store
@@ -82,19 +82,19 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<CreateStoreResponse> CreateStore(ClientCreateStoreRequest body,
         ClientRequestOptions? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.CreateStore(body, cancellationToken);
+        await api.CreateStore(body, options?.Headers, cancellationToken);
 
     /**
    * GetStore - Get information about the current store
    */
     public async Task<GetStoreResponse> GetStore(IClientRequestOptionsWithStoreId? options = default, CancellationToken cancellationToken = default) =>
-        await api.GetStore(GetStoreId(options), cancellationToken);
+        await api.GetStore(GetStoreId(options), options?.Headers, cancellationToken);
 
     /**
    * DeleteStore - Delete a store
    */
     public async Task DeleteStore(IClientRequestOptionsWithStoreId? options = default, CancellationToken cancellationToken = default) =>
-        await api.DeleteStore(GetStoreId(options), cancellationToken);
+        await api.DeleteStore(GetStoreId(options), options?.Headers, cancellationToken);
 
     /************************
      * Authorization Models *
@@ -106,7 +106,7 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<ReadAuthorizationModelsResponse> ReadAuthorizationModels(
         IClientReadAuthorizationModelsOptions? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.ReadAuthorizationModels(GetStoreId(options), options?.PageSize, options?.ContinuationToken, cancellationToken);
+        await api.ReadAuthorizationModels(GetStoreId(options), options?.PageSize, options?.ContinuationToken, options?.Headers, cancellationToken);
 
     /**
      * WriteAuthorizationModel - Create a new version of the authorization model
@@ -114,7 +114,7 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<WriteAuthorizationModelResponse> WriteAuthorizationModel(ClientWriteAuthorizationModelRequest body,
         IClientRequestOptionsWithStoreId? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.WriteAuthorizationModel(GetStoreId(options), body, cancellationToken);
+        await api.WriteAuthorizationModel(GetStoreId(options), body, options?.Headers, cancellationToken);
 
     /**
      * ReadAuthorizationModel - Read the current authorization model
@@ -127,7 +127,7 @@ public class {{appShortName}}Client : IDisposable {
             throw new FgaRequiredParamError("ClientConfiguration", "AuthorizationModelId");
         }
 
-        return await api.ReadAuthorizationModel(GetStoreId(options), authorizationModelId, cancellationToken);
+        return await api.ReadAuthorizationModel(GetStoreId(options), authorizationModelId, options?.Headers, cancellationToken);
     }
 
     /**
@@ -156,7 +156,7 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<ReadChangesResponse> ReadChanges(ClientReadChangesRequest? body = default,
         ClientReadChangesOptions? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.ReadChanges(GetStoreId(options), body?.Type, options?.PageSize, options?.ContinuationToken, body?.StartTime, cancellationToken);
+        await api.ReadChanges(GetStoreId(options), body?.Type, options?.PageSize, options?.ContinuationToken, body?.StartTime, options?.Headers, cancellationToken);
 
     /**
      * Read - Read tuples previously written to the store (does not evaluate)
@@ -197,7 +197,7 @@ public class {{appShortName}}Client : IDisposable {
                 requestBody.Deletes = new WriteRequestDeletes(body.Deletes.ConvertAll(key => key.ToTupleKeyWithoutCondition()));
             }
 
-            await api.Write(GetStoreId(options), requestBody, cancellationToken);
+            await api.Write(GetStoreId(options), requestBody, options?.Headers, cancellationToken);
             return new ClientWriteResponse {
                 Writes =
                     body.Writes?.ConvertAll(tupleKey =>
@@ -298,7 +298,7 @@ public class {{appShortName}}Client : IDisposable {
                 Context = body.Context,
                 AuthorizationModelId = GetAuthorizationModelId(options),
                 Consistency = options?.Consistency,
-            }, cancellationToken);
+            }, options?.Headers, cancellationToken);
 
     /**
    * BatchCheck - Run a set of checks (evaluates)
@@ -341,7 +341,7 @@ public class {{appShortName}}Client : IDisposable {
                     },
                 AuthorizationModelId = GetAuthorizationModelId(options),
                 Consistency = options?.Consistency
-            }, cancellationToken);
+            }, options?.Headers, cancellationToken);
 
     /**
      * ListObjects - List the objects of a particular type that the user has a certain relation to (evaluates)
@@ -361,7 +361,7 @@ public class {{appShortName}}Client : IDisposable {
             Context = body.Context,
             AuthorizationModelId = GetAuthorizationModelId(options),
             Consistency = options?.Consistency,
-        }, cancellationToken);
+        }, options?.Headers, cancellationToken);
 
 
     /**
@@ -418,7 +418,7 @@ public class {{appShortName}}Client : IDisposable {
             Context = body.Context,
             AuthorizationModelId = GetAuthorizationModelId(options),
             Consistency = options?.Consistency
-        });
+        }, options?.Headers, cancellationToken);
 
     /**************
      * Assertions *
@@ -434,7 +434,7 @@ public class {{appShortName}}Client : IDisposable {
             throw new FgaRequiredParamError("ClientConfiguration", "AuthorizationModelId");
         }
 
-        return await api.ReadAssertions(GetStoreId(options), authorizationModelId, cancellationToken);
+        return await api.ReadAssertions(GetStoreId(options), authorizationModelId, options?.Headers, cancellationToken);
     }
 
     /**
@@ -463,6 +463,6 @@ public class {{appShortName}}Client : IDisposable {
         }
 
         await api.WriteAssertions(GetStoreId(options), authorizationModelId,
-            new WriteAssertionsRequest {Assertions = assertions}, cancellationToken);
+            new WriteAssertionsRequest {Assertions = assertions}, options?.Headers, cancellationToken);
     }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientBatchCheckOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientBatchCheckOptions.mustache
@@ -13,6 +13,8 @@ public interface IClientBatchCheckOptions: IClientCheckOptions {
 
 public class ClientBatchCheckOptions : IClientBatchCheckOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientCheckOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientCheckOptions.mustache
@@ -9,6 +9,8 @@ public interface IClientCheckOptions : IClientRequestOptionsWithAuthZModelIdAndC
 
 public class ClientCheckOptions : IClientCheckOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientCreateStoreOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientCreateStoreOptions.mustache
@@ -4,4 +4,8 @@ namespace {{packageName}}.Client.Model;
 
 public interface IClientCreateStoreOptions : ClientRequestOptions {}
 
-public class ClientCreateStoreOptions: IClientCreateStoreOptions {}
+public class ClientCreateStoreOptions: IClientCreateStoreOptions
+{
+    /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+}

--- a/config/clients/dotnet/template/Client/Model/ClientExpandOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientExpandOptions.mustache
@@ -9,6 +9,8 @@ public interface IClientExpandOptions : IClientRequestOptionsWithAuthZModelIdAnd
 
 public class ClientExpandOptions : IClientExpandOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientListObjectsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListObjectsOptions.mustache
@@ -9,6 +9,8 @@ public interface IClientListObjectsOptions : IClientRequestOptionsWithAuthZModel
 
 public class ClientListObjectsOptions : IClientListObjectsOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientListRelationsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListRelationsOptions.mustache
@@ -6,6 +6,8 @@ namespace {{packageName}}.Client.Model;
 
 public class ClientListRelationsOptions : IClientBatchCheckOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientListStoresOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListStoresOptions.mustache
@@ -10,6 +10,8 @@ public interface IClientListStoresOptions : ClientRequestOptions, AuthorizationM
 
 /// <inheritdoc />
 public class ClientListStoresOptions : IClientListStoresOptions {
+    /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
 
     /// <inheritdoc />
     public string? AuthorizationModelId { get; set; }

--- a/config/clients/dotnet/template/Client/Model/ClientListUsersOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListUsersOptions.mustache
@@ -9,6 +9,8 @@ public interface IClientListUsersOptions : IClientRequestOptionsWithAuthZModelId
 
 public class ClientListUsersOptions : IClientListUsersOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientReadAssertionsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadAssertionsOptions.mustache
@@ -11,6 +11,8 @@ public interface IClientReadAssertionsOptions : IClientRequestOptionsWithStoreId
 /// <inheritdoc />
 public class ClientReadAssertionsOptions : IClientReadAssertionsOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientReadAuthorizaionModelOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadAuthorizaionModelOptions.mustache
@@ -11,6 +11,8 @@ public interface IClientReadAuthorizationModelOptions : IClientRequestOptionsWit
 /// <inheritdoc />
 public class ClientReadAuthorizationModelOptions : IClientReadAuthorizationModelOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientReadAuthorizaionModelsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadAuthorizaionModelsOptions.mustache
@@ -11,6 +11,8 @@ public interface IClientReadAuthorizationModelsOptions : IClientRequestOptionsWi
 /// <inheritdoc />
 public class ClientReadAuthorizationModelsOptions : IClientReadAuthorizationModelsOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientReadChangesOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadChangesOptions.mustache
@@ -11,6 +11,8 @@ public interface IClientReadChangesOptions : IClientRequestOptionsWithStoreId, C
 /// <inheritdoc />
 public class ClientReadChangesOptions : IClientReadChangesOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientReadOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadOptions.mustache
@@ -13,6 +13,8 @@ public interface IClientReadOptions : IClientRequestOptionsWithStoreId, ClientPa
 /// <inheritdoc />
 public class ClientReadOptions : IClientReadOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <inheritdoc />

--- a/config/clients/dotnet/template/Client/Model/ClientRequestOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientRequestOptions.mustache
@@ -6,4 +6,5 @@ namespace {{packageName}}.Client.Model;
 ///     Base Client Request Options
 /// </summary>
 public interface ClientRequestOptions {
+    IDictionary<string, string>? Headers { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientWriteAssertionsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientWriteAssertionsOptions.mustache
@@ -10,6 +10,8 @@ public interface IClientWriteAssertionsOptions : IClientRequestOptionsWithStoreI
 
 /// <inheritdoc />
 public class ClientWriteAssertionsOptions : IClientWriteAssertionsOptions {
+    /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
 
     /// <inheritdoc />
     public string? StoreId { get; set; }

--- a/config/clients/dotnet/template/Client/Model/ClientWriteOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientWriteOptions.mustache
@@ -47,6 +47,9 @@ public interface IClientWriteOptions : IClientRequestOptionsWithAuthZModelId {
 
 public class ClientWriteOptions : IClientWriteOptions {
     /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
+
+    /// <inheritdoc />
     public string? StoreId { get; set; }
 
     /// <summary>

--- a/config/clients/dotnet/template/Client/Model/ClientWriteOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientWriteOptions.mustache
@@ -23,6 +23,8 @@ public interface ITransactionOpts {
 }
 
 public class TransactionOptions : ITransactionOpts {
+    /// <inheritdoc />
+    public IDictionary<string, string>? Headers { get; set; }
     /// <summary>
     ///     Disables full transaction mode (note: if MaxPerChunk > 1, each chunk will be a transaction)
     /// </summary>

--- a/config/clients/dotnet/template/Client_ApiClient.mustache
+++ b/config/clients/dotnet/template/Client_ApiClient.mustache
@@ -5,6 +5,7 @@ using {{packageName}}.Configuration;
 using {{packageName}}.Exceptions;
 using {{packageName}}.Telemetry;
 using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace {{packageName}}.ApiClient;
 
@@ -62,8 +63,8 @@ public class ApiClient : IDisposable {
     /// <returns></returns>
     /// <exception cref="FgaApiAuthenticationError"></exception>
     public async Task<TRes> SendRequestAsync<TReq, TRes>(RequestBuilder<TReq> requestBuilder, string apiName,
-        CancellationToken cancellationToken = default) {
-        IDictionary<string, string> additionalHeaders = new Dictionary<string, string>();
+        IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default) {
+        IDictionary<string, string> additionalHeaders = headers != null ? new Dictionary<string, string>(headers) : new Dictionary<string, string>();
 
         var sw = Stopwatch.StartNew();
         if (_oauth2Client != null) {
@@ -99,8 +100,8 @@ public class ApiClient : IDisposable {
     /// <param name="cancellationToken"></param>
     /// <exception cref="FgaApiAuthenticationError"></exception>
     public async Task SendRequestAsync<TReq>(RequestBuilder<TReq> requestBuilder, string apiName,
-        CancellationToken cancellationToken = default) {
-        IDictionary<string, string> additionalHeaders = new Dictionary<string, string>();
+        IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default) {
+        IDictionary<string, string> additionalHeaders = headers != null ? new Dictionary<string, string>(headers) : new Dictionary<string, string>();
 
         var sw = Stopwatch.StartNew();
         if (_oauth2Client != null) {

--- a/config/clients/dotnet/template/Client_BaseClient.mustache
+++ b/config/clients/dotnet/template/Client_BaseClient.mustache
@@ -4,6 +4,7 @@ using {{packageName}}.Exceptions;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Collections.Generic;
 
 namespace {{packageName}}.ApiClient;
 

--- a/config/clients/dotnet/template/OpenFgaClientTests.mustache
+++ b/config/clients/dotnet/template/OpenFgaClientTests.mustache
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 
 using Moq;
 using Moq.Protected;
@@ -173,6 +174,43 @@ public class {{appShortName}}ClientTests {
         Assert.IsType<ListStoresResponse>(response);
         Assert.Single(response.Stores);
         Assert.Equal(response, expectedResponse);
+    }
+
+    /// <summary>
+    /// Test per-request custom headers
+    /// </summary>
+    [Fact]
+    public async Task ListStoresCustomHeadersTest() {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.Headers.Contains("X-Custom-Header") &&
+                    req.Headers.GetValues("X-Custom-Header").Single() == "value"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage() {
+                StatusCode = HttpStatusCode.OK,
+                Content = Utils.CreateJsonStringContent(new ListStoresResponse() { Stores = new List<Store>() { } }),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var fgaClient = new {{appShortName}}Client(_config, httpClient);
+
+        await fgaClient.ListStores(
+            new ClientListStoresRequest(),
+            new ClientListStoresOptions { Headers = new Dictionary<string, string> { { "X-Custom-Header", "value" } } }
+        );
+
+        mockHandler.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Headers.Contains("X-Custom-Header") &&
+                req.Headers.GetValues("X-Custom-Header").Single() == "value"),
+            ItExpr.IsAny<CancellationToken>()
+        );
     }
 
     /// <summary>

--- a/config/clients/dotnet/template/api.mustache
+++ b/config/clients/dotnet/template/api.mustache
@@ -3,6 +3,7 @@
 using {{packageName}}.ApiClient;
 using {{packageName}}.Exceptions;
 using {{packageName}}.{{modelPackage}};
+using System.Collections.Generic;
 
 namespace {{packageName}}.{{apiPackage}};
 
@@ -38,7 +39,7 @@ public class {{classname}} : IDisposable {
     {{#isDeprecated}}
     [Obsolete]
     {{/isDeprecated}}
-    {{#returnType}}public async Task<{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}CancellationToken cancellationToken = default) {
+    {{#returnType}}public async Task<{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}IDictionary<string, string>? headers = null, CancellationToken cancellationToken = default) {
         var pathParams = new Dictionary<string, string> {};
         {{#pathParams.0}}
         if (string.IsNullOrWhiteSpace(storeId)) {
@@ -82,7 +83,7 @@ public class {{classname}} : IDisposable {
         };
 
         {{#returnType}}return {{/returnType}}await _apiClient.SendRequestAsync{{#returnType}}<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Any{{/bodyParam}}, {{{.}}}>{{/returnType}}(requestBuilder,
-            "{{operationId}}", cancellationToken);
+            "{{operationId}}", headers, cancellationToken);
     }
 
     {{/operation}}

--- a/config/clients/go/template/api.mustache
+++ b/config/clients/go/template/api.mustache
@@ -61,7 +61,7 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request s
 {{#allParams}}
     {{paramName}} {{^isPathParam}}*{{/isPathParam}}{{{dataType}}}
 {{/allParams}}
-    Headers map[string]string
+    headers map[string]string
 }
 {{#allParams}}{{^isPathParam}}
 func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
@@ -70,7 +70,7 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Reques
 }{{/isPathParam}}{{/allParams}}
 
 func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Headers(headers map[string]string) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
-        r.Headers = headers
+        r.headers = headers
         return r
 }
 
@@ -243,7 +243,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{/required}}
 {{/headerParams}}
 
-        for k, v := range r.Headers {
+        for k, v := range r.headers {
                 localVarHeaderParams[k] = v
         }
 {{#formParams}}

--- a/config/clients/go/template/api.mustache
+++ b/config/clients/go/template/api.mustache
@@ -53,20 +53,26 @@ type {{classname}}Service service
 {{#operation}}
 
 type {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request struct {
-	ctx context.Context{{#generateInterfaces}}
-	ApiService {{classname}}
+        ctx context.Context{{#generateInterfaces}}
+        ApiService {{classname}}
 {{/generateInterfaces}}{{^generateInterfaces}}
-	ApiService *{{classname}}Service
+        ApiService *{{classname}}Service
 {{/generateInterfaces}}
 {{#allParams}}
     {{paramName}} {{^isPathParam}}*{{/isPathParam}}{{{dataType}}}
 {{/allParams}}
+    Headers map[string]string
 }
 {{#allParams}}{{^isPathParam}}
 func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{{dataType}}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
-	r.{{paramName}} = &{{paramName}}
-	return r
+        r.{{paramName}} = &{{paramName}}
+        return r
 }{{/isPathParam}}{{/allParams}}
+
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Headers(headers map[string]string) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
+        r.Headers = headers
+        return r
+}
 
 func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*http.Response, error) {
 	return r.ApiService.{{nickname}}Execute(r)
@@ -236,6 +242,10 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 	{{/required}}
 {{/headerParams}}
+
+        for k, v := range r.Headers {
+                localVarHeaderParams[k] = v
+        }
 {{#formParams}}
 {{#isFile}}
 	localVarFormFileName = "{{baseName}}"

--- a/config/clients/go/template/api_client.mustache
+++ b/config/clients/go/template/api_client.mustache
@@ -277,21 +277,19 @@ func (c *APIClient) prepareRequest(
 		return nil, err
 	}
 
-	// add header parameters, if any
-	if len(headerParams) > 0 {
-		headers := http.Header{}
-		for h, v := range headerParams {
-			headers.Set(h, v)
-		}
-		localVarRequest.Header = headers
-	}
+        // Add the user agent to the request and apply headers
+        headers := http.Header{}
+        headers.Set("User-Agent", c.cfg.UserAgent)
 
-	// Add the user agent to the request.
-	localVarRequest.Header.Set("User-Agent", c.cfg.UserAgent)
+        for header, value := range c.cfg.DefaultHeaders {
+                headers.Set(header, value)
+        }
 
-	for header, value := range c.cfg.DefaultHeaders {
-		localVarRequest.Header.Set(header, value)
-	}
+        for h, v := range headerParams {
+                headers.Set(h, v)
+        }
+
+        localVarRequest.Header = headers
 
 	if ctx != nil {
 		// add context to the request

--- a/config/clients/go/template/api_test.mustache
+++ b/config/clients/go/template/api_test.mustache
@@ -687,10 +687,51 @@ func Test{{appShortName}}Api(t *testing.T) {
 			t.Fatalf("%v", err)
 		}
 
-		if *got.Allowed != *expectedResponse.Allowed {
-			t.Fatalf("{{appShortName}}%v().Execute() = %v, want %v", test.Name, string(responseJson), test.JsonResponse)
-		}
-	})
+        if *got.Allowed != *expectedResponse.Allowed {
+                t.Fatalf("{{appShortName}}%v().Execute() = %v, want %v", test.Name, string(responseJson), test.JsonResponse)
+        }
+        })
+
+        t.Run("CheckWithCustomHeader", func(t *testing.T) {
+                test := TestDefinition{
+                        Name:           "Check",
+                        JsonResponse:   `{"allowed":true, "resolution":""}`,
+                        ResponseStatus: 200,
+                        Method:         "POST",
+                        RequestPath:    "check",
+                }
+                requestBody := CheckRequest{
+                        TupleKey: CheckRequestTupleKey{
+                                User:     "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                                Relation: "viewer",
+                                Object:   "document:0192ab2a-d83f-756d-9397-c5ed9f3cb69a",
+                        },
+                }
+
+                var expectedResponse CheckResponse
+                if err := json.Unmarshal([]byte(test.JsonResponse), &expectedResponse); err != nil {
+                        t.Fatalf("%v", err)
+                }
+
+                httpmock.Activate()
+                defer httpmock.DeactivateAndReset()
+                httpmock.RegisterResponder(test.Method, fmt.Sprintf("%s/stores/%s/%s", configuration.ApiUrl, "01GXSB9YR785C4FYS3C0RTG7B2", test.RequestPath),
+                        func(req *http.Request) (*http.Response, error) {
+                                if req.Header.Get("X-Custom-Header") != "value" {
+                                        t.Fatalf("expected custom header to be set")
+                                }
+                                resp, err := httpmock.NewJsonResponse(test.ResponseStatus, expectedResponse)
+                                if err != nil {
+                                        return httpmock.NewStringResponse(500, ""), nil
+                                }
+                                return resp, nil
+                        },
+                )
+                _, _, err := apiClient.{{appShortName}}Api.Check(context.Background(), "01GXSB9YR785C4FYS3C0RTG7B2").Body(requestBody).Headers(map[string]string{"X-Custom-Header":"value"}).Execute()
+                if err != nil {
+                        t.Fatalf("%v", err)
+                }
+        })
 
 	t.Run("Write (Write Tuple)", func(t *testing.T) {
 		test := TestDefinition{

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -108,7 +108,8 @@ func NewSdkClient(cfg *ClientConfiguration) (*{{appShortName}}Client, error) {
 }
 
 type ClientRequestOptions struct {
-	MaxRetry    *int `json:"max_retry,omitempty"`
+        Headers map[string]string `json:"headers,omitempty"`
+        MaxRetry    *int `json:"max_retry,omitempty"`
 	MinWaitInMs *int `json:"min_wait_in_ms,omitempty"`
 }
 
@@ -146,6 +147,7 @@ type ClientBatchCheckRequest struct {
 
 // BatchCheckOptions represents options for server-side batch check operations
 type BatchCheckOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string                       `json:"authorization_model_id,omitempty"`
 	StoreId              *string                       `json:"store_id,omitempty"`
 	MaxParallelRequests  *int32                        `json:"max_parallel_requests,omitempty"`
@@ -155,6 +157,7 @@ type BatchCheckOptions struct {
 
 
 type ClientPaginationOptions struct {
+        ClientRequestOptions
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
 }
@@ -570,6 +573,7 @@ type SdkClientListStoresRequestInterface interface {
 }
 
 type ClientListStoresOptions struct {
+        ClientRequestOptions
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
 }
@@ -595,6 +599,9 @@ func (request *SdkClientListStoresRequest) GetOptions() *ClientListStoresOptions
 
 func (client *{{appShortName}}Client) ListStoresExecute(request SdkClientListStoresRequestInterface) (*ClientListStoresResponse, error) {
 	req := client.{{appShortName}}Api.ListStores(request.GetContext())
+        if request.GetOptions() != nil && request.GetOptions().Headers != nil {
+                req = req.Headers(request.GetOptions().Headers)
+        }
 	pageSize := getPageSizeFromRequest((*ClientPaginationOptions)(request.GetOptions()))
 	if pageSize != nil {
 		req = req.PageSize(*pageSize)
@@ -641,6 +648,7 @@ type ClientCreateStoreRequest struct {
 }
 
 type ClientCreateStoreOptions struct {
+        ClientRequestOptions
 }
 
 type ClientCreateStoreResponse = fgaSdk.CreateStoreResponse
@@ -706,6 +714,7 @@ type SdkClientGetStoreRequestInterface interface{
 }
 
 type ClientGetStoreOptions struct {
+        ClientRequestOptions
 	StoreId  *string `json:"store_id,omitempty"`
 }
 
@@ -772,6 +781,7 @@ type SdkClientDeleteStoreRequestInterface interface{
 }
 
 type ClientDeleteStoreOptions struct {
+        ClientRequestOptions
 	StoreId *string `json:"store_id,omitempty"`
 }
 
@@ -841,6 +851,7 @@ type SdkClientReadAuthorizationModelsRequestInterface interface{
 }
 
 type ClientReadAuthorizationModelsOptions struct {
+        ClientRequestOptions
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
 	StoreId           *string `json:"store_id,omitempty"`
@@ -885,6 +896,9 @@ func (client *{{appShortName}}Client) ReadAuthorizationModelsExecute(request Sdk
 	}
 
 	req := client.{{appShortName}}Api.ReadAuthorizationModels(request.GetContext(), *storeId)
+        if request.GetOptions() != nil && request.GetOptions().Headers != nil {
+                req = req.Headers(request.GetOptions().Headers)
+        }
 	pageSize := getPageSizeFromRequest(&pagingOpts)
 	if pageSize != nil {
 		req = req.PageSize(*pageSize)
@@ -930,6 +944,7 @@ type SdkClientWriteAuthorizationModelRequestInterface interface {
 type ClientWriteAuthorizationModelRequest = fgaSdk.WriteAuthorizationModelRequest;
 
 type ClientWriteAuthorizationModelOptions struct {
+        ClientRequestOptions
 	StoreId              *string `json:"store_id,omitempty"`
 }
 
@@ -1012,6 +1027,7 @@ type ClientReadAuthorizationModelRequest struct {
 }
 
 type ClientReadAuthorizationModelOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 }
@@ -1103,6 +1119,7 @@ type SdkClientReadLatestAuthorizationModelRequestInterface interface {
 }
 
 type ClientReadLatestAuthorizationModelOptions struct {
+        ClientRequestOptions
 	StoreId              *string `json:"store_id,omitempty"`
 }
 
@@ -1145,6 +1162,9 @@ func (client *{{appShortName}}Client) ReadLatestAuthorizationModelExecute(reques
 		opts.StoreId = request.GetOptions().StoreId
 	}
 	req := client.ReadAuthorizationModels(request.GetContext()).Options(opts)
+        if request.GetOptions() != nil && request.GetOptions().Headers != nil {
+                req = req.Headers(request.GetOptions().Headers)
+        }
 
 	response, err := req.Execute()
 	if err != nil {
@@ -1191,6 +1211,7 @@ type ClientReadChangesRequest struct {
 }
 
 type ClientReadChangesOptions struct {
+        ClientRequestOptions
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
 	StoreId           *string `json:"store_id"`
@@ -1251,6 +1272,9 @@ func (client *{{appShortName}}Client) ReadChangesExecute(request SdkClientReadCh
 	}
 
 	req := client.{{appShortName}}Api.ReadChanges(request.GetContext(), *storeId)
+        if request.GetOptions() != nil && request.GetOptions().Headers != nil {
+                req = req.Headers(request.GetOptions().Headers)
+        }
 	pageSize := getPageSizeFromRequest(&pagingOpts)
 	if pageSize != nil {
 		req = req.PageSize(*pageSize)
@@ -1301,6 +1325,7 @@ type ClientReadRequest struct {
 }
 
 type ClientReadOptions struct {
+        ClientRequestOptions
 	PageSize          *int32  `json:"page_size,omitempty"`
 	ContinuationToken *string `json:"continuation_token,omitempty"`
 	StoreId           *string `json:"store_id,omitempty"`
@@ -1409,6 +1434,7 @@ type ClientWriteRequest struct {
 }
 
 type TransactionOptions struct {
+        ClientRequestOptions
 	// If set to true will disable running in transaction mode (transaction mode means everything is sent in a single transaction to the server)
 	Disable bool `json:"disable,omitempty"`
 	// When transaction mode is disabled, the requests are chunked and sent separately and each chunk is a transaction (default = 1)
@@ -1418,6 +1444,7 @@ type TransactionOptions struct {
 }
 
 type ClientWriteOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string             `json:"authorization_model_id,omitempty"`
 	StoreId              *string             `json:"store_id,omitempty"`
 	Transaction          *TransactionOptions `json:"transaction_options,omitempty"`
@@ -1875,6 +1902,7 @@ type ClientCheckRequest struct {
 }
 
 type ClientCheckOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 	Consistency       *fgaSdk.ConsistencyPreference `json:"consistency,omitempty"`
@@ -1991,6 +2019,7 @@ type SdkClientBatchCheckClientRequestInterface interface {
 type ClientBatchCheckClientBody = []ClientCheckRequest
 
 type ClientBatchCheckClientOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 	MaxParallelRequests  *int32  `json:"max_parallel_requests,omitempty"`
@@ -2250,6 +2279,9 @@ func (client *OpenFgaClient) singleBatchCheck(ctx _context.Context, body fgaSdk.
 	}
 	
 	req := client.OpenFgaApi.BatchCheck(ctx, *storeId)
+        if request.GetOptions() != nil && request.GetOptions().Headers != nil {
+                req = req.Headers(request.GetOptions().Headers)
+        }
 	req = req.Body(body)
 
 	response, _, err := req.Execute()
@@ -2365,6 +2397,7 @@ type ClientExpandRequest struct {
 }
 
 type ClientExpandOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 	Consistency       *fgaSdk.ConsistencyPreference `json:"consistency,omitempty"`
@@ -2478,6 +2511,7 @@ type ClientListObjectsRequest struct {
 }
 
 type ClientListObjectsOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 	Consistency       *fgaSdk.ConsistencyPreference `json:"consistency,omitempty"`
@@ -2596,6 +2630,7 @@ type ClientListRelationsRequest struct {
 }
 
 type ClientListRelationsOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	MaxParallelRequests  *int32  `json:"max_parallel_requests,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
@@ -2744,6 +2779,7 @@ type ClientListUsersRequest struct {
 }
 
 type ClientListUsersOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 	Consistency       *fgaSdk.ConsistencyPreference `json:"consistency,omitempty"`
@@ -2852,6 +2888,7 @@ type SdkClientReadAssertionsRequestInterface interface {
 }
 
 type ClientReadAssertionsOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 }
@@ -2967,6 +3004,7 @@ func (clientAssertion ClientAssertion) ToAssertion() fgaSdk.Assertion {
 }
 
 type ClientWriteAssertionsOptions struct {
+        ClientRequestOptions
 	AuthorizationModelId *string `json:"authorization_model_id,omitempty"`
 	StoreId              *string `json:"store_id,omitempty"`
 }

--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -1155,21 +1155,19 @@ func (request *SdkClientReadLatestAuthorizationModelRequest) GetOptions() *Clien
 }
 
 func (client *{{appShortName}}Client) ReadLatestAuthorizationModelExecute(request SdkClientReadLatestAuthorizationModelRequestInterface) (*ClientReadAuthorizationModelResponse, error) {
-	opts := ClientReadAuthorizationModelsOptions{
-		PageSize: fgaSdk.PtrInt32(1),
-	}
-	if request.GetOptions() != nil {
-		opts.StoreId = request.GetOptions().StoreId
-	}
-	req := client.ReadAuthorizationModels(request.GetContext()).Options(opts)
-        if request.GetOptions() != nil && request.GetOptions().Headers != nil {
-                req = req.Headers(request.GetOptions().Headers)
+        opts := ClientReadAuthorizationModelsOptions{
+                PageSize: fgaSdk.PtrInt32(1),
         }
+        if request.GetOptions() != nil {
+                opts.StoreId = request.GetOptions().StoreId
+                opts.Headers = request.GetOptions().Headers
+        }
+        req := client.ReadAuthorizationModels(request.GetContext()).Options(opts)
 
-	response, err := req.Execute()
-	if err != nil {
-		return nil, err
-	}
+        response, err := req.Execute()
+        if err != nil {
+                return nil, err
+        }
 
 	var authorizationModel *fgaSdk.AuthorizationModel
 
@@ -2278,11 +2276,11 @@ func (client *OpenFgaClient) singleBatchCheck(ctx _context.Context, body fgaSdk.
 		return nil, err
 	}
 	
-	req := client.OpenFgaApi.BatchCheck(ctx, *storeId)
-        if request.GetOptions() != nil && request.GetOptions().Headers != nil {
-                req = req.Headers(request.GetOptions().Headers)
+        req := client.OpenFgaApi.BatchCheck(ctx, *storeId)
+        if options != nil && options.Headers != nil {
+                req = req.Headers(options.Headers)
         }
-	req = req.Body(body)
+        req = req.Body(body)
 
 	response, _, err := req.Execute()
 	if err != nil {

--- a/config/clients/js/template/README_calling_api.mustache
+++ b/config/clients/js/template/README_calling_api.mustache
@@ -12,7 +12,7 @@ Get a paginated list of stores.
 [API Documentation]({{apiDocsUrl}}#/Stores/ListStores)
 
 ```javascript
-const options = { pageSize: 10, continuationToken: "..." };
+const options = { pageSize: 10, continuationToken: "...", headers: { "X-Custom": "value" } };
 
 const { stores } = await fgaClient.listStores(options);
 

--- a/config/clients/js/template/api.mustache
+++ b/config/clients/js/template/api.mustache
@@ -1,7 +1,7 @@
 {{>partial_header}}
 
 {{^withSeparateModelsAndApi}}
-import globalAxios, { AxiosInstance } from 'axios';
+import globalAxios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
 import { BaseAPI } from './base';
 import {
@@ -11,6 +11,7 @@ import {
     toPathString,
     createRequestFunction,
     RequestArgs,
+    RequestOptions,
     CallResult,
     PromiseResult
 } from './common';

--- a/config/clients/js/template/apiInner.mustache
+++ b/config/clients/js/template/apiInner.mustache
@@ -62,7 +62,7 @@ export const {{classname}}AxiosParamCreator = function (configuration: Configura
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions: AxiosRequestConfig = { method: '{{httpMethod}}', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: '{{httpMethod}}', ...baseOptions, ...options } as AxiosRequestConfig & RequestOptions;
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;{{#vendorExtensions}}{{#hasFormParams}}
             const localVarFormParams = new {{^multipartFormData}}URLSearchParams(){{/multipartFormData}}{{#multipartFormData}}((configuration && configuration.formDataCtor) || FormData)(){{/multipartFormData}};{{/hasFormParams}}{{/vendorExtensions}}
@@ -180,9 +180,16 @@ export const {{classname}}AxiosParamCreator = function (configuration: Configura
             localVarRequestOptions.data = serializeDataIfNeeded({{paramName}}, localVarRequestOptions)
     {{/bodyParam}}
 
+            const localVarRequestOptionsWithHeaders: RequestOptions = {
+                ...localVarRequestOptions,
+                headers: localVarRequestOptions.headers
+                    ? Object.fromEntries(Object.entries(localVarRequestOptions.headers as any))
+                    : undefined,
+            };
+
             return {
                 url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
+                options: localVarRequestOptionsWithHeaders,
             };
         },
     {{/operation}}

--- a/config/clients/js/template/apiInner.mustache
+++ b/config/clients/js/template/apiInner.mustache
@@ -41,11 +41,12 @@ export const {{classname}}AxiosParamCreator = function (configuration: Configura
          {{#allParams}}
          * @param {{=<% %>=}}{<%&dataType%>}<%={{ }}=%> {{^required}}[{{/required}}{{paramName}}{{^required}}]{{/required}}{{#description}} {{description}}{{/description}}
          {{/allParams}}
-         * @param {*} [options] Override http request option.{{#isDeprecated}}
+         * @param {RequestOptions} [options] Override http request option.{{#isDeprecated}}
+         * @param {Record<string, string>} [options.headers] Custom headers to send with the request.
          * @deprecated{{/isDeprecated}}
          * @throws { FgaError }
          */
-        {{nickname}}: ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: any = {}): RequestArgs => {
+        {{nickname}}: ({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options: RequestOptions = {}): RequestArgs => {
     {{#allParams}}
     {{#required}}
             // verify required parameter '{{paramName}}' is not null or undefined
@@ -61,7 +62,7 @@ export const {{classname}}AxiosParamCreator = function (configuration: Configura
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: '{{httpMethod}}', ...baseOptions, ...options};
+            const localVarRequestOptions: AxiosRequestConfig = { method: '{{httpMethod}}', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;{{#vendorExtensions}}{{#hasFormParams}}
             const localVarFormParams = new {{^multipartFormData}}URLSearchParams(){{/multipartFormData}}{{#multipartFormData}}((configuration && configuration.formDataCtor) || FormData)(){{/multipartFormData}};{{/hasFormParams}}{{/vendorExtensions}}
@@ -209,7 +210,7 @@ export const {{classname}}Fp = function(configuration: Configuration, credential
          * @deprecated{{/isDeprecated}}
          * @throws { FgaError }
          */
-        async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): Promise<(axios?: AxiosInstance) => PromiseResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
+        async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: RequestOptions): Promise<(axios?: AxiosInstance) => PromiseResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
             const localVarAxiosArgs = localVarAxiosParamCreator.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, configuration, credentials, {
                 [TelemetryAttribute.FgaClientRequestMethod]: "{{operationIdCamelCase}}",
@@ -246,7 +247,7 @@ export const {{classname}}Factory = function (configuration: Configuration, cred
          * @deprecated{{/isDeprecated}}
          * @throws { FgaError }
          */
-        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): PromiseResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
+        {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: RequestOptions): PromiseResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
             return localVarFp.{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options).then((request) => request(axios));
         },
     {{/operation}}
@@ -275,7 +276,7 @@ export interface {{classname}}Interface {
      * @throws { FgaError }
      * @memberof {{classname}}Interface
      */
-    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): PromiseResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
+    {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: RequestOptions): PromiseResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>;
 
 {{/operation}}
 }
@@ -341,12 +342,12 @@ export class {{classname}} extends BaseAPI {
      * @memberof {{classname}}
      */
     {{#useSingleRequestParameter}}
-    public {{nickname}}({{#allParams.0}}requestParameters: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}options?: any): Promise<CallResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
+    public {{nickname}}({{#allParams.0}}requestParameters: {{classname}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}options?: RequestOptions): Promise<CallResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
         return {{classname}}Fp(this.configuration, this.credentials).{{nickname}}({{#allParams.0}}{{#allParams}}requestParameters.{{paramName}}, {{/allParams}}{{/allParams.0}}options).then((request) => request(this.axios));
     }
     {{/useSingleRequestParameter}}
     {{^useSingleRequestParameter}}
-    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: any): Promise<CallResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
+    public {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/allParams}}options?: RequestOptions): Promise<CallResult<{{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}>> {
         return {{classname}}Fp(this.configuration, this.credentials).{{nickname}}({{#allParams}}{{paramName}}, {{/allParams}}options).then((request) => request(this.axios));
     }
     {{/useSingleRequestParameter}}

--- a/config/clients/js/template/apiInner.mustache
+++ b/config/clients/js/template/apiInner.mustache
@@ -172,7 +172,11 @@ export const {{classname}}AxiosParamCreator = function (configuration: Configura
 
     {{/bodyParam}}
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...options.headers};
+            localVarRequestOptions.headers = {
+                ...(baseOptions && baseOptions.headers ? baseOptions.headers : {}),
+                ...localVarHeaderParameter,
+                ...options.headers,
+            };
     {{#hasFormParams}}
             localVarRequestOptions.data = localVarFormParams{{#vendorExtensions}}{{^multipartFormData}}.toString(){{/multipartFormData}}{{/vendorExtensions}};
     {{/hasFormParams}}

--- a/config/clients/js/template/baseApi.mustache
+++ b/config/clients/js/template/baseApi.mustache
@@ -50,4 +50,24 @@ export class BaseAPI {
       });
     }
   }
+
+  public setDefaultHeader(headerName: string, headerValue: string) {
+    if (!this.configuration.baseOptions) {
+      this.configuration.baseOptions = { headers: {} };
+    }
+    if (!this.configuration.baseOptions.headers) {
+      this.configuration.baseOptions.headers = {};
+    }
+    this.configuration.baseOptions.headers[headerName] = headerValue;
+
+    if (this.axios) {
+      if (!this.axios.defaults.headers) {
+        this.axios.defaults.headers = {} as any;
+      }
+      if (!this.axios.defaults.headers.common) {
+        this.axios.defaults.headers.common = {} as any;
+      }
+      this.axios.defaults.headers.common[headerName] = headerValue;
+    }
+  }
 }

--- a/config/clients/js/template/client.mustache
+++ b/config/clients/js/template/client.mustache
@@ -40,7 +40,7 @@ import {
   WriteRequest,
 } from "./apiModel";
 import { BaseAPI } from "./base";
-import { CallResult, PromiseResult } from "./common";
+import { CallResult, PromiseResult, RequestOptions } from "./common";
 import { Configuration, RetryParams, UserConfigurationParams } from "./configuration";
 import { FgaApiAuthenticationError, FgaRequiredParamError, FgaValidationError } from "./errors";
 import {
@@ -95,9 +95,8 @@ const DEFAULT_MAX_BATCH_SIZE = 50;
 const CLIENT_METHOD_HEADER = "{{clientMethodHeader}}";
 const CLIENT_BULK_REQUEST_ID_HEADER = "{{clientBulkRequestIdHeader}}";
 
-export interface ClientRequestOpts {
+export interface ClientRequestOpts extends RequestOptions {
   retryParams?: RetryParams;
-  headers?: Record<string, string>;
 }
 
 export interface StoreIdOpts {

--- a/config/clients/js/template/common.mustache
+++ b/config/clients/js/template/common.mustache
@@ -2,7 +2,7 @@
 
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 
-import { Configuration } from "./configuration";
+import { Configuration, RetryParams } from "./configuration";
 import type { Credentials } from "./credentials";
 import {
   FgaApiError,
@@ -31,11 +31,12 @@ export const DUMMY_BASE_URL = "https://example.com";
  */
 export interface RequestArgs {
     url: string;
-    options: AxiosRequestConfig;
+    options: RequestOptions;
 }
 
 export interface RequestOptions {
     headers?: Record<string, string>;
+    retryParams?: RetryParams;
     [key: string]: any;
 }
 

--- a/config/clients/js/template/common.mustache
+++ b/config/clients/js/template/common.mustache
@@ -195,8 +195,8 @@ export const createRequestFunction = function (axiosArgs: RequestArgs, axiosInst
   configuration.isValid();
 
   const retryParams = axiosArgs.options?.retryParams ? axiosArgs.options?.retryParams : configuration.retryParams;
-  const maxRetry:number = retryParams ? retryParams.maxRetry : 0;
-  const minWaitInMs:number = retryParams ? retryParams.minWaitInMs : 0;
+  const maxRetry: number = retryParams?.maxRetry ?? 0;
+  const minWaitInMs: number = retryParams?.minWaitInMs ?? 0;
 
   const start = performance.now();
 

--- a/config/clients/js/template/common.mustache
+++ b/config/clients/js/template/common.mustache
@@ -31,7 +31,12 @@ export const DUMMY_BASE_URL = "https://example.com";
  */
 export interface RequestArgs {
     url: string;
-    options: any;
+    options: AxiosRequestConfig;
+}
+
+export interface RequestOptions {
+    headers?: Record<string, string>;
+    [key: string]: any;
 }
 
 

--- a/config/clients/js/template/tests/client.test.ts.mustache
+++ b/config/clients/js/template/tests/client.test.ts.mustache
@@ -74,6 +74,39 @@ describe("{{appTitleCaseName}} Client", () => {
         fgaClient.authorizationModelId = defaultConfiguration.authorizationModelId;
         expect(fgaClient.authorizationModelId).toBe(defaultConfiguration.authorizationModelId);
       });
+
+      it("should allow setting custom default headers", async () => {
+        const customClient = new {{appShortName}}Client({
+          apiUrl: defaultConfiguration.apiUrl,
+          credentials: { method: CredentialsMethod.None },
+        });
+        customClient.setDefaultHeader("Custom-Header", "custom value");
+
+        const scope = nock(defaultConfiguration.getBasePath(), {
+          reqheaders: { "Custom-Header": "custom value" }
+        })
+          .get("/stores")
+          .reply(200, { continuation_token: "", stores: [] });
+
+        await customClient.listStores();
+        expect(scope.isDone()).toBe(true);
+      });
+
+      it("should allow sending custom headers per request", async () => {
+        const customClient = new {{appShortName}}Client({
+          apiUrl: defaultConfiguration.apiUrl,
+          credentials: { method: CredentialsMethod.None },
+        });
+
+        const scope = nock(defaultConfiguration.getBasePath(), {
+          reqheaders: { "X-Custom-Header": "value" }
+        })
+          .get("/stores")
+          .reply(200, { continuation_token: "", stores: [] });
+
+        await customClient.listStores({ headers: { "X-Custom-Header": "value" } });
+        expect(scope.isDone()).toBe(true);
+      });
     });
 
 

--- a/config/clients/python/template/src/api.py.mustache
+++ b/config/clients/python/template/src/api.py.mustache
@@ -87,6 +87,8 @@ class {{classname}}:
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param headers: additional headers to include in the request
+        :type headers: Dict[str, str], optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -136,7 +138,9 @@ class {{classname}}:
                               request; this effectively ignores the authentication
                               in the spec for a single request.
         :param _retry_param: if specified, override the retry parameters specified in configuration
+        :param headers: additional headers to include in the request
         :type _request_auth: dict, optional
+        :type headers: Dict[str, str], optional
         :type _content_type: string, optional: force content-type for the request
         :return: Returns the result object.
                  If the method is called asynchronously,
@@ -178,6 +182,7 @@ class {{classname}}:
                 '_request_timeout',
                 '_request_auth',
                 '_content_type',
+                'headers',
                 '_headers',
                 '_retry_params',
                 '_streaming',
@@ -236,7 +241,8 @@ class {{classname}}:
             collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isArray}}
 {{/queryParams}}
 
-        header_params = dict(local_var_params.get('_headers', {}))
+        header_params = dict(local_var_params.get("headers", {}))
+        header_params.update(local_var_params.get('_headers', {}))
 {{#headerParams}}
         if '{{paramName}}' in local_var_params:
             header_params['{{baseName}}'] = local_var_params['{{paramName}}']{{#isArray}}

--- a/config/clients/python/template/src/sync/api.py.mustache
+++ b/config/clients/python/template/src/sync/api.py.mustache
@@ -74,6 +74,8 @@ class {{classname}}:
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
+        :param headers: additional headers to include in the request
+        :type headers: Dict[str, str], optional
         :return: Returns the result object.
                  If the method is called asynchronously,
                  returns the request thread.
@@ -123,7 +125,9 @@ class {{classname}}:
                               request; this effectively ignores the authentication
                               in the spec for a single request.
         :param _retry_param: if specified, override the retry parameters specified in configuration
+        :param headers: additional headers to include in the request
         :type _request_auth: dict, optional
+        :type headers: Dict[str, str], optional
         :type _content_type: string, optional: force content-type for the request
         :return: Returns the result object.
                  If the method is called asynchronously,
@@ -165,6 +169,7 @@ class {{classname}}:
                 "_request_timeout",
                 "_request_auth",
                 "_content_type",
+                "headers",
                 "_headers",
                 "_retry_params",
                 "_streaming",
@@ -223,7 +228,8 @@ class {{classname}}:
             collection_formats['{{baseName}}'] = '{{collectionFormat}}'{{/isArray}}
 {{/queryParams}}
 
-        header_params = dict(local_var_params.get('_headers', {}))
+        header_params = dict(local_var_params.get("headers", {}))
+        header_params.update(local_var_params.get('_headers', {}))
 {{#headerParams}}
         if '{{paramName}}' in local_var_params:
             header_params['{{baseName}}'] = local_var_params['{{paramName}}']{{#isArray}}

--- a/config/clients/python/template/test/api_test.py.mustache
+++ b/config/clients/python/template/test/api_test.py.mustache
@@ -1805,7 +1805,6 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
         configuration = self.configuration
         configuration.store_id = store_id
         async with {{packageName}}.ApiClient(configuration) as api_client:
-            api_client.set_default_header("Custom Header", "custom value")
             api_instance = open_fga_api.OpenFgaApi(api_client)
             body = CheckRequest(
                 tuple_key=TupleKey(
@@ -1816,6 +1815,7 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
             )
             api_response = await api_instance.check(
                 body=body,
+                headers={"Custom Header": "custom value"},
             )
             self.assertIsInstance(api_response, CheckResponse)
             self.assertTrue(api_response.allowed)

--- a/config/clients/python/template/test/sync/api_test.py.mustache
+++ b/config/clients/python/template/test/sync/api_test.py.mustache
@@ -1870,7 +1870,6 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
         configuration = self.configuration
         configuration.store_id = store_id
         with ApiClient(configuration) as api_client:
-            api_client.set_default_header("Custom Header", "custom value")
             api_instance = open_fga_api.OpenFgaApi(api_client)
             body = CheckRequest(
                 tuple_key=TupleKey(
@@ -1881,6 +1880,7 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
             )
             api_response = api_instance.check(
                 body=body,
+                headers={"Custom Header": "custom value"},
             )
             self.assertIsInstance(api_response, CheckResponse)
             self.assertTrue(api_response.allowed)


### PR DESCRIPTION
## Summary
- add `headers` option to Go, .NET, Python and JS SDK templates for per-request customization
- forward request option headers through client layers and update API helpers/tests
- Codex experiment to implement #569 

## Testing
- `make test-client-js` *(fails: docker: not found)*
- `make test-client-go` *(fails: docker: not found)*
- `make test-client-dotnet` *(fails: docker: not found)*
- `make test-client-python` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ad8c586b883308920e6952d58bdf4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add per-request custom HTTP headers support across .NET, Go, Python, and JS clients.
  - JS client now supports setting default headers globally.

- Refactor
  - Simplified and standardized header assembly in the Go client for predictable behavior.

- Documentation
  - Updated JS examples to demonstrate sending headers via request options.

- Tests
  - Added tests across SDKs to verify custom header propagation in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->