### PR TITLE
ci(python-sdk): fix flaky unit tests

### DIFF
--- a/config/clients/python/template/test/api_test.py.mustache
+++ b/config/clients/python/template/test/api_test.py.mustache
@@ -1514,12 +1514,12 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
               "message": "Rate Limit exceeded"
             }
         """
-        retry_after_in_sec = 5
-        five_seconds_from_now = (datetime.now(timezone.utc) + timedelta(seconds=retry_after_in_sec)).strftime('%a, %d %b %Y %H:%M:%S GMT')
+        retry_after_in_sec = 10
+        ten_seconds_from_now = (datetime.now(timezone.utc) + timedelta(seconds=retry_after_in_sec)).strftime('%a, %d %b %Y %H:%M:%S GMT')
         mock_http_response = http_mock_response(
             body=error_response_body,
             status=429,
-            headers={"Retry-After": five_seconds_from_now}
+            headers={"Retry-After": ten_seconds_from_now}
         )
         mock_request.side_effect = [
             RateLimitExceededError(
@@ -1531,7 +1531,7 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
         retry = {{packageName}}.configuration.RetryParams(
             max_retry=1,
             min_wait_in_ms=10,
-            max_wait_in_sec=1
+            max_wait_in_sec=15
         )
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1552,7 +1552,7 @@ class TestOpenFgaApi(IsolatedAsyncioTestCase):
             self.assertTrue(api_response.allowed)
             mock_request.assert_called()
             self.assertEqual(mock_request.call_count, 2)
-            self.assertTrue(retry_after_in_sec-1 <= mock_sleep.call_args[0][0] <= retry_after_in_sec)
+            self.assertTrue(retry_after_in_sec - 2 <= mock_sleep.call_args[0][0] <= retry_after_in_sec)
 
     @patch('asyncio.sleep')
     @patch.object(rest.RESTClientObject, "request")

--- a/config/clients/python/template/test/client/client_test.py.mustache
+++ b/config/clients/python/template/test/client/client_test.py.mustache
@@ -2031,12 +2031,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         Check whether a user is authorized to access an object
         """
 
-        # First, mock the response
-        mock_request.side_effect = [
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-            mock_response('{"allowed": false, "resolution": "1234"}', 200),
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-        ]
         body1 = ClientCheckRequest(
             object="document:2021-budget",
             relation="reader",
@@ -2052,6 +2046,20 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             relation="reader",
             user="user:81684243-9356-4421-8fbf-a4f8d36aa31d",
         )
+
+        # Mock the response based on request body to avoid race conditions
+        def mock_side_effect(*args, **kwargs):
+            body = kwargs.get("body", {})
+            user = body.get("tuple_key", {}).get("user", "")
+            if user == "user:81684243-9356-4421-8fbf-a4f8d36aa31b":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31c":
+                return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31d":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+
+        mock_request.side_effect = mock_side_effect
         configuration = self.configuration
         configuration.store_id = store_id
         async with OpenFgaClient(configuration) as api_client:
@@ -2140,12 +2148,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 }
         """
 
-        # First, mock the response
-        mock_request.side_effect = [
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-            ValidationException(http_resp=http_mock_response(response_body, 400)),
-            mock_response('{"allowed": false, "resolution": "1234"}', 200),
-        ]
         body1 = ClientCheckRequest(
             object="document:2021-budget",
             relation="reader",
@@ -2161,6 +2163,20 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             relation="reader",
             user="user:81684243-9356-4421-8fbf-a4f8d36aa31d",
         )
+
+        # Mock the response based on request body to avoid race conditions
+        def mock_side_effect(*args, **kwargs):
+            body = kwargs.get("body", {})
+            user = body.get("tuple_key", {}).get("user", "")
+            if user == "user:81684243-9356-4421-8fbf-a4f8d36aa31b":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31c":
+                raise ValidationException(http_resp=http_mock_response(response_body, 400))
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31d":
+                return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+            return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+
+        mock_request.side_effect = mock_side_effect
         configuration = self.configuration
         configuration.store_id = store_id
         async with OpenFgaClient(configuration) as api_client:

--- a/config/clients/python/template/test/sync/api_test.py.mustache
+++ b/config/clients/python/template/test/sync/api_test.py.mustache
@@ -1578,13 +1578,13 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
                   "message": "Rate Limit exceeded"
                 }
             """
