### PR TITLE
fix(python): reuse ssl context in the python sync client

### DIFF
--- a/config/clients/python/template/src/sync/rest.py.mustache
+++ b/config/clients/python/template/src/sync/rest.py.mustache
@@ -143,10 +143,19 @@ class RESTClientObject:
         :param pools_size: The number of connection pools to use.
         :param maxsize: The maximum number of connections per pool.
         """
-        if hasattr(configuration, "verify_ssl") and configuration.verify_ssl:
-            cert_reqs = ssl.CERT_REQUIRED
-        else:
-            cert_reqs = ssl.CERT_NONE
+
+        # Reuse SSL context to mitigate OpenSSL 3.0+ performance issues
+        # See: https://github.com/openssl/openssl/issues/17064
+        ssl_context = ssl.create_default_context(cafile=configuration.ssl_ca_cert)
+
+        if configuration.cert_file:
+            ssl_context.load_cert_chain(
+                configuration.cert_file, keyfile=configuration.key_file
+            )
+
+        if not configuration.verify_ssl:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
 
         addition_pool_args = {}
 
@@ -181,10 +190,10 @@ class RESTClientObject:
                 urllib3.ProxyManager(
                     num_pools=pools_size,
                     maxsize=maxsize,
-                    cert_reqs=cert_reqs,
                     ca_certs=configuration.ssl_ca_cert,
                     cert_file=configuration.cert_file,
                     key_file=configuration.key_file,
+                    ssl_context=ssl_context,
                     proxy_url=configuration.proxy,
                     proxy_headers=configuration.proxy_headers,
                     **addition_pool_args,
@@ -196,10 +205,10 @@ class RESTClientObject:
         self.pool_manager = urllib3.PoolManager(
             num_pools=pools_size,
             maxsize=maxsize,
-            cert_reqs=cert_reqs,
             ca_certs=configuration.ssl_ca_cert,
             cert_file=configuration.cert_file,
             key_file=configuration.key_file,
+            ssl_context=ssl_context,
             **addition_pool_args,
         )
 

--- a/config/clients/python/template/src/sync/rest.py.mustache
+++ b/config/clients/python/template/src/sync/rest.py.mustache
@@ -190,9 +190,6 @@ class RESTClientObject:
                 urllib3.ProxyManager(
                     num_pools=pools_size,
                     maxsize=maxsize,
-                    ca_certs=configuration.ssl_ca_cert,
-                    cert_file=configuration.cert_file,
-                    key_file=configuration.key_file,
                     ssl_context=ssl_context,
                     proxy_url=configuration.proxy,
                     proxy_headers=configuration.proxy_headers,
@@ -205,9 +202,6 @@ class RESTClientObject:
         self.pool_manager = urllib3.PoolManager(
             num_pools=pools_size,
             maxsize=maxsize,
-            ca_certs=configuration.ssl_ca_cert,
-            cert_file=configuration.cert_file,
-            key_file=configuration.key_file,
             ssl_context=ssl_context,
             **addition_pool_args,
         )


### PR DESCRIPTION
## Description
This brings sync client ssl context handling in line with the async client. Importantly, [openssl has a pretty significant performance regression](https://github.com/openssl/openssl/issues/17064) in creating ssl contexts v3.0+ that can be mitigated by paying the context creation tax once, instead of for every request.

#### What problem is being solved?
Performance penalty observed when we upgraded from debian bullseye (openssl 1.1.1w) to debian bookworm (openssl 3.0.17). We saw a roughly 40ms performance penalty across our use of the sync client.

#### How is it being solved?
We remove an expensive call (ssl context creation) from each request, and instead do it once, upon client instantiation.  This matches the behavior in the aio client.

#### What changes are made to solve it?
See above

### Testing
TLDR: On the worst openssl version I tested, we saw a 40ms reduction in p50 FGA call time. This accounts for 75% of the total call time.  4x performance improvement!
```
p50 before: 53.9ms
p50 after:  13.5ms
```

I didn't write any tests on the FGA side.  However I did do benchmarking using the following script.

<details><summary>fgabench.py</summary>

```python
import os
import ssl
import time
import statistics
import sys

import openfga_sdk
from openfga_sdk.credentials import Credentials, CredentialConfiguration
from openfga_sdk.sync import OpenFgaClient as OpenFgaClient
from openfga_sdk.client.models import ClientCheckRequest


def benchmark(client, num_requests: int = 10) -> None:
    times: List[float] = []
    for i in range(1, num_requests + 1):
        options = {}
        body = ClientCheckRequest(
            user="account:1#admin",
            relation="editor",
            object="folder:{n}",
        )
        start = time.perf_counter()
        resp = client.check(body, options)
        end = time.perf_counter()
        times.append(end - start)
    return times


def main():
    secret = os.environ['OPENFGA_SECRET']
    credentials = Credentials(
        method='client_credentials',
        configuration=CredentialConfiguration(
            api_issuer= "<redacted>",
            api_audience= "<redacted>",
            client_id= "<redacted>",
            client_secret=secret
        )
    )
    configuration = openfga_sdk.ClientConfiguration(
        api_url = "<redacted>",
        store_id = "<redacted>",
        credentials = credentials,
    )
    if len(sys.argv) > 1:
        num_requests = sys.argv[1]
    else:
        num_requests = 100
    with OpenFgaClient(configuration) as client:
        times = benchmark(client, num_requests)

    print(f"OpenSSL: {ssl.OPENSSL_VERSION}")
    print(f"avg:     {statistics.mean(times) * 1000:>6.1f}ms")
    print(f"stddev:  {statistics.stdev(times) * 1000:>6.1f}ms")
    print(f"p0:      {min(times)* 1000:>6.1f}ms")
    print(f"p50:     {statistics.median(times) * 1000:>6.1f}ms")
    print(f"p90:     {statistics.quantiles(times, n=10)[8] * 1000:>6.1f}ms")
    print(f"p100:    {max(times) * 1000:>6.1f}ms")
    print(f"count:   {num_requests:>4}")


if __name__ == "__main__":
    main()
```

</details>


Here are the results tested on an amd64 t2.medium AWS instance in us-west-2.

* `openfga-sdk` is the performance as of v0.9.4
* `sdk-patched` is v0.9.4 with a monkey patched `openfga_sdk.sync.rest.RESTClientObject.__init__` to use my new version
* `urllib` is the default `urllib.request.urlopen("https://api.us1.fga.dev/")` behavior. Included as a reference point.
* `urllib+ctx` is `urllib` with a reused ssl-context.  Same fix, but without any of the potential complications of FGA client or server logic.

```console
$ ./fgabench.sh
python:3.10.18-slim-bullseye
OpenSSL 1.1.1w  11 Sep 2023
metric  openfga-sdk sdk-patched      urllib  urllib+ctx
avg:         16.3ms      14.7ms      57.4ms       7.6ms
stddev:      26.2ms      21.3ms     501.2ms       4.3ms
p0:          10.2ms       9.8ms       5.6ms       5.1ms
p50:         12.7ms      12.4ms       7.3ms       7.1ms
p90:         15.2ms      13.8ms       8.2ms       9.1ms
p100:       265.1ms     224.3ms    5019.5ms      47.0ms
count:      100         100         100         100
python:3.10.18-slim-bookworm
OpenSSL 3.0.17 1 Jul 2025
metric  openfga-sdk sdk-patched      urllib  urllib+ctx
avg:         57.0ms      15.2ms      47.7ms       7.3ms
stddev:      29.3ms      17.6ms       1.3ms       1.0ms
p0:          51.6ms      10.9ms      45.6ms       5.6ms
p50:         53.9ms      13.5ms      47.6ms       7.6ms
p90:         55.8ms      15.0ms      48.8ms       8.4ms
p100:       347.1ms     189.0ms      56.6ms      10.2ms
count:      100         100         100         100
python:3.10.18-slim-trixie
OpenSSL 3.5.1 1 Jul 2025
metric  openfga-sdk sdk-patched      urllib  urllib+ctx
avg:         30.8ms      15.5ms      18.8ms       7.0ms
stddev:      22.9ms      20.7ms       3.7ms       0.9ms
p0:          22.9ms      10.5ms      16.4ms       5.3ms
p50:         26.6ms      13.3ms      18.7ms       7.3ms
p90:         33.7ms      15.3ms      19.5ms       8.1ms
p100:       243.3ms     219.0ms      52.3ms       9.3ms
count:      100         100         100         100
```

## References

See https://github.com/openssl/openssl/issues/17064 for a comprehensive discussion of the openssl performance issues.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) N/A
- [x] The correct base branch is being used, if not `main`
- [x] I have performed tests to validate that the change in functionality is working as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Python client TLS handling to use a reusable SSL context for both direct and proxy connections, improving reliability without changing the public API.
* **Bug Fixes**
  * Mitigated performance issues seen with OpenSSL 3.x by reusing the TLS context.
  * Preserved expected behavior when SSL verification is disabled (hostname and certificate checks are turned off).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->