### PR TITLE
release(java-sdk): release v0.9.0

### DIFF
--- a/config/clients/java/CHANGELOG.md.mustache
+++ b/config/clients/java/CHANGELOG.md.mustache
@@ -2,29 +2,28 @@
 
 ## [Unreleased](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v{{packageVersion}}...HEAD)
 
+## v0.9.0
+
+### [0.9.0](https://github.com/openfga/java-sdk/compare/v0.8.3...v0.9.0) (2025-08-15)
+
 ### Added
-- feat: RFC 9110 compliant Retry-After header support with exponential backoff and jitter
-- feat: Enhanced retry strategy with delay calculation
-- feat: Retry-After header value exposed in error objects for better observability
-- feat: Input validation for Configuration.minimumRetryDelay() to prevent negative values
-- feat: Default value (100ms) now explicitly set for minimumRetryDelay configuration
+- RFC 9110 compliant `Retry-After` header support with exponential backoff and jitter
+- `Retry-After` header value exposed in error objects for better observability
+- `FgaError` now exposes `Retry-After` header value via `getRetryAfterHeader()` method
 
 ### Changed
+- Enhanced retry strategy with delay calculation
 - **BREAKING**: Maximum allowable retry count is now enforced at 15 (default remains 3)
-- **BREAKING**: FgaError now exposes Retry-After header value via getRetryAfterHeader() method
 - **BREAKING**: Configuration.minimumRetryDelay() now requires non-null values and validates input, throwing IllegalArgumentException for null or negative values
-
-### Technical Details
-- Implements RFC 9110 compliant Retry-After header parsing (supports both integer seconds and HTTP-date formats)
-- Adds exponential backoff with jitter (base delay: 2^retryCount * 100ms, capped at 120 seconds)
-- Validates Retry-After values between 1-1800 seconds (30 minutes maximum)
-- Prioritizes Retry-After header delays over exponential backoff when present
-- Unified retry behavior: All requests retry on 429s and 5xx errors (except 501 Not Implemented)
 
 **Migration Guide**: 
 - Update error handling code if using FgaError properties - new getRetryAfterHeader() method available
 - Note: Maximum allowable retries is now enforced at 15 (validation added to prevent exceeding this limit)
 - **IMPORTANT**: Configuration.minimumRetryDelay() now requires non-null values and validates input - ensure you're not passing null or negative Duration values, as this will now throw IllegalArgumentException. Previously null values were silently accepted and would fall back to default behavior at runtime.
+
+### Fixed
+- Fixed issue where telemetry metrics are not being exported correctly [#590](https://github.com/openfga/sdk-generator/pull/590)
+- Fixed issue with non-transactional write error handling [https://github.com/openfga/sdk-generator/pull/573](https://github.com/openfga/sdk-generator/pull/573) 
 
 ## v0.8.3
 

--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -3,7 +3,7 @@
   "gitRepoId": "java-sdk",
   "artifactId": "openfga-sdk",
   "groupId": "dev.openfga",
-  "packageVersion": "0.8.3",
+  "packageVersion": "0.9.0",
   "apiPackage": "dev.openfga.sdk.api",
   "authPackage": "dev.openfga.sdk.api.auth",
   "clientPackage": "dev.openfga.sdk.api.client",

--- a/config/clients/java/template/README_retries.mustache
+++ b/config/clients/java/template/README_retries.mustache
@@ -34,7 +34,7 @@ public class Example {
                 .storeId(System.getenv("FGA_STORE_ID")) // Not required when calling createStore() or listStores()
                 .authorizationModelId(System.getenv("FGA_MODEL_ID")) // Optional, can be overridden per request
                 .maxRetries(3) // retry up to 3 times on API requests (default: 3, maximum: 15)
-                .minimumRetryDelay(100); // minimum wait time between retries in milliseconds (default: 100ms)
+                .minimumRetryDelay(Duration.ofMillis(100)); // minimum wait time between retries in milliseconds (default: 100ms)
 
         var fgaClient = new OpenFgaClient(config);
         var response = fgaClient.readAuthorizationModels().get();


### PR DESCRIPTION
release v0.9.0

https://github.com/openfga/java-sdk/pull/207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Support for RFC 9110 Retry-After with exponential backoff and jitter.
  * Retry-After value now exposed in error details for better observability.
* Changed
  * Enhanced retry strategy and delay calculation.
  * Minimum retry delay configuration now uses java.time.Duration.
* Bug Fixes
  * Resolved telemetry export issues.
  * Improved handling of non-transactional write errors.
* Documentation
  * Updated changelog and retry README for the new release.
* Chores
  * Version bump to 0.9.0 for the Java client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->