-        retry_after_in_sec = 5
-        five_seconds_from_now = (datetime.now(timezone.utc) + timedelta(seconds=retry_after_in_sec)).strftime(
+        retry_after_in_sec = 10
+        ten_seconds_from_now = (datetime.now(timezone.utc) + timedelta(seconds=retry_after_in_sec)).strftime(
             '%a, %d %b %Y %H:%M:%S GMT')
         mock_http_response = http_mock_response(
             body=error_response_body,
             status=429,
-            headers={"Retry-After": five_seconds_from_now}
+            headers={"Retry-After": ten_seconds_from_now}
         )
         mock_request.side_effect = [
             RateLimitExceededError(
@@ -1596,7 +1596,7 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
         retry = {{packageName}}.configuration.RetryParams(
             max_retry=1,
             min_wait_in_ms=10,
-            max_wait_in_sec=1
+            max_wait_in_sec=15
         )
         configuration = self.configuration
         configuration.store_id = store_id
@@ -1617,7 +1617,11 @@ class TestOpenFgaApiSync(IsolatedAsyncioTestCase):
             self.assertTrue(api_response.allowed)
             mock_request.assert_called()
             self.assertEqual(mock_request.call_count, 2)
-            self.assertEqual(mock_sleep.call_args[0][0], retry_after_in_sec)
+            self.assertTrue(
+                retry_after_in_sec - 2
+                <= mock_sleep.call_args[0][0]
+                <= retry_after_in_sec
+            )
 
     @patch('time.sleep')
     @patch.object(rest.RESTClientObject, "request")

--- a/config/clients/python/template/test/sync/client/client_test.py.mustache
+++ b/config/clients/python/template/test/sync/client/client_test.py.mustache
@@ -2034,12 +2034,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
         Check whether a user is authorized to access an object
         """
 
-        # First, mock the response
-        mock_request.side_effect = [
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-            mock_response('{"allowed": false, "resolution": "1234"}', 200),
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-        ]
         body1 = ClientCheckRequest(
             object="document:2021-budget",
             relation="reader",
@@ -2055,6 +2049,20 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             relation="reader",
             user="user:81684243-9356-4421-8fbf-a4f8d36aa31d",
         )
+
+        # Mock the response based on request body to avoid race conditions
+        def mock_side_effect(*args, **kwargs):
+            body = kwargs.get("body", {})
+            user = body.get("tuple_key", {}).get("user", "")
+            if user == "user:81684243-9356-4421-8fbf-a4f8d36aa31b":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31c":
+                return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31d":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+
+        mock_request.side_effect = mock_side_effect
         configuration = self.configuration
         configuration.store_id = store_id
         with OpenFgaClient(configuration) as api_client:
@@ -2143,12 +2151,6 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
 }
         """
 
-        # First, mock the response
-        mock_request.side_effect = [
-            mock_response('{"allowed": true, "resolution": "1234"}', 200),
-            ValidationException(http_resp=http_mock_response(response_body, 400)),
-            mock_response('{"allowed": false, "resolution": "1234"}', 200),
-        ]
         body1 = ClientCheckRequest(
             object="document:2021-budget",
             relation="reader",
@@ -2164,6 +2166,20 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             relation="reader",
             user="user:81684243-9356-4421-8fbf-a4f8d36aa31d",
         )
+
+        # Mock the response based on request body to avoid race conditions
+        def mock_side_effect(*args, **kwargs):
+            body = kwargs.get("body", {})
+            user = body.get("tuple_key", {}).get("user", "")
+            if user == "user:81684243-9356-4421-8fbf-a4f8d36aa31b":
+                return mock_response('{"allowed": true, "resolution": "1234"}', 200)
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31c":
+                raise ValidationException(http_resp=http_mock_response(response_body, 400))
+            elif user == "user:81684243-9356-4421-8fbf-a4f8d36aa31d":
+                return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+            return mock_response('{"allowed": false, "resolution": "1234"}', 200)
+
+        mock_request.side_effect = mock_side_effect
         configuration = self.configuration
         configuration.store_id = store_id
         with OpenFgaClient(configuration) as api_client:


### PR DESCRIPTION
This PR addresses flaky unit tests resulting from race conditions in async batch check operations and timing precision issues in retry logic.

- **Fixed race conditions when running BatchCheck tests with parallelization**
  Replaced sequential mock responses with conditional responses based on request body content. I only noticed this after the package modernization and adoption of `uv`, where `pytest` is run with parallelization enabled by default, unlike previously.

- **Improved retry timing stability**
  I adjusted the retry delay from exact matches to tolerance ranges of 1 or 2 seconds, and increased test timeouts to account for variance. I haven't encountered this locally, but have seen it pop up a few times on our CI during PR status checks.

## References

https://github.com/openfga/python-sdk/pull/231

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated retry/backoff expectations for 429 handling, increasing Retry-After duration and maximum wait limits.
  - Adjusted assertions to verify sleep durations within a bounded range around the Retry-After value.
  - Aligned tests using HTTP-date Retry-After headers with the new timing values.
  - Replaced static mock sequences with request-driven side effects to return responses based on payload content, applied to both async and sync tests.
  - Maintained existing success and error assertions with the new mocking approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->