### PR TITLE
chore: upgrade Gradle to 8.14.3

### DIFF
--- a/config/clients/java/template/example/example1/gradle/wrapper/gradle-wrapper.properties
+++ b/config/clients/java/template/example/example1/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/config/clients/java/template/gradle-wrapper.properties.mustache
+++ b/config/clients/java/template/gradle-wrapper.properties.mustache
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Update main gradle-wrapper.properties.mustache from 8.2.1 to 8.14.3
- Update example gradle-wrapper.properties from 8.0 to 8.14.3
- This will support Java 24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Gradle wrapper in Java client templates to version 8.14.3 (bin/all), modernizing build tooling with performance improvements, security fixes, and improved compatibility with recent JDKs and plugins. No functional changes to generated clients; builds should behave as before. If you cache Gradle, refresh the wrapper to pick up the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->