### PR TITLE
chore: simplify ClientWriteStatus enum to basic Java enum

### DIFF
--- a/config/clients/java/template/src/main/api/client/model/ClientWriteStatus.java.mustache
+++ b/config/clients/java/template/src/main/api/client/model/ClientWriteStatus.java.mustache
@@ -2,21 +2,6 @@
 package {{clientPackage}}.model;
 
 public enum ClientWriteStatus {
-    SUCCESS("success"),
-    FAILURE("failure");
-
-    private final String value;
-
-    ClientWriteStatus(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return value;
-    }
+    SUCCESS,
+    FAILURE
 }

--- a/config/clients/java/template/src/test/api/client/model/ClientWriteStatusTest.java.mustache
+++ b/config/clients/java/template/src/test/api/client/model/ClientWriteStatusTest.java.mustache
@@ -8,13 +8,11 @@ public class ClientWriteStatusTest {
 
     @Test
     public void testSuccessValue() {
-        assertEquals("success", ClientWriteStatus.SUCCESS.getValue());
-        assertEquals("success", ClientWriteStatus.SUCCESS.toString());
+        assertEquals("SUCCESS", ClientWriteStatus.SUCCESS.toString());
     }
 
     @Test
     public void testFailureValue() {
-        assertEquals("failure", ClientWriteStatus.FAILURE.getValue());
-        assertEquals("failure", ClientWriteStatus.FAILURE.toString());
+        assertEquals("FAILURE", ClientWriteStatus.FAILURE.toString());
     }
 }


### PR DESCRIPTION
- Remove unnecessary value field, constructor, and getValue() method
- Update enum to use simple SUCCESS and FAILURE constants
- Update tests to expect uppercase enum names instead of lowercase values
- Follows standard Java enum practices and reduces complexity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized client write status labels to uppercase (SUCCESS/FAILURE) across UI, logs, and responses; previously shown as lowercase.
  * This may affect automations or integrations that expect lowercase values.
  * No other behavior changes.

* **Tests**
  * Updated test coverage to reflect the uppercase status labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->