### PR TITLE
chore(js-sdk): Add unit tests and docs for custom headers

### DIFF
--- a/config/clients/js/config.overrides.json
+++ b/config/clients/js/config.overrides.json
@@ -26,6 +26,10 @@
       "destinationFilename": "tests/validation.test.ts",
       "templateType": "SupportingFiles"
     },
+    "tests/headers.test.ts.mustache": {
+      "destinationFilename": "tests/headers.test.ts",
+      "templateType": "SupportingFiles"
+    },
     "tests/helpers/index.ts.mustache": {
       "destinationFilename": "tests/helpers/index.ts",
       "templateType": "SupportingFiles"

--- a/config/clients/js/template/README_initializing.mustache
+++ b/config/clients/js/template/README_initializing.mustache
@@ -52,3 +52,43 @@ const fgaClient = new {{appShortName}}Client({
   }
 });
 ```
+
+### Custom Headers
+
+#### Default Headers
+
+You can set default headers that will be sent with every request during client initialization:
+
+```javascript
+const { OpenFgaClient } = require('@openfga/sdk'); // OR import { OpenFgaClient } from '@openfga/sdk';
+
+const fgaClient = new OpenFgaClient({
+  apiUrl: process.env.FGA_API_URL,
+  storeId: process.env.FGA_STORE_ID,
+  authorizationModelId: process.env.FGA_MODEL_ID,
+  baseOptions: {
+    headers: {
+      "X-Custom-Header": "default-value",
+      "X-Request-Source": "my-app",
+    }
+  }
+});
+```
+
+#### Per-Request Headers
+
+You can also send custom headers on a per-request basis by using the `options` parameter. Custom headers will override any default headers set in the client configuration.
+
+```javascript
+// Add custom headers to a specific request
+const result = await fgaClient.check({
+  user: "user:anne",
+  relation: "viewer",
+  object: "document:roadmap",
+}, {
+  headers: {
+    "X-Request-ID": "123e4567-e89b-12d3-a456-426614174000",
+    "X-Custom-Header": "custom-value", // these override any default headers set
+  }
+});
+```

--- a/config/clients/js/template/tests/headers.test.ts.mustache
+++ b/config/clients/js/template/tests/headers.test.ts.mustache
@@ -1,0 +1,733 @@
+{{>partial_header}}
+
+import * as nock from "nock";
+import { OpenFgaClient, UserClientConfigurationParams } from "../index";
+import { baseConfig } from "./helpers/default-config";
+import { CredentialsMethod } from "../credentials";
+
+nock.disableNetConnect();
+
+describe("Header Functionality Tests", () => {
+  const testConfig: UserClientConfigurationParams = {
+    ...baseConfig,
+    credentials: { method: CredentialsMethod.None }
+  };
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("Default headers from client configuration", () => {
+    it("should send default headers from baseOptions on all requests", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Default-Header": "default-value",
+            "X-Client-ID": "test-client-123",
+            "X-API-Version": "v1.0"
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // Verify all default headers are present
+          expect(this.req.headers["x-default-header"]).toBe("default-value");
+          expect(this.req.headers["x-client-id"]).toBe("test-client-123");
+          expect(this.req.headers["x-api-version"]).toBe("v1.0");
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should send default headers on multiple different API calls", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Persistent-Header": "should-appear-everywhere"
+          }
+        }
+      });
+
+      // Test check endpoint
+      const checkScope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          expect(this.req.headers["x-persistent-header"]).toBe("should-appear-everywhere");
+          return [200, { allowed: true }];
+        });
+
+      // Test read endpoint
+      const readScope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/read`)
+        .reply(function() {
+          expect(this.req.headers["x-persistent-header"]).toBe("should-appear-everywhere");
+          return [200, { tuples: [] }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader", 
+        object: "document:test"
+      });
+
+      await fgaClient.read({});
+
+      expect(checkScope.isDone()).toBe(true);
+      expect(readScope.isDone()).toBe(true);
+    });
+  });
+
+  describe("Per-request headers", () => {
+    it("should send per-request headers when specified", async () => {
+      const fgaClient = new OpenFgaClient(testConfig);
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          expect(this.req.headers["x-request-header"]).toBe("request-value");
+          expect(this.req.headers["x-correlation-id"]).toBe("abc-123-def");
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {
+          "X-Request-Header": "request-value",
+          "X-Correlation-ID": "abc-123-def"
+        }
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should only send per-request headers on the specific request", async () => {
+      const fgaClient = new OpenFgaClient(testConfig);
+
+      // First request with headers
+      const firstScope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          expect(this.req.headers["x-first-request"]).toBe("first-value");
+          expect(this.req.headers["x-second-request"]).toBeUndefined();
+          return [200, { allowed: true }];
+        });
+
+      // Second request with different headers
+      const secondScope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          expect(this.req.headers["x-second-request"]).toBe("second-value");
+          expect(this.req.headers["x-first-request"]).toBeUndefined();
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {
+          "X-First-Request": "first-value"
+        }
+      });
+
+      await fgaClient.check({
+        user: "user:different",
+        relation: "writer",
+        object: "document:other"
+      }, {
+        headers: {
+          "X-Second-Request": "second-value"
+        }
+      });
+
+      expect(firstScope.isDone()).toBe(true);
+      expect(secondScope.isDone()).toBe(true);
+    });
+  });
+
+  describe("Default + per-request header combination", () => {
+    it("should send both default headers and per-request headers", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Default-Header": "default-value",
+            "X-Client-Name": "test-client"
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // Verify default headers are present
+          expect(this.req.headers["x-default-header"]).toBe("default-value");
+          expect(this.req.headers["x-client-name"]).toBe("test-client");
+          
+          // Verify per-request headers are present
+          expect(this.req.headers["x-request-id"]).toBe("req-123");
+          expect(this.req.headers["x-user-context"]).toBe("test-user");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {
+          "X-Request-ID": "req-123",
+          "X-User-Context": "test-user"
+        }
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should merge headers from multiple sources correctly", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Source": "default",
+            "X-Default-Only": "only-in-default",
+            "X-Version": "1.0"
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          const headers = this.req.headers;
+          
+          // Default headers should be present
+          expect(headers["x-source"]).toBe("default");
+          expect(headers["x-default-only"]).toBe("only-in-default");
+          expect(headers["x-version"]).toBe("1.0");
+          
+          // Per-request headers should be present
+          expect(headers["x-request-only"]).toBe("only-in-request");
+          expect(headers["x-timestamp"]).toBe("2023-10-01");
+          
+          // SDK headers should be present
+          expect(headers["content-type"]).toBe("application/json");
+          expect(headers["user-agent"]).toMatch(/openfga-sdk/);
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {
+          "X-Request-Only": "only-in-request",
+          "X-Timestamp": "2023-10-01"
+        }
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe("Header precedence and override behavior", () => {
+    it("should allow per-request headers to override default headers", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Environment": "default-env",
+            "X-Priority": "low",
+            "X-Shared-Header": "from-default"
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // Per-request headers should override default headers
+          expect(this.req.headers["x-environment"]).toBe("production");
+          expect(this.req.headers["x-priority"]).toBe("high");
+          expect(this.req.headers["x-shared-header"]).toBe("from-request");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {
+          "X-Environment": "production",
+          "X-Priority": "high",
+          "X-Shared-Header": "from-request"
+        }
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should preserve non-overridden default headers", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Keep-Default": "keep-this",
+            "X-Override-This": "original-value",
+            "X-Also-Keep": "also-keep-this"
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // Non-overridden defaults should remain
+          expect(this.req.headers["x-keep-default"]).toBe("keep-this");
+          expect(this.req.headers["x-also-keep"]).toBe("also-keep-this");
+          
+          // Overridden header should have new value
+          expect(this.req.headers["x-override-this"]).toBe("new-value");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {
+          "X-Override-This": "new-value"
+        }
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should handle case-insensitive header overrides correctly", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Test-Header": "default-value"
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // HTTP headers are case-insensitive, so request header should override default
+          const testHeaderValue = this.req.headers["x-test-header"];
+          
+          // Per-request should win
+          expect(testHeaderValue).toBe("request-value");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {
+          "x-test-header": "request-value"  // Different case
+        }
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe("Content-Type header protection behavior", () => {
+    it("does not honor Content-Type header from baseOptions override", async () => {
+      // The SDK protects Content-Type
+      // User attempts to set Content-Type via baseOptions are ignored
+      
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "Content-Type": "text/plain",           // SDK ignores this
+            "X-Custom-Header": "should-work"        // Custom headers work fine
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          const headers = this.req.headers;
+          
+          // SDK enforces Content-Type for JSON APIs
+          expect(headers["content-type"]).toBe("application/json");
+          
+          // Custom headers are preserved
+          expect(headers["x-custom-header"]).toBe("should-work");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("allows Content-Type override via per-request headers", async () => {
+      // At the request level, user headers can override SDK headers
+      
+      const fgaClient = new OpenFgaClient(testConfig);
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // Per-request headers override SDK headers (including Content-Type)
+          expect(this.req.headers["content-type"]).toBe("application/xml");
+          expect(this.req.headers["x-custom-request"]).toBe("request-value");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {
+          "Content-Type": "application/xml",        // This overrides SDK's Content-Type
+          "X-Custom-Request": "request-value"       // Custom headers also work
+        }
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should set Content-Type to application/json by default", async () => {
+      // When no Content-Type is specified, SDK sets it to application/json
+      
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-API-Version": "v1",              // Custom header without Content-Type
+            "Authorization": "Bearer token"      // Another custom header
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          const headers = this.req.headers;
+          
+          // SDK automatically sets Content-Type for JSON APIs
+          expect(headers["content-type"]).toBe("application/json");
+          
+          // Custom headers are preserved
+          expect(headers["x-api-version"]).toBe("v1");
+          expect(headers["authorization"]).toBe("Bearer token");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should demonstrate Content-Type protection is only critical header", async () => {
+      // Only Content-Type receives special protection - other SDK headers can be overridden
+      
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "Content-Type": "text/plain",       // SDK ignores this
+            "User-Agent": "custom-agent",       // This might work (not protected)
+            "Accept": "text/html",              // This might work (not protected)
+            "X-Custom": "definitely-works"      // Custom headers always work
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          const headers = this.req.headers;
+          
+          // Only Content-Type is strictly protected
+          expect(headers["content-type"]).toBe("application/json");
+          
+          // Other headers may or may not be overrideable (depends on axios behavior)
+          // The key point is that only Content-Type has explicit SDK protection
+          
+          // Custom headers definitely work
+          expect(headers["x-custom"]).toBe("definitely-works");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe("Edge cases and special scenarios", () => {
+    it("should handle empty baseOptions headers", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {}
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // Should still have SDK headers
+          expect(this.req.headers["content-type"]).toBe("application/json");
+          expect(this.req.headers["user-agent"]).toMatch(/openfga-sdk/);
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should handle undefined baseOptions", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig
+        // No baseOptions specified
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // Should still have SDK headers
+          expect(this.req.headers["content-type"]).toBe("application/json");
+          expect(this.req.headers["user-agent"]).toMatch(/openfga-sdk/);
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should handle empty per-request headers", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Default": "default-value"
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          // Default headers should still be present
+          expect(this.req.headers["x-default"]).toBe("default-value");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: {}  // Empty headers object
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should handle special header values", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Empty-String": "",
+            "X-Number-Value": "123",
+            "X-Boolean-Value": "true",
+            "X-Special-Chars": "test@#$%^&*()_+-={}[]|\\:;\"'<>,.?/"
+          }
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          const headers = this.req.headers;
+          
+          expect(headers["x-empty-string"]).toBe("");
+          expect(headers["x-number-value"]).toBe("123");
+          expect(headers["x-boolean-value"]).toBe("true");
+          expect(headers["x-special-chars"]).toBe("test@#$%^&*()_+-={}[]|\\:;\"'<>,.?/");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it("should handle large number of headers", async () => {
+      const defaultHeaders: Record<string, string> = {};
+      const requestHeaders: Record<string, string> = {};
+      
+      // Create many default headers
+      for (let i = 1; i <= 50; i++) {
+        defaultHeaders[`X-Default-${i}`] = `default-value-${i}`;
+      }
+      
+      // Create many request headers
+      for (let i = 1; i <= 50; i++) {
+        requestHeaders[`X-Request-${i}`] = `request-value-${i}`;
+      }
+
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: defaultHeaders
+        }
+      });
+
+      const scope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          const headers = this.req.headers;
+          
+          // Verify a sample of default headers
+          expect(headers["x-default-1"]).toBe("default-value-1");
+          expect(headers["x-default-25"]).toBe("default-value-25");
+          expect(headers["x-default-50"]).toBe("default-value-50");
+          
+          // Verify a sample of request headers
+          expect(headers["x-request-1"]).toBe("request-value-1");
+          expect(headers["x-request-25"]).toBe("request-value-25");
+          expect(headers["x-request-50"]).toBe("request-value-50");
+          
+          return [200, { allowed: true }];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      }, {
+        headers: requestHeaders
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe("Header behavior across different API methods", () => {
+    it("should send headers consistently across different API endpoints", async () => {
+      const fgaClient = new OpenFgaClient({
+        ...testConfig,
+        baseOptions: {
+          headers: {
+            "X-Consistent-Header": "always-present"
+          }
+        }
+      });
+
+      // Test multiple endpoints
+      const checkScope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/check`)
+        .reply(function() {
+          expect(this.req.headers["x-consistent-header"]).toBe("always-present");
+          return [200, { allowed: true }];
+        });
+
+      const readScope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/read`)
+        .reply(function() {
+          expect(this.req.headers["x-consistent-header"]).toBe("always-present");
+          return [200, { tuples: [] }];
+        });
+
+      const writeScope = nock(testConfig.apiUrl!)
+        .post(`/stores/${testConfig.storeId}/write`)
+        .reply(function() {
+          expect(this.req.headers["x-consistent-header"]).toBe("always-present");
+          return [200, {}];
+        });
+
+      await fgaClient.check({
+        user: "user:test",
+        relation: "reader",
+        object: "document:test"
+      });
+
+      await fgaClient.read({});
+
+      await fgaClient.write({
+        writes: [{
+          user: "user:test",
+          relation: "reader", 
+          object: "document:test"
+        }]
+      });
+
+      expect(checkScope.isDone()).toBe(true);
+      expect(readScope.isDone()).toBe(true);
+      expect(writeScope.isDone()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Add unit tests and docs for specifying custom http headers using the JS SDK.

## Description

Adding https://github.com/openfga/js-sdk/pull/262 to generator to the geneartor

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

Add https://github.com/openfga/js-sdk/pull/262 to generator

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added guidance on using custom headers in the JS client, including default vs per-request behavior, precedence, and examples.

- Tests
  - Introduced comprehensive tests for header handling, covering merging rules, case-insensitivity, Content-Type behavior, and multiple endpoints.

- Chores
  - Updated JS client configuration to include the new header tests in the generated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->