### PR TITLE
chore(java-sdk): sync back version bumps and dependabot formatting fix

### DIFF
--- a/config/clients/java/template/.github/dependabot.yaml
+++ b/config/clients/java/template/.github/dependabot.yaml
@@ -1,26 +1,30 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 version: 2
+
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "monthly"
     groups:
-     dependencies:
+      dependencies:
         patterns:
           - "*"
+
   - package-ecosystem: "gradle"
     directory: "/example/example1"
     schedule:
       interval: "monthly"
     groups:
-     dependencies:
+      dependencies:
         patterns:
           - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     groups:
-     dependencies:
+      dependencies:
         patterns:
           - "*"

--- a/config/clients/java/template/build.gradle.mustache
+++ b/config/clients/java/template/build.gradle.mustache
@@ -80,7 +80,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jackson_version"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson_version"
     implementation "org.openapitools:jackson-databind-nullable:0.2.6"
-    implementation platform("io.opentelemetry:opentelemetry-bom:1.52.0")
+    implementation platform("io.opentelemetry:opentelemetry-bom:1.53.0")
     implementation "io.opentelemetry:opentelemetry-api"
     {{#hasFormParamsInSpec}}
     implementation "org.apache.httpcomponents:httpmime:$httpmime_version"
@@ -92,7 +92,7 @@ testing {
         test {
             useJUnitJupiter()
             dependencies {
-                implementation 'org.assertj:assertj-core:3.27.3'
+                implementation 'org.assertj:assertj-core:3.27.4'
                 implementation 'org.mockito:mockito-core:5.18.0'
                 implementation 'org.junit.jupiter:junit-jupiter:5.13.4'
                 implementation 'org.wiremock:wiremock:3.13.1'

--- a/config/clients/java/template/example/example1/build.gradle.mustache
+++ b/config/clients/java/template/example/example1/build.gradle.mustache
@@ -1,7 +1,7 @@
 plugins {
     id 'application'
     id 'com.diffplug.spotless' version '7.2.1'
-    id 'org.jetbrains.kotlin.jvm' version '2.2.0'
+    id 'org.jetbrains.kotlin.jvm' version '2.2.10'
 }
 
 application {


### PR DESCRIPTION
sync back:

- https://github.com/openfga/java-sdk/pull/205
- https://github.com/openfga/java-sdk/pull/203
- https://github.com/openfga/java-sdk/pull/202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Corrected Dependabot configuration indentation to ensure dependency groups are recognized correctly.

- **Dependencies**
  - Updated OpenTelemetry BOM to 1.53.0 for the Java client template.
  - Bumped AssertJ Core to 3.27.4 in testing dependencies.
  - Upgraded Kotlin JVM plugin to 2.2.10 in the example project.

- **Build**
  - Refreshed build configurations to align with the latest dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->