### PR TITLE
Update .NET client WriteAuthorizationModel signature

### DIFF
--- a/config/clients/dotnet/template/Client/Client.mustache
+++ b/config/clients/dotnet/template/Client/Client.mustache
@@ -111,7 +111,7 @@ public class {{appShortName}}Client : IDisposable {
     /**
      * WriteAuthorizationModel - Create a new version of the authorization model
      */
-    public async Task<WriteAuthorizationModelResponse> WriteAuthorizationModel(ClientWriteAuthorizationModelRequest body,
+    public async Task<WriteAuthorizationModelResponse> WriteAuthorizationModel(WriteAuthorizationModelRequest body,
         IClientRequestOptionsWithStoreId? options = default,
         CancellationToken cancellationToken = default) =>
         await api.WriteAuthorizationModel(GetStoreId(options), body, cancellationToken);

--- a/config/clients/dotnet/template/README_calling_api.mustache
+++ b/config/clients/dotnet/template/README_calling_api.mustache
@@ -134,6 +134,15 @@ var response = await fgaClient.WriteAuthorizationModel(body);
 // response.AuthorizationModelId = "01GXSA8YR785C4FYS3C0RTG7B1"
 ```
 
+If you already have an authorization model represented as JSON (for example, stored on disk), you can deserialize it using the
+`WriteAuthorizationModelRequest.FromJson` helper and pass it directly to `WriteAuthorizationModel`:
+
+```csharp
+var modelJson = await File.ReadAllTextAsync("model.json");
+var request = WriteAuthorizationModelRequest.FromJson(modelJson);
+var response = await fgaClient.WriteAuthorizationModel(request);
+```
+
 #### Read a Single Authorization Model
 
 Read a particular authorization model.


### PR DESCRIPTION
## Summary
- allow the generated .NET client's `WriteAuthorizationModel` helper to accept the base `WriteAuthorizationModelRequest`
- document how to submit authorization models read from JSON by using `WriteAuthorizationModelRequest.FromJson`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de6d7d64cc8323b2a35248d27fa85c