### PR TITLE
Ensure AdditionalHeaders used in all .NET client requests

### DIFF
--- a/config/clients/dotnet/template/Client/Client.mustache
+++ b/config/clients/dotnet/template/Client/Client.mustache
@@ -74,7 +74,7 @@ public class {{appShortName}}Client : IDisposable {
    */
     public async Task<ListStoresResponse> ListStores(IClientListStoresRequest? body, IClientListStoresOptions? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.ListStores(options?.PageSize, options?.ContinuationToken, body?.Name, cancellationToken);
+        await api.ListStores(options?.PageSize, options?.ContinuationToken, body?.Name, options?.AdditionalHeaders, cancellationToken);
 
     /**
    * CreateStore - Initialize a store
@@ -82,19 +82,19 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<CreateStoreResponse> CreateStore(ClientCreateStoreRequest body,
         ClientRequestOptions? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.CreateStore(body, cancellationToken);
+        await api.CreateStore(body, options?.AdditionalHeaders, cancellationToken);
 
     /**
    * GetStore - Get information about the current store
    */
     public async Task<GetStoreResponse> GetStore(IClientRequestOptionsWithStoreId? options = default, CancellationToken cancellationToken = default) =>
-        await api.GetStore(GetStoreId(options), cancellationToken);
+        await api.GetStore(GetStoreId(options), options?.AdditionalHeaders, cancellationToken);
 
     /**
    * DeleteStore - Delete a store
    */
     public async Task DeleteStore(IClientRequestOptionsWithStoreId? options = default, CancellationToken cancellationToken = default) =>
-        await api.DeleteStore(GetStoreId(options), cancellationToken);
+        await api.DeleteStore(GetStoreId(options), options?.AdditionalHeaders, cancellationToken);
 
     /************************
      * Authorization Models *
@@ -106,7 +106,7 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<ReadAuthorizationModelsResponse> ReadAuthorizationModels(
         IClientReadAuthorizationModelsOptions? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.ReadAuthorizationModels(GetStoreId(options), options?.PageSize, options?.ContinuationToken, cancellationToken);
+        await api.ReadAuthorizationModels(GetStoreId(options), options?.PageSize, options?.ContinuationToken, options?.AdditionalHeaders, cancellationToken);
 
     /**
      * WriteAuthorizationModel - Create a new version of the authorization model
@@ -114,7 +114,7 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<WriteAuthorizationModelResponse> WriteAuthorizationModel(ClientWriteAuthorizationModelRequest body,
         IClientRequestOptionsWithStoreId? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.WriteAuthorizationModel(GetStoreId(options), body, cancellationToken);
+        await api.WriteAuthorizationModel(GetStoreId(options), body, options?.AdditionalHeaders, cancellationToken);
 
     /**
      * ReadAuthorizationModel - Read the current authorization model
@@ -122,12 +122,13 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<ReadAuthorizationModelResponse> ReadAuthorizationModel(
         IClientReadAuthorizationModelOptions? options = default,
         CancellationToken cancellationToken = default) {
+        var storeId = GetStoreId(options);
         var authorizationModelId = GetAuthorizationModelId(options);
         if (authorizationModelId == null) {
             throw new FgaRequiredParamError("ClientConfiguration", "AuthorizationModelId");
         }
 
-        return await api.ReadAuthorizationModel(GetStoreId(options), authorizationModelId, cancellationToken);
+        return await api.ReadAuthorizationModel(GetStoreId(options), authorizationModelId, options?.AdditionalHeaders, cancellationToken);
     }
 
     /**
@@ -137,7 +138,13 @@ public class {{appShortName}}Client : IDisposable {
         IClientRequestOptionsWithAuthZModelId? options = default,
         CancellationToken cancellationToken = default) {
         var response =
-            await ReadAuthorizationModels(new ClientReadAuthorizationModelsOptions {StoreId = options?.StoreId, PageSize = 1}, cancellationToken);
+            await ReadAuthorizationModels(
+                new ClientReadAuthorizationModelsOptions {
+                    StoreId = options?.StoreId,
+                    PageSize = 1,
+                    AdditionalHeaders = options?.AdditionalHeaders
+                },
+                cancellationToken);
 
         if (response.AuthorizationModels.Count > 0) {
             return new ReadAuthorizationModelResponse { AuthorizationModel = response.AuthorizationModels?[0] };
@@ -156,7 +163,7 @@ public class {{appShortName}}Client : IDisposable {
     public async Task<ReadChangesResponse> ReadChanges(ClientReadChangesRequest? body = default,
         ClientReadChangesOptions? options = default,
         CancellationToken cancellationToken = default) =>
-        await api.ReadChanges(GetStoreId(options), body?.Type, options?.PageSize, options?.ContinuationToken, body?.StartTime, cancellationToken);
+        await api.ReadChanges(GetStoreId(options), body?.Type, options?.PageSize, options?.ContinuationToken, body?.StartTime, options?.AdditionalHeaders, cancellationToken);
 
     /**
      * Read - Read tuples previously written to the store (does not evaluate)
@@ -171,7 +178,7 @@ public class {{appShortName}}Client : IDisposable {
             GetStoreId(options),
             new ReadRequest {
                 TupleKey = tupleKey, PageSize = options?.PageSize, ContinuationToken = options?.ContinuationToken, Consistency = options?.Consistency,
-            }, cancellationToken);
+            }, options?.AdditionalHeaders, cancellationToken);
     }
 
     /**
@@ -184,6 +191,7 @@ public class {{appShortName}}Client : IDisposable {
             1; // 1 has to be the default otherwise the chunks will be sent in transactions
         var maxParallelReqs =
             options?.Transaction?.MaxParallelRequests ?? DEFAULT_MAX_METHOD_PARALLEL_REQS;
+        var storeId = GetStoreId(options);
         var authorizationModelId = GetAuthorizationModelId(options);
 
         if (options?.Transaction?.Disable != true) {
@@ -197,7 +205,7 @@ public class {{appShortName}}Client : IDisposable {
                 requestBody.Deletes = new WriteRequestDeletes(body.Deletes.ConvertAll(key => key.ToTupleKeyWithoutCondition()));
             }
 
-            await api.Write(GetStoreId(options), requestBody, cancellationToken);
+            await api.Write(storeId, requestBody, options?.AdditionalHeaders, cancellationToken);
             return new ClientWriteResponse {
                 Writes =
                     body.Writes?.ConvertAll(tupleKey =>
@@ -210,7 +218,11 @@ public class {{appShortName}}Client : IDisposable {
             };
         }
 
-        var clientWriteOpts = new ClientWriteOptions() { StoreId = StoreId, AuthorizationModelId = authorizationModelId };
+        var clientWriteOpts = new ClientWriteOptions() {
+            StoreId = storeId,
+            AuthorizationModelId = authorizationModelId,
+            AdditionalHeaders = options?.AdditionalHeaders
+        };
 
         var writeChunks = body.Writes?.Chunk(maxPerChunk).ToList() ?? new List<ClientTupleKey[]>();
         var deleteChunks = body.Deletes?.Chunk(maxPerChunk).ToList() ?? new List<ClientTupleKeyWithoutCondition[]>();
@@ -298,7 +310,7 @@ public class {{appShortName}}Client : IDisposable {
                 Context = body.Context,
                 AuthorizationModelId = GetAuthorizationModelId(options),
                 Consistency = options?.Consistency,
-            }, cancellationToken);
+            }, options?.AdditionalHeaders, cancellationToken);
 
     /**
    * BatchCheck - Run a set of checks (evaluates)
@@ -341,7 +353,7 @@ public class {{appShortName}}Client : IDisposable {
                     },
                 AuthorizationModelId = GetAuthorizationModelId(options),
                 Consistency = options?.Consistency
-            }, cancellationToken);
+            }, options?.AdditionalHeaders, cancellationToken);
 
     /**
      * ListObjects - List the objects of a particular type that the user has a certain relation to (evaluates)
@@ -361,7 +373,7 @@ public class {{appShortName}}Client : IDisposable {
             Context = body.Context,
             AuthorizationModelId = GetAuthorizationModelId(options),
             Consistency = options?.Consistency,
-        }, cancellationToken);
+        }, options?.AdditionalHeaders, cancellationToken);
 
 
     /**
@@ -418,7 +430,7 @@ public class {{appShortName}}Client : IDisposable {
             Context = body.Context,
             AuthorizationModelId = GetAuthorizationModelId(options),
             Consistency = options?.Consistency
-        });
+        }, options?.AdditionalHeaders, cancellationToken);
 
     /**************
      * Assertions *
@@ -434,7 +446,7 @@ public class {{appShortName}}Client : IDisposable {
             throw new FgaRequiredParamError("ClientConfiguration", "AuthorizationModelId");
         }
 
-        return await api.ReadAssertions(GetStoreId(options), authorizationModelId, cancellationToken);
+        return await api.ReadAssertions(GetStoreId(options), authorizationModelId, options?.AdditionalHeaders, cancellationToken);
     }
 
     /**
@@ -463,6 +475,6 @@ public class {{appShortName}}Client : IDisposable {
         }
 
         await api.WriteAssertions(GetStoreId(options), authorizationModelId,
-            new WriteAssertionsRequest {Assertions = assertions}, cancellationToken);
+            new WriteAssertionsRequest {Assertions = assertions}, options?.AdditionalHeaders, cancellationToken);
     }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientBatchCheckOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientBatchCheckOptions.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
 using OpenFga.Sdk.Model;
 
 namespace {{packageName}}.Client.Model;
@@ -25,4 +26,7 @@ public class ClientBatchCheckOptions : IClientBatchCheckOptions {
 
     /// <inheritdoc />
     public ConsistencyPreference? Consistency { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientCheckOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientCheckOptions.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
 using OpenFga.Sdk.Model;
 
 namespace {{packageName}}.Client.Model;
@@ -16,4 +17,7 @@ public class ClientCheckOptions : IClientCheckOptions {
 
     /// <inheritdoc />
     public ConsistencyPreference? Consistency { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientCreateStoreOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientCreateStoreOptions.mustache
@@ -1,7 +1,12 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 public interface IClientCreateStoreOptions : ClientRequestOptions {}
 
-public class ClientCreateStoreOptions: IClientCreateStoreOptions {}
+public class ClientCreateStoreOptions: IClientCreateStoreOptions {
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
+}

--- a/config/clients/dotnet/template/Client/Model/ClientExpandOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientExpandOptions.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
 using OpenFga.Sdk.Model;
 
 namespace {{packageName}}.Client.Model;
@@ -16,4 +17,7 @@ public class ClientExpandOptions : IClientExpandOptions {
 
     /// <inheritdoc />
     public ConsistencyPreference? Consistency { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientListObjectsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListObjectsOptions.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
 using OpenFga.Sdk.Model;
 
 namespace {{packageName}}.Client.Model;
@@ -16,4 +17,7 @@ public class ClientListObjectsOptions : IClientListObjectsOptions {
 
     /// <inheritdoc />
     public ConsistencyPreference? Consistency { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientListRelationsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListRelationsOptions.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
 using OpenFga.Sdk.Model;
 
 namespace {{packageName}}.Client.Model;
@@ -17,5 +18,8 @@ public class ClientListRelationsOptions : IClientBatchCheckOptions {
     public int? MaxParallelRequests { get; set; }
 
     /// <inheritdoc />
-    public ConsistencyPreference? Consistency { get; set; }    
+    public ConsistencyPreference? Consistency { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientListStoresOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListStoresOptions.mustache
@@ -1,5 +1,7 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 /// <summary>
@@ -19,4 +21,7 @@ public class ClientListStoresOptions : IClientListStoresOptions {
 
     /// <inheritdoc />
     public string? ContinuationToken { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientListUsersOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientListUsersOptions.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
 using OpenFga.Sdk.Model;
 
 namespace {{packageName}}.Client.Model;
@@ -16,4 +17,7 @@ public class ClientListUsersOptions : IClientListUsersOptions {
 
     /// <inheritdoc />
     public ConsistencyPreference? Consistency { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientReadAssertionsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadAssertionsOptions.mustache
@@ -1,5 +1,7 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 /// <summary>
@@ -15,4 +17,7 @@ public class ClientReadAssertionsOptions : IClientReadAssertionsOptions {
 
     /// <inheritdoc />
     public string? AuthorizationModelId { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientReadAuthorizaionModelOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadAuthorizaionModelOptions.mustache
@@ -1,5 +1,7 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 /// <summary>
@@ -15,4 +17,7 @@ public class ClientReadAuthorizationModelOptions : IClientReadAuthorizationModel
 
     /// <inheritdoc />
     public string? AuthorizationModelId { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientReadAuthorizaionModelsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadAuthorizaionModelsOptions.mustache
@@ -1,5 +1,7 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 /// <summary>
@@ -18,4 +20,7 @@ public class ClientReadAuthorizationModelsOptions : IClientReadAuthorizationMode
 
     /// <inheritdoc />
     public string? ContinuationToken { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientReadChangesOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadChangesOptions.mustache
@@ -1,5 +1,7 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 /// <summary>
@@ -18,4 +20,7 @@ public class ClientReadChangesOptions : IClientReadChangesOptions {
 
     /// <inheritdoc />
     public string? ContinuationToken { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientReadOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientReadOptions.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
 using OpenFga.Sdk.Model;
 
 namespace {{packageName}}.Client.Model;
@@ -22,5 +23,8 @@ public class ClientReadOptions : IClientReadOptions {
     public string? ContinuationToken { get; set; }
 
     /// <inheritdoc />
-    public ConsistencyPreference? Consistency { get; set; }    
+    public ConsistencyPreference? Consistency { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientRequestOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientRequestOptions.mustache
@@ -1,9 +1,15 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 /// <summary>
 ///     Base Client Request Options
 /// </summary>
 public interface ClientRequestOptions {
+    /// <summary>
+    ///     Additional headers to send with the request.
+    /// </summary>
+    Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientWriteAssertionsOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientWriteAssertionsOptions.mustache
@@ -1,5 +1,7 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 /// <summary>
@@ -16,4 +18,7 @@ public class ClientWriteAssertionsOptions : IClientWriteAssertionsOptions {
 
     /// <inheritdoc />
     public string? AuthorizationModelId { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client/Model/ClientWriteOptions.mustache
+++ b/config/clients/dotnet/template/Client/Model/ClientWriteOptions.mustache
@@ -1,5 +1,7 @@
 {{>partial_header}}
 
+using System.Collections.Generic;
+
 namespace {{packageName}}.Client.Model;
 
 /// <summary>
@@ -54,4 +56,7 @@ public class ClientWriteOptions : IClientWriteOptions {
 
     /// <inheritdoc />
     public ITransactionOpts Transaction { get; set; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
 }

--- a/config/clients/dotnet/template/Client_ApiClient.mustache
+++ b/config/clients/dotnet/template/Client_ApiClient.mustache
@@ -5,6 +5,7 @@ using {{packageName}}.Configuration;
 using {{packageName}}.Exceptions;
 using {{packageName}}.Telemetry;
 using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace {{packageName}}.ApiClient;
 
@@ -61,9 +62,9 @@ public class ApiClient : IDisposable {
     /// <typeparam name="T">Response Type</typeparam>
     /// <returns></returns>
     /// <exception cref="FgaApiAuthenticationError"></exception>
-    public async Task<TRes> SendRequestAsync<TReq, TRes>(RequestBuilder<TReq> requestBuilder, string apiName,
+    public async Task<TRes> SendRequestAsync<TReq, TRes>(RequestBuilder<TReq> requestBuilder, IDictionary<string, string>? headers, string apiName,
         CancellationToken cancellationToken = default) {
-        IDictionary<string, string> additionalHeaders = new Dictionary<string, string>();
+        IDictionary<string, string> additionalHeaders = headers != null ? new Dictionary<string, string>(headers) : new Dictionary<string, string>();
 
         var sw = Stopwatch.StartNew();
         if (_oauth2Client != null) {
@@ -98,9 +99,9 @@ public class ApiClient : IDisposable {
     /// <param name="apiName"></param>
     /// <param name="cancellationToken"></param>
     /// <exception cref="FgaApiAuthenticationError"></exception>
-    public async Task SendRequestAsync<TReq>(RequestBuilder<TReq> requestBuilder, string apiName,
+    public async Task SendRequestAsync<TReq>(RequestBuilder<TReq> requestBuilder, IDictionary<string, string>? headers, string apiName,
         CancellationToken cancellationToken = default) {
-        IDictionary<string, string> additionalHeaders = new Dictionary<string, string>();
+        IDictionary<string, string> additionalHeaders = headers != null ? new Dictionary<string, string>(headers) : new Dictionary<string, string>();
 
         var sw = Stopwatch.StartNew();
         if (_oauth2Client != null) {

--- a/config/clients/dotnet/template/OpenFgaClientTests.mustache
+++ b/config/clients/dotnet/template/OpenFgaClientTests.mustache
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 
 using Moq;
 using Moq.Protected;
@@ -593,6 +594,66 @@ public class {{appShortName}}ClientTests {
         Assert.Equal(authorizationModelId, response.AuthorizationModel.Id);
     }
 
+    /// <summary>
+    /// Test ReadLatestAuthorizationModel forwards AdditionalHeaders
+    /// </summary>
+    [Fact]
+    public async Task ReadLatestAuthorizationModelHeadersTest() {
+        const string authorizationModelId = "01FMJA27YCE3QAT8RDS9VZFN0T";
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri ==
+                    new Uri(
+                        $"{_config.BasePath}/stores/{_config.StoreId}/authorization-models?page_size=1&") &&
+                    req.Method == HttpMethod.Get &&
+                    req.Headers.Contains("X-Correlation-ID") &&
+                    req.Headers.GetValues("X-Correlation-ID").First() == "123" &&
+                    req.Headers.Contains("Trace-ID") &&
+                    req.Headers.GetValues("Trace-ID").First() == "abc"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage() {
+                StatusCode = HttpStatusCode.OK,
+                Content = Utils.CreateJsonStringContent(new ReadAuthorizationModelsResponse() {
+                    AuthorizationModels = new List<AuthorizationModel>() {new(id: authorizationModelId,
+                        typeDefinitions: new List<TypeDefinition>(), schemaVersion: "1.1")}
+                }),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var fgaClient = new {{appShortName}}Client(_config, httpClient);
+
+        var options = new ClientCheckOptions {
+            AdditionalHeaders = new Dictionary<string, string> {
+                ["X-Correlation-ID"] = "123",
+                ["Trace-ID"] = "abc"
+            }
+        };
+
+        var response = await fgaClient.ReadLatestAuthorizationModel(options);
+
+        mockHandler.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri ==
+                new Uri($"{_config.BasePath}/stores/{_config.StoreId}/authorization-models?page_size=1&") &&
+                req.Method == HttpMethod.Get &&
+                req.Headers.Contains("X-Correlation-ID") &&
+                req.Headers.GetValues("X-Correlation-ID").First() == "123" &&
+                req.Headers.Contains("Trace-ID") &&
+                req.Headers.GetValues("Trace-ID").First() == "abc"),
+            ItExpr.IsAny<CancellationToken>()
+        );
+
+        Assert.IsType<ReadAuthorizationModelResponse>(response);
+        Assert.Equal(authorizationModelId, response.AuthorizationModel.Id);
+    }
+
     /***********************
      * Relationship Tuples *
      ***********************/
@@ -914,7 +975,11 @@ public class {{appShortName}}ClientTests {
                 "SendAsync",
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/write") &&
-                    req.Method == HttpMethod.Post),
+                    req.Method == HttpMethod.Post &&
+                    req.Headers.Contains("X-Correlation-ID") &&
+                    req.Headers.GetValues("X-Correlation-ID").First() == "123" &&
+                    req.Headers.Contains("Trace-ID") &&
+                    req.Headers.GetValues("Trace-ID").First() == "abc"),
                 ItExpr.IsAny<CancellationToken>()
             )
             .ReturnsAsync(new HttpResponseMessage() {
@@ -960,6 +1025,10 @@ public class {{appShortName}}ClientTests {
                 Disable = true,
                 MaxParallelRequests = 1,
                 MaxPerChunk = 1,
+            },
+            AdditionalHeaders = new Dictionary<string, string> {
+                ["X-Correlation-ID"] = "123",
+                ["Trace-ID"] = "abc"
             }
         };
         var response = await fgaClient.Write(body, options);
@@ -969,7 +1038,11 @@ public class {{appShortName}}ClientTests {
             Times.Exactly(3),
             ItExpr.Is<HttpRequestMessage>(req =>
                 req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/write") &&
-                req.Method == HttpMethod.Post),
+                req.Method == HttpMethod.Post &&
+                req.Headers.Contains("X-Correlation-ID") &&
+                req.Headers.GetValues("X-Correlation-ID").First() == "123" &&
+                req.Headers.Contains("Trace-ID") &&
+                req.Headers.GetValues("Trace-ID").First() == "abc"),
             ItExpr.IsAny<CancellationToken>()
         );
         Assert.IsType<ClientWriteResponse>(response);
@@ -1017,7 +1090,12 @@ public class {{appShortName}}ClientTests {
             },
             Context = new { ViewCount = 100 }
         };
-        var options = new ClientCheckOptions {};
+        var options = new ClientCheckOptions {
+            AdditionalHeaders = new Dictionary<string, string> {
+                ["X-Correlation-ID"] = "123",
+                ["Trace-ID"] = "abc"
+            }
+        };
         var response = await fgaClient.Check(body, options);
 
         mockHandler.Protected().Verify(
@@ -1025,7 +1103,11 @@ public class {{appShortName}}ClientTests {
             Times.Exactly(1),
             ItExpr.Is<HttpRequestMessage>(req =>
                 req.RequestUri == new Uri($"{_config.BasePath}/stores/{_config.StoreId}/check") &&
-                req.Method == HttpMethod.Post),
+                req.Method == HttpMethod.Post &&
+                req.Headers.Contains("X-Correlation-ID") &&
+                req.Headers.GetValues("X-Correlation-ID").First() == "123" &&
+                req.Headers.Contains("Trace-ID") &&
+                req.Headers.GetValues("Trace-ID").First() == "abc"),
             ItExpr.IsAny<CancellationToken>()
         );
 

--- a/config/clients/dotnet/template/README_calling_api.mustache
+++ b/config/clients/dotnet/template/README_calling_api.mustache
@@ -330,6 +330,10 @@ Check if a user has a particular relation with an object.
 var options = new ClientCheckOptions {
     // You can rely on the model id set in the configuration or override it for this specific request
     AuthorizationModelId = "01GXSA8YR785C4FYS3C0RTG7B1",
+    AdditionalHeaders = new Dictionary<string, string> {
+        ["X-Correlation-ID"] = "123",
+        ["Trace-ID"] = "abc"
+    }
 };
 var body = new ClientCheckRequest {
     User = "user:81684243-9356-4421-8fbf-a4f8d36aa31b",

--- a/config/clients/dotnet/template/api.mustache
+++ b/config/clients/dotnet/template/api.mustache
@@ -3,6 +3,7 @@
 using {{packageName}}.ApiClient;
 using {{packageName}}.Exceptions;
 using {{packageName}}.{{modelPackage}};
+using System.Collections.Generic;
 
 namespace {{packageName}}.{{apiPackage}};
 
@@ -33,12 +34,13 @@ public class {{classname}} : IDisposable {
     {{#allParams}}
     /// <param name="{{paramName}}">{{description}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}</param>
     {{/allParams}}
+    /// <param name="additionalHeaders">Additional headers to include in the request.</param>
     /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
     /// <returns>Task of {{returnType}}{{^returnType}}void{{/returnType}}</returns>
     {{#isDeprecated}}
     [Obsolete]
     {{/isDeprecated}}
-    {{#returnType}}public async Task<{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}CancellationToken cancellationToken = default) {
+    {{#returnType}}public async Task<{{{.}}}>{{/returnType}}{{^returnType}}public async Task{{/returnType}} {{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^required}}{{#optionalMethodArgument}} = default({{{dataType}}}){{/optionalMethodArgument}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}{{#allParams.0}}, {{/allParams.0}}IDictionary<string, string>? additionalHeaders = null, CancellationToken cancellationToken = default) {
         var pathParams = new Dictionary<string, string> {};
         {{#pathParams.0}}
         if (string.IsNullOrWhiteSpace(storeId)) {
@@ -82,7 +84,7 @@ public class {{classname}} : IDisposable {
         };
 
         {{#returnType}}return {{/returnType}}await _apiClient.SendRequestAsync{{#returnType}}<{{#bodyParam}}{{{dataType}}}{{/bodyParam}}{{^bodyParam}}Any{{/bodyParam}}, {{{.}}}>{{/returnType}}(requestBuilder,
-            "{{operationId}}", cancellationToken);
+            additionalHeaders, "{{operationId}}", cancellationToken);
     }
 
     {{/operation}}


### PR DESCRIPTION
## Summary
- forward options.AdditionalHeaders when ReadLatestAuthorizationModel calls ReadAuthorizationModels
- propagate AdditionalHeaders to recursive Write calls in non-transaction mode
- test that chunked Write and ReadLatestAuthorizationModel preserve caller headers

## Testing
- `make test-client-dotnet` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa592cf3c8322b9199b3278cdc560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * .NET client now supports per-request custom HTTP headers across all operations (read, write, list, expand, check, batch check). Headers propagate through nested operations and parallelized writes, enabling consistent context (e.g., correlation IDs) per call. Backward compatibility and cancellation token behavior are preserved.

* **Documentation**
  * Added examples showing how to supply AdditionalHeaders in request options.

* **Tests**
  * Expanded test coverage to verify header forwarding across key operations, including latest authorization model retrieval and write/check paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->