### PR TITLE
docs(python-sdk): add custom headers guidance to README

### DIFF
--- a/config/clients/python/template/README_initializing.mustache
+++ b/config/clients/python/template/README_initializing.mustache
@@ -76,6 +76,66 @@ async def main():
         return api_response
 ```
 
+### Custom Headers
+
+#### Default Headers
+
+You can set default headers that will be sent with every request by accessing the API client and using the `set_default_header` method:
+
+```python
+from {{packageName}} import ClientConfiguration, OpenFgaClient
+
+
+async def main():
+    configuration = ClientConfiguration(
+        api_url=FGA_API_URL,
+        store_id=FGA_STORE_ID,
+        authorization_model_id=FGA_MODEL_ID,
+    )
+
+    async with OpenFgaClient(configuration) as fga_client:
+        # Set default headers that will be sent with every request
+        fga_client._api_client.set_default_header("X-Custom-Header", "default-value")
+        fga_client._api_client.set_default_header("X-Request-Source", "my-app")
+
+        api_response = await fga_client.read_authorization_models()
+        return api_response
+```
+
+#### Per-Request Headers
+
+You can also send custom headers on a per-request basis by using the `options` parameter. Per-request headers will override any default headers with the same name.
+
+```python
+from {{packageName}} import ClientConfiguration, OpenFgaClient
+from {{packageName}}.client.models import ClientCheckRequest
+
+
+async def main():
+    configuration = ClientConfiguration(
+        api_url=FGA_API_URL,
+        store_id=FGA_STORE_ID,
+        authorization_model_id=FGA_MODEL_ID,
+    )
+
+    async with OpenFgaClient(configuration) as fga_client:
+        # Add custom headers to a specific request
+        result = await fga_client.check(
+            body=ClientCheckRequest(
+                user="user:anne",
+                relation="viewer",
+                object="document:roadmap",
+            ),
+            options={
+                "headers": {
+                    "X-Request-ID": "123e4567-e89b-12d3-a456-426614174000",
+                    "X-Custom-Header": "custom-value",  # Overrides default header value
+                }
+            }
+        )
+        return result
+```
+
 #### Synchronous Client
 
 To run outside of an async context, the project exports a synchronous client


### PR DESCRIPTION
This pull request adds README documentation covering the usage of default custom headers and per-request custom headers with the Python SDK.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

