### PR TITLE
feat(js-sdk): support per-request custom headers

### DIFF
--- a/config/clients/js/template/apiInner.mustache
+++ b/config/clients/js/template/apiInner.mustache
@@ -171,7 +171,7 @@ export const {{classname}}AxiosParamCreator = function (configuration: Configura
 
     {{/bodyParam}}
             setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...options.headers};
+            localVarRequestOptions.headers = { ...baseOptions?.headers, ...localVarHeaderParameter, ...options.headers };
     {{#hasFormParams}}
             localVarRequestOptions.data = localVarFormParams{{#vendorExtensions}}{{^multipartFormData}}.toString(){{/multipartFormData}}{{/vendorExtensions}};
     {{/hasFormParams}}

--- a/config/clients/js/template/tests/client.test.ts.mustache
+++ b/config/clients/js/template/tests/client.test.ts.mustache
@@ -99,6 +99,17 @@ describe("{{appTitleCaseName}} Client", () => {
         expect(response.stores).toHaveLength(1);
         expect(response.stores?.[0]).toMatchObject(store);
       });
+
+      it("should include custom headers when provided", async () => {
+        const scope = nock(defaultConfiguration.getBasePath())
+          .get("/stores")
+          .matchHeader("X-Correlation-ID", "abc123")
+          .reply(200, { continuation_token: "", stores: [] });
+
+        await fgaClient.listStores({ headers: { "X-Correlation-ID": "abc123" } });
+
+        expect(scope.isDone()).toBe(true);
+      });
     });
 
     describe("CreateStore", () => {


### PR DESCRIPTION
## Summary
- include base and custom headers in generated requests for JS SDK
- test that JS client forwards per-request headers

## Testing
- `make test-client-js` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e30cc7cac8322bb66ce1ec6428da3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Per-request custom headers now correctly merge and take precedence over default headers in the JavaScript client, ensuring values like correlation IDs and other custom headers are reliably sent with API calls.

* **Tests**
  * Added coverage verifying custom headers are included when calling listStores, ensuring header merging behaves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->