### PR TITLE
feat(python): support per-request headers

### DIFF
--- a/config/clients/python/CHANGELOG.md.mustache
+++ b/config/clients/python/CHANGELOG.md.mustache
@@ -5,6 +5,7 @@
 ### [{{packageVersion}}](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.9.4...{{packageVersion}}) (2025-07-09)
 
 - fix: aiohttp.ClientResponse.data should be awaited (#197) - thanks @cmbernard333
+- feat: allow per-request custom headers via `options["headers"]`
 
 ### [0.9.4](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v0.9.3...0.9.4) (2025-04-30)
 

--- a/config/clients/python/template/src/api_client.py.mustache
+++ b/config/clients/python/template/src/api_client.py.mustache
@@ -184,8 +184,7 @@ class ApiClient:
         start = float(time.time())
 
         # header parameters
-        header_params = header_params or {}
-        header_params.update(self.default_headers)
+        header_params = {**self.default_headers, **(header_params or {})}
         if self.cookie:
             header_params['Cookie'] = self.cookie
         if header_params:

--- a/config/clients/python/template/src/client/client.py.mustache
+++ b/config/clients/python/template/src/client/client.py.mustache
@@ -62,13 +62,13 @@ def _chuck_array(array, max_size):
     return [array[i * max_size:(i + 1) * max_size] for i in range((len(array) + max_size - 1) // max_size )]
 
 
-def set_heading_if_not_set(
+def set_header_if_not_set(
     options: dict[str, int | str | dict[str, int | str]] | None,
     name: str,
     value: str,
 ) -> dict[str, int | str | dict[str, int | str]]:
     """
-    Set heading to the value if it is not set
+    Set header to the value if it is not set
     """
     _options: dict[str, int | str | dict[str, int | str]] = (
         options if options is not None else {}
@@ -88,7 +88,7 @@ def options_to_kwargs(
     options: dict[str, int | str | dict[str, int | str]] | None = None,
 ) -> dict[str, int | str | dict[str, int | str]]:
     """
-    Return kwargs with continuation_token and page_size
+    Return kwargs with continuation_token, page_size, headers and retry parameters
     """
     kwargs = {}
     if options is not None:
@@ -221,7 +221,7 @@ class OpenFgaClient:
         :param name(options) - The name parameter instructs the API to only include results that match that name. Multiple results may be returned. Only exact matches will be returned; substring matches and regexes will not be evaluated.
         :param page_size(options) - Number of items returned per request
         :param continuation_token(options) - No continuation_token by default
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -236,7 +236,7 @@ class OpenFgaClient:
     {{#asyncio}}async {{/asyncio}}def create_store(self, body: CreateStoreRequest, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Create the stores in the system
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -251,7 +251,7 @@ class OpenFgaClient:
     {{#asyncio}}async {{/asyncio}}def get_store(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Get the store info in the system. Store id is from the configuration.
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -265,7 +265,7 @@ class OpenFgaClient:
     {{#asyncio}}async {{/asyncio}}def delete_store(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Delete the store from the system. Store id is from the configuration.
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -283,7 +283,7 @@ class OpenFgaClient:
     {{#asyncio}}async {{/asyncio}}def read_authorization_models(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Return all the authorization models for a particular store.
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -298,7 +298,7 @@ class OpenFgaClient:
         """
         Write authorization model.
         :param body - WriteAuthorizationModelRequest
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -313,7 +313,7 @@ class OpenFgaClient:
     {{#asyncio}}async {{/asyncio}}def read_authorization_model(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Read an authorization model.
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -329,12 +329,12 @@ class OpenFgaClient:
     {{#asyncio}}async {{/asyncio}}def read_latest_authorization_model(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Convenient method of reading the latest authorization model
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel")
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel")
         options["page_size"] = 1
         api_response = {{#asyncio}}await {{/asyncio}}self.read_authorization_models(options)
         model = api_response.authorization_models[0] if len(api_response.authorization_models) > 0 else None
@@ -350,7 +350,7 @@ class OpenFgaClient:
         :param body - the type we want to look for change
         :param page_size(options) - Number of items returned per request
         :param continuation_token(options) - No continuation_token by default
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -374,7 +374,7 @@ class OpenFgaClient:
         :param body - the tuples we want to read
         :param page_size(options) - Number of items returned per request
         :param continuation_token(options) - No continuation_token by default
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -476,18 +476,18 @@ class OpenFgaClient:
         """
         Write or deletes tuples
         :param body - the write request
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Write")
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "Write")
         transaction = options_to_transaction_info(options)
         if not transaction.disabled:
             results = {{#asyncio}}await {{/asyncio}}self._write_with_transaction(body, options)
             return results
 
-        options = set_heading_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
+        options = set_header_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
 
         # otherwise, it is not a transaction and it is a batch write requests
         writes_response = None
@@ -502,12 +502,12 @@ class OpenFgaClient:
         """
         Convenient method for writing tuples
         :param body - the list of tuples we want to write
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "WriteTuples")
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "WriteTuples")
         result = {{#asyncio}}await {{/asyncio}}self.write(ClientWriteRequest(body, None), options)
         return result
 
@@ -515,12 +515,12 @@ class OpenFgaClient:
         """
         Convenient method for deleteing tuples
         :param body - the list of tuples we want to delete
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "DeleteTuples")
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "DeleteTuples")
         result = {{#asyncio}}await {{/asyncio}}self.write(ClientWriteRequest(None, body), options)
         return result
 
@@ -536,7 +536,7 @@ class OpenFgaClient:
         Check whether a user is authorized to access an object
         :param body - ClientCheckRequest defining check request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -598,13 +598,13 @@ class OpenFgaClient:
         :param body - list of ClientCheckRequest defining check request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
         :param max_parallel_requests(options) - Max number of requests to issue in parallel. Defaults to {{ clientMaxMethodParallelRequests }}
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "BatchCheck")
-        options = set_heading_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "BatchCheck")
+        options = set_header_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
 
         max_parallel_requests = {{ clientMaxMethodParallelRequests }}
         if options is not None and "max_parallel_requests" in options:
@@ -664,12 +664,12 @@ class OpenFgaClient:
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
         :param max_parallel_requests(options) - Max number of requests to issue in parallel. Defaults to 10
         :param max_batch_size(options) - Max number of checks to include in a request. Defaults to 50
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
+        options = set_header_if_not_set(
             options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4())
         )
 
@@ -746,7 +746,7 @@ class OpenFgaClient:
         Run expand request
         :param body - list of ClientExpandRequest defining expand request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -777,7 +777,7 @@ class OpenFgaClient:
         Run list object request
         :param body - list object parameters
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -811,7 +811,7 @@ class OpenFgaClient:
 
         :param body - list object parameters
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -845,14 +845,14 @@ class OpenFgaClient:
         Return all the relations for which user has a relationship with the object
         :param body - list relation request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListRelations")
-        options = set_heading_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "ListRelations")
+        options = set_header_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
 
         request_body = [construct_check_request(user=body.user, relation=i, object=body.object, contextual_tuples=body.contextual_tuples, context=body.context) for i in body.relations]
         result = {{#asyncio}}await {{/asyncio}}self.client_batch_check(request_body, options)
@@ -875,7 +875,7 @@ class OpenFgaClient:
         Run list users request
         :param body - list user parameters
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -907,7 +907,7 @@ class OpenFgaClient:
         """
         Return the assertions
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -923,7 +923,7 @@ class OpenFgaClient:
         Upsert the assertions
         :param body - Write assertion request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated

--- a/config/clients/python/template/src/sync/api_client.py.mustache
+++ b/config/clients/python/template/src/sync/api_client.py.mustache
@@ -170,8 +170,7 @@ class ApiClient:
         start = float(time.time())
 
         # header parameters
-        header_params = header_params or {}
-        header_params.update(self.default_headers)
+        header_params = {**self.default_headers, **(header_params or {})}
         if self.cookie:
             header_params['Cookie'] = self.cookie
         if header_params:

--- a/config/clients/python/template/src/sync/client/client.py.mustache
+++ b/config/clients/python/template/src/sync/client/client.py.mustache
@@ -62,13 +62,13 @@ def _chuck_array(array, max_size):
     return [array[i * max_size:(i + 1) * max_size] for i in range((len(array) + max_size - 1) // max_size )]
 
 
-def set_heading_if_not_set(
+def set_header_if_not_set(
     options: dict[str, int | str | dict[str, int | str]] | None,
     name: str,
     value: str,
 ) -> dict[str, int | str | dict[str, int | str]]:
     """
-    Set heading to the value if it is not set
+    Set header to the value if it is not set
     """
     _options: dict[str, int | str | dict[str, int | str]] = (
         options if options is not None else {}
@@ -88,7 +88,7 @@ def options_to_kwargs(
     options: dict[str, int | str | dict[str, int | str]] | None = None,
 ) -> dict[str, int | str | dict[str, int | str]]:
     """
-    Return kwargs with continuation_token and page_size
+    Return kwargs with continuation_token, page_size, headers and retry parameters
     """
     kwargs = {}
     if options is not None:
@@ -212,7 +212,7 @@ class OpenFgaClient:
         :param name(options) - The name parameter instructs the API to only include results that match that name. Multiple results may be returned. Only exact matches will be returned; substring matches and regexes will not be evaluated.
         :param page_size(options) - Number of items returned per request
         :param continuation_token(options) - No continuation_token by default
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -227,7 +227,7 @@ class OpenFgaClient:
     def create_store(self, body: CreateStoreRequest, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Create the stores in the system
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -242,7 +242,7 @@ class OpenFgaClient:
     def get_store(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Get the store info in the system. Store id is from the configuration.
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -256,7 +256,7 @@ class OpenFgaClient:
     def delete_store(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Delete the store from the system. Store id is from the configuration.
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -274,7 +274,7 @@ class OpenFgaClient:
     def read_authorization_models(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Return all the authorization models for a particular store.
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -289,7 +289,7 @@ class OpenFgaClient:
         """
         Write authorization model.
         :param body - WriteAuthorizationModelRequest
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -304,7 +304,7 @@ class OpenFgaClient:
     def read_authorization_model(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Read an authorization model.
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -320,12 +320,12 @@ class OpenFgaClient:
     def read_latest_authorization_model(self, options: dict[str, int | str | dict[str, int | str]] | None = None):
         """
         Convenient method of reading the latest authorization model
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel")
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "ReadLatestAuthorizationModel")
         options["page_size"] = 1
         api_response = self.read_authorization_models(options)
         model = api_response.authorization_models[0] if len(api_response.authorization_models) > 0 else None
@@ -341,7 +341,7 @@ class OpenFgaClient:
         :param body - the type we want to look for change
         :param page_size(options) - Number of items returned per request
         :param continuation_token(options) - No continuation_token by default
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -365,7 +365,7 @@ class OpenFgaClient:
         :param body - the tuples we want to read
         :param page_size(options) - Number of items returned per request
         :param continuation_token(options) - No continuation_token by default
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -461,18 +461,18 @@ class OpenFgaClient:
         """
         Write or deletes tuples
         :param body - the write request
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "Writes")
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "Writes")
         transaction = options_to_transaction_info(options)
         if not transaction.disabled:
             results = self._write_with_transaction(body, options)
             return results
 
-        options = set_heading_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
+        options = set_header_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
 
         # otherwise, it is not a transaction and it is a batch write requests
         writes_response = None
@@ -487,12 +487,12 @@ class OpenFgaClient:
         """
         Convenient method for writing tuples
         :param body - the list of tuples we want to write
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "WriteTuples")
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "WriteTuples")
         result = self.write(ClientWriteRequest(body, None), options)
         return result
 
@@ -500,12 +500,12 @@ class OpenFgaClient:
         """
         Convenient method for deleteing tuples
         :param body - the list of tuples we want to delete
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "DeleteTuples")
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "DeleteTuples")
         result = self.write(ClientWriteRequest(None, body), options)
         return result
 
@@ -517,7 +517,7 @@ class OpenFgaClient:
         Check whether a user is authorized to access an object
         :param body - ClientCheckRequest defining check request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -573,14 +573,14 @@ class OpenFgaClient:
         :param body - list of ClientCheckRequest defining check request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
         :param max_parallel_requests(options) - Max number of requests to issue in parallel. Defaults to {{ clientMaxMethodParallelRequests }}
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "BatchCheck")
-        options = set_heading_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "BatchCheck")
+        options = set_header_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
 
         max_parallel_requests = {{ clientMaxMethodParallelRequests }}
         if options is not None and "max_parallel_requests" in options:
@@ -632,12 +632,12 @@ class OpenFgaClient:
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
         :param max_parallel_requests(options) - Max number of requests to issue in parallel. Defaults to 10
         :param max_batch_size(options) - Max number of checks to include in a request. Defaults to 50
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         """
-        options = set_heading_if_not_set(
+        options = set_header_if_not_set(
             options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4())
         )
 
@@ -720,7 +720,7 @@ class OpenFgaClient:
         Run expand request
         :param body - list of ClientExpandRequest defining expand request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -751,7 +751,7 @@ class OpenFgaClient:
         Run list object request
         :param body - list object parameters
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -785,7 +785,7 @@ class OpenFgaClient:
 
         :param body - list object parameters
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -819,14 +819,14 @@ class OpenFgaClient:
         Return all the relations for which user has a relationship with the object
         :param body - list relation request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
         :param consistency(options) - The type of consistency preferred for the request
         """
-        options = set_heading_if_not_set(options, CLIENT_METHOD_HEADER, "ListRelations")
-        options = set_heading_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
+        options = set_header_if_not_set(options, CLIENT_METHOD_HEADER, "ListRelations")
+        options = set_header_if_not_set(options, CLIENT_BULK_REQUEST_ID_HEADER, str(uuid.uuid4()))
 
         request_body = [construct_check_request(user=body.user, relation=i, object=body.object, contextual_tuples=body.contextual_tuples, context=body.context) for i in body.relations]
         result = self.client_batch_check(request_body, options)
@@ -848,7 +848,7 @@ class OpenFgaClient:
         Run list users request
         :param body - list user parameters
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -881,7 +881,7 @@ class OpenFgaClient:
         """
         Return the assertions
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated
@@ -897,7 +897,7 @@ class OpenFgaClient:
         Upsert the assertions
         :param body - Write assertion request
         :param authorization_model_id(options) - Overrides the authorization model id in the configuration
-        :param header(options) - Custom headers to send alongside the request
+        :param headers(options) - Custom headers to send alongside the request
         :param retryParams(options) - Override the retry parameters for this request
         :param retryParams.maxRetry(options) - Override the max number of retries on each API request
         :param retryParams.minWaitInMs(options) - Override the minimum wait before a retry is initiated

--- a/config/clients/python/template/test/api_test.py.mustache
+++ b/config/clients/python/template/test/api_test.py.mustache
@@ -1792,6 +1792,60 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
             )
 
     @patch.object(rest.RESTClientObject, "request")
+    async def test_check_override_default_header(self, mock_request):
+        """Test case for overriding default header
+
+        Ensure per-request headers override default headers
+        """
+
+        response_body = '{"allowed": true}'
+        mock_request.return_value = mock_response(response_body, 200)
+
+        configuration = self.configuration
+        configuration.store_id = store_id
+        async with {{packageName}}.ApiClient(configuration) as api_client:
+            api_client.set_default_header("Custom Header", "default value")
+            api_instance = open_fga_api.OpenFgaApi(api_client)
+            body = CheckRequest(
+                tuple_key=TupleKey(
+                    object="document:2021-budget",
+                    relation="reader",
+                    user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                ),
+            )
+            options = {"headers": {"Custom Header": "override value"}}
+            api_response = await api_instance.check(
+                body=body,
+                options=options,
+            )
+            self.assertIsInstance(api_response, CheckResponse)
+            self.assertTrue(api_response.allowed)
+            expected_headers = urllib3.response.HTTPHeaderDict(
+                {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "openfga-sdk python/{{packageVersion}}",
+                    "Custom Header": "override value",
+                }
+            )
+            mock_request.assert_called_once_with(
+                "POST",
+                "http://api.fga.example/stores/01H0H015178Y2V4CX10C2KGHF4/check",
+                headers=expected_headers,
+                query_params=[],
+                post_params=[],
+                body={
+                    "tuple_key": {
+                        "object": "document:2021-budget",
+                        "relation": "reader",
+                        "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                    }
+                },
+                _preload_content=ANY,
+                _request_timeout=None,
+            )
+
+    @patch.object(rest.RESTClientObject, "request")
     async def test_check_custom_header(self, mock_request):
         """Test case for custom header
 

--- a/config/clients/python/template/test/sync/api_test.py.mustache
+++ b/config/clients/python/template/test/sync/api_test.py.mustache
@@ -1857,6 +1857,60 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
             )
 
     @patch.object(rest.RESTClientObject, "request")
+    def test_check_override_default_header(self, mock_request):
+        """Test case for overriding default header
+
+        Ensure per-request headers override default headers
+        """
+
+        response_body = '{"allowed": true}'
+        mock_request.return_value = mock_response(response_body, 200)
+
+        configuration = self.configuration
+        configuration.store_id = store_id
+        with ApiClient(configuration) as api_client:
+            api_client.set_default_header("Custom Header", "default value")
+            api_instance = open_fga_api.OpenFgaApi(api_client)
+            body = CheckRequest(
+                tuple_key=TupleKey(
+                    object="document:2021-budget",
+                    relation="reader",
+                    user="user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                ),
+            )
+            options = {"headers": {"Custom Header": "override value"}}
+            api_response = api_instance.check(
+                body=body,
+                options=options,
+            )
+            self.assertIsInstance(api_response, CheckResponse)
+            self.assertTrue(api_response.allowed)
+            expected_headers = urllib3.response.HTTPHeaderDict(
+                {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                    "User-Agent": "openfga-sdk python/{{packageVersion}}",
+                    "Custom Header": "override value",
+                }
+            )
+            mock_request.assert_called_once_with(
+                "POST",
+                "http://api.fga.example/stores/01H0H015178Y2V4CX10C2KGHF4/check",
+                headers=expected_headers,
+                query_params=[],
+                post_params=[],
+                body={
+                    "tuple_key": {
+                        "object": "document:2021-budget",
+                        "relation": "reader",
+                        "user": "user:81684243-9356-4421-8fbf-a4f8d36aa31b",
+                    }
+                },
+                _preload_content=ANY,
+                _request_timeout=None,
+            )
+
+    @patch.object(rest.RESTClientObject, "request")
     def test_check_custom_header(self, mock_request):
         """Test case for custom header
 


### PR DESCRIPTION
## Summary
- allow custom headers on individual Python client calls via `options["headers"]`
- document `headers` option on client methods
- document change in changelog

## Testing
- `make test-client-python` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e4bfaadcc832291107ea947202073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Support setting custom HTTP headers per request via an options headers parameter.
* Documentation
  * Changelog updated to include the new per-request headers capability.
* Refactor
  * Standardized internal header handling and naming for consistency; no user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->