### PR TITLE
feat: add `headers` configuration property

### DIFF
--- a/config/clients/python/template/README_initializing.mustache
+++ b/config/clients/python/template/README_initializing.mustache
@@ -80,7 +80,7 @@ async def main():
 
 #### Default Headers
 
-You can set default headers that will be sent with every request by accessing the API client and using the `set_default_header` method:
+You can configure default headers that will be sent with every request by passing them to the `ClientConfiguration`:
 
 ```python
 from {{packageName}} import ClientConfiguration, OpenFgaClient
@@ -91,13 +91,13 @@ async def main():
         api_url=FGA_API_URL,
         store_id=FGA_STORE_ID,
         authorization_model_id=FGA_MODEL_ID,
+        headers={
+            "X-Custom-Header": "default-value",
+            "X-Request-Source": "my-app",
+        },
     )
 
     async with OpenFgaClient(configuration) as fga_client:
-        # Set default headers that will be sent with every request
-        fga_client._api_client.set_default_header("X-Custom-Header", "default-value")
-        fga_client._api_client.set_default_header("X-Request-Source", "my-app")
-
         api_response = await fga_client.read_authorization_models()
         return api_response
 ```

--- a/config/clients/python/template/src/client/client.py.mustache
+++ b/config/clients/python/template/src/client/client.py.mustache
@@ -135,6 +135,11 @@ class OpenFgaClient:
         self._api_client = ApiClient(configuration)
         self._api = OpenFgaApi(self._api_client)
 
+        # Set default headers from configuration
+        if configuration.headers:
+            for header_name, header_value in configuration.headers.items():
+                self._api_client.set_default_header(header_name, header_value)
+
     {{#asyncio}}
     async def __aenter__(self):
         return self

--- a/config/clients/python/template/src/client/configuration.py.mustache
+++ b/config/clients/python/template/src/client/configuration.py.mustache
@@ -42,6 +42,7 @@ class ClientConfiguration(Configuration):
                 ]
                 | None
             ) = None,
+            headers: dict[str, str] | None = None,
         ):
         super().__init__(
             api_scheme,
@@ -53,6 +54,7 @@ class ClientConfiguration(Configuration):
             api_url=api_url,
             timeout_millisec=timeout_millisec,
             telemetry=telemetry,
+            headers=headers,
         )
         self._authorization_model_id = authorization_model_id
 

--- a/config/clients/python/template/src/configuration.py.mustache
+++ b/config/clients/python/template/src/configuration.py.mustache
@@ -193,6 +193,7 @@ class Configuration:
             | None
         ) = None,
         timeout_millisec: int | None = None,
+        headers: dict[str, str] | None = None,
     ):
         """Constructor"""
         self._url = api_url
@@ -315,6 +316,10 @@ class Configuration:
             self._telemetry = telemetry
 
         """Telemetry configuration
+        """
+
+        self._headers = headers or {}
+        """Default headers to be sent with every request
         """
 
     def __deepcopy__(self, memo):
@@ -647,6 +652,17 @@ class Configuration:
                     f"timeout_millisec not within reasonable range (0,60000), {self._timeout_millisec}"
                 )
 
+        if self._headers is not None:
+            for key, value in self._headers.items():
+                if not isinstance(key, str):
+                    raise FgaValidationException(
+                        f"header keys must be strings, got {type(key).__name__} for key {key}"
+                    )
+                if not isinstance(value, str):
+                    raise FgaValidationException(
+                        f"header values must be strings, got {type(value).__name__} for key '{key}'"
+                    )
+
     @property
     def api_scheme(self):
         """Return connection is https or http."""
@@ -731,3 +747,31 @@ class Configuration:
         Update timeout milliseconds
         """
         self._timeout_millisec = value
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """
+        Return default headers to be sent with every request.
+
+        Headers are key-value pairs that will be included in all API requests.
+        Common use cases include correlation IDs, API versioning, and tenant identification.
+        """
+        return self._headers
+
+    @headers.setter
+    def headers(self, value: dict[str, str] | None) -> None:
+        """
+        Update default headers to be sent with every request.
+
+        Args:
+            value: Dictionary of header names to values, or None to clear headers.
+                   Both keys and values must be strings.
+
+        Raises:
+            FgaValidationException: If value is not a dict or None.
+        """
+        if value is not None and not isinstance(value, dict):
+            raise FgaValidationException(
+                f"headers must be a dict or None, got {type(value).__name__}"
+            )
+        self._headers = value or {}

--- a/config/clients/python/template/src/sync/client/client.py.mustache
+++ b/config/clients/python/template/src/sync/client/client.py.mustache
@@ -135,6 +135,11 @@ class OpenFgaClient:
         self._api_client = ApiClient(configuration)
         self._api = OpenFgaApi(self._api_client)
 
+        # Set default headers from configuration
+        if configuration.headers:
+            for header_name, header_value in configuration.headers.items():
+                self._api_client.set_default_header(header_name, header_value)
+
     def __enter__(self):
         return self
 

--- a/config/clients/python/template/test/client/client_test.py.mustache
+++ b/config/clients/python/template/test/client/client_test.py.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+import copy
 import json
 import uuid
 
@@ -7,6 +8,7 @@ from datetime import datetime
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import ANY, patch
 
+import pytest
 import urllib3
 
 from {{packageName}} import rest
@@ -3687,3 +3689,253 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertEqual(len(api_response), 2)
             self.assertTrue(api_response[0].allowed)
             self.assertFalse(api_response[1].allowed)
+
+    async def test_client_initialization_without_headers(self):
+        """Test that client initializes correctly without headers"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        )
+
+        async with OpenFgaClient(config) as client:
+            # Should not raise any errors
+            assert client._client_configuration == config
+            assert "User-Agent" in client._api_client.default_headers
+
+    async def test_client_initialization_with_headers(self):
+        """Test that client applies headers from configuration on initialization"""
+        headers = {
+            "X-Custom-Header": "custom-value",
+            "X-Request-Source": "test-app",
+        }
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+
+        async with OpenFgaClient(config) as client:
+            # Verify headers were set on the API client
+            assert "X-Custom-Header" in client._api_client.default_headers
+            assert (
+                client._api_client.default_headers["X-Custom-Header"] == "custom-value"
+            )
+            assert "X-Request-Source" in client._api_client.default_headers
+            assert client._api_client.default_headers["X-Request-Source"] == "test-app"
+
+    async def test_client_initialization_with_empty_headers(self):
+        """Test client initialization with empty headers dict"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={},
+        )
+
+        async with OpenFgaClient(config) as client:
+            # Only default User-Agent header should be present
+            assert "User-Agent" in client._api_client.default_headers
+            # No custom headers should be set
+            assert (
+                len(
+                    [k for k in client._api_client.default_headers if k != "User-Agent"]
+                )
+                == 0
+            )
+
+    async def test_client_initialization_with_multiple_headers(self):
+        """Test client initialization with multiple custom headers"""
+        headers = {
+            "X-Request-ID": "123e4567-e89b-12d3-a456-426614174000",
+            "X-API-Key": "secret-key",
+            "X-Tenant-ID": "tenant-123",
+            "X-User-Agent": "custom-agent/1.0",
+        }
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+
+        async with OpenFgaClient(config) as client:
+            for header_name, header_value in headers.items():
+                assert header_name in client._api_client.default_headers
+                assert client._api_client.default_headers[header_name] == header_value
+
+    async def test_client_initialization_headers_with_none(self):
+        """Test client initialization with headers=None"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=None,
+        )
+
+        async with OpenFgaClient(config) as client:
+            # Should only have default User-Agent header
+            assert "User-Agent" in client._api_client.default_headers
+
+    async def test_correlation_id_tracking(self):
+        """Test using headers for correlation ID tracking"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={
+                "X-Correlation-ID": "correlation-123",
+                "X-Request-Source": "api-gateway",
+            },
+        )
+
+        async with OpenFgaClient(config) as client:
+            assert (
+                client._api_client.default_headers["X-Correlation-ID"]
+                == "correlation-123"
+            )
+            assert (
+                client._api_client.default_headers["X-Request-Source"] == "api-gateway"
+            )
+
+    async def test_api_versioning_headers(self):
+        """Test using headers for API versioning"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={
+                "X-API-Version": "2024-01-01",
+                "Accept": "application/vnd.openfga.v1+json",
+            },
+        )
+
+        async with OpenFgaClient(config) as client:
+            assert client._api_client.default_headers["X-API-Version"] == "2024-01-01"
+            assert (
+                client._api_client.default_headers["Accept"]
+                == "application/vnd.openfga.v1+json"
+            )
+
+    async def test_multi_tenant_headers(self):
+        """Test using headers for multi-tenant applications"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={
+                "X-Tenant-ID": "tenant-abc-123",
+                "X-Organization-ID": "org-xyz-789",
+                "X-Environment": "production",
+            },
+        )
+
+        async with OpenFgaClient(config) as client:
+            assert client._api_client.default_headers["X-Tenant-ID"] == "tenant-abc-123"
+            assert (
+                client._api_client.default_headers["X-Organization-ID"] == "org-xyz-789"
+            )
+            assert client._api_client.default_headers["X-Environment"] == "production"
+
+    async def test_authentication_delegation_headers(self):
+        """Test using headers for authentication delegation"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={
+                "X-Forwarded-User": "user@example.com",
+                "X-Forwarded-Groups": "admin,developers",
+            },
+        )
+
+        async with OpenFgaClient(config) as client:
+            assert (
+                client._api_client.default_headers["X-Forwarded-User"]
+                == "user@example.com"
+            )
+            assert (
+                client._api_client.default_headers["X-Forwarded-Groups"]
+                == "admin,developers"
+            )
+
+    async def test_custom_user_agent(self):
+        """Test setting custom User-Agent header"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={
+                "User-Agent": "MyApp/1.0 (custom-client)",
+            },
+        )
+
+        async with OpenFgaClient(config) as client:
+            # Custom User-Agent should override the default
+            assert "MyApp/1.0" in client._api_client.default_headers["User-Agent"]
+
+
+@pytest.fixture
+def client_configuration():
+    """Fixture for creating a basic ClientConfiguration"""
+    return ClientConfiguration(
+        api_url="https://api.fga.example",
+        store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    )
+
+
+class TestClientConfigurationHeaders:
+    """Tests for ClientConfiguration headers parameter"""
+
+    def test_client_configuration_headers_default_none(self, client_configuration):
+        """Test that headers default to an empty dict in ClientConfiguration"""
+        assert client_configuration.headers == {}
+
+    def test_client_configuration_headers_initialization_with_dict(self):
+        """Test initializing ClientConfiguration with headers"""
+        headers = {
+            "X-Custom-Header": "custom-value",
+            "X-Request-Source": "test-app",
+        }
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+        assert config.headers == headers
+        assert config.headers["X-Custom-Header"] == "custom-value"
+        assert config.headers["X-Request-Source"] == "test-app"
+
+    def test_client_configuration_headers_initialization_with_none(self):
+        """Test initializing ClientConfiguration with headers=None"""
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            headers=None,
+        )
+        assert config.headers == {}
+
+    def test_client_configuration_headers_setter(self, client_configuration):
+        """Test setting headers via property setter"""
+        headers = {"X-Test": "test-value"}
+        client_configuration.headers = headers
+        assert client_configuration.headers == headers
+
+    def test_client_configuration_headers_with_authorization_model_id(self):
+        """Test ClientConfiguration with headers and authorization_model_id"""
+        headers = {"X-Model": "test"}
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            authorization_model_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+        assert config.headers == headers
+        assert config.authorization_model_id == "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+    def test_client_configuration_headers_deepcopy(self):
+        """Test that headers are properly deep copied in ClientConfiguration"""
+        headers = {"X-Test": "value"}
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+
+        copied_config = copy.deepcopy(config)
+
+        assert copied_config.headers == config.headers
+        assert copied_config.headers is not config.headers
+
+        config.headers["X-New"] = "new-value"
+        assert "X-New" not in copied_config.headers

--- a/config/clients/python/template/test/configuration_test.py.mustache
+++ b/config/clients/python/template/test/configuration_test.py.mustache
@@ -275,6 +275,155 @@ class TestConfigurationHostSettings:
             configuration.get_host_from_settings(999, variables={"var": "value"})
 
 
+class TestConfigurationHeaders:
+    def test_configuration_headers_default_none(self, configuration):
+        """Test that headers default to an empty dict"""
+        assert configuration.headers == {}
+
+    def test_configuration_headers_initialization_with_dict(self):
+        """Test initializing Configuration with headers"""
+        headers = {
+            "X-Custom-Header": "custom-value",
+            "X-Request-Source": "test-app",
+        }
+        config = Configuration(
+            api_url="https://fga.example",
+            headers=headers,
+        )
+        assert config.headers == headers
+        assert config.headers["X-Custom-Header"] == "custom-value"
+        assert config.headers["X-Request-Source"] == "test-app"
+
+    def test_configuration_headers_initialization_with_none(self):
+        """Test initializing Configuration with headers=None"""
+        config = Configuration(
+            api_url="https://fga.example",
+            headers=None,
+        )
+        assert config.headers == {}
+
+    def test_configuration_headers_setter_with_dict(self, configuration):
+        """Test setting headers using the property setter"""
+        headers = {"X-Test": "test-value"}
+        configuration.headers = headers
+        assert configuration.headers == headers
+        assert configuration.headers["X-Test"] == "test-value"
+
+    def test_configuration_headers_setter_with_none(self, configuration):
+        """Test setting headers to None using the property setter"""
+        configuration.headers = {"X-Test": "value"}
+        assert configuration.headers == {"X-Test": "value"}
+
+        configuration.headers = None
+        assert configuration.headers == {}
+
+    def test_configuration_headers_modification(self, configuration):
+        """Test that headers can be modified after initialization"""
+        configuration.headers = {"X-Initial": "initial"}
+        assert configuration.headers["X-Initial"] == "initial"
+
+        configuration.headers["X-Additional"] = "additional"
+        assert configuration.headers["X-Additional"] == "additional"
+        assert len(configuration.headers) == 2
+
+    def test_configuration_headers_with_multiple_headers(self):
+        """Test Configuration with multiple custom headers"""
+        headers = {
+            "X-Request-ID": "123e4567-e89b-12d3-a456-426614174000",
+            "X-API-Key": "secret-key",
+            "X-Tenant-ID": "tenant-123",
+            "X-User-Agent": "custom-agent/1.0",
+        }
+        config = Configuration(
+            api_url="https://fga.example",
+            headers=headers,
+        )
+        assert config.headers == headers
+        assert len(config.headers) == 4
+
+    def test_configuration_headers_empty_dict(self):
+        """Test initializing Configuration with empty headers dict"""
+        config = Configuration(
+            api_url="https://fga.example",
+            headers={},
+        )
+        assert config.headers == {}
+
+    def test_configuration_headers_deepcopy(self):
+        """Test that headers are properly deep copied"""
+        headers = {"X-Test": "value"}
+        config = Configuration(
+            api_url="https://fga.example",
+            headers=headers,
+        )
+
+        copied_config = copy.deepcopy(config)
+
+        assert copied_config.headers == config.headers
+        assert copied_config.headers is not config.headers  # Different object
+
+        # Modify original and verify copy is unaffected
+        config.headers["X-New"] = "new-value"
+        assert "X-New" not in copied_config.headers
+
+    def test_configuration_headers_setter_validation_non_dict(self):
+        """Test that setting headers to non-dict raises FgaValidationException"""
+        from openfga_sdk.exceptions import FgaValidationException
+
+        config = Configuration(api_url="https://fga.example")
+
+        with pytest.raises(
+            FgaValidationException, match="headers must be a dict or None"
+        ):
+            config.headers = "not a dict"
+
+        with pytest.raises(
+            FgaValidationException, match="headers must be a dict or None"
+        ):
+            config.headers = ["list", "of", "values"]
+
+        with pytest.raises(
+            FgaValidationException, match="headers must be a dict or None"
+        ):
+            config.headers = 123
+
+    def test_configuration_headers_validation_non_string_keys(self):
+        """Test that headers with non-string keys fail validation"""
+        from openfga_sdk.exceptions import FgaValidationException
+
+        config = Configuration(
+            api_url="https://fga.example",
+            headers={123: "value", "valid": "value"},
+        )
+
+        with pytest.raises(FgaValidationException, match="header keys must be strings"):
+            config.is_valid()
+
+    def test_configuration_headers_validation_non_string_values(self):
+        """Test that headers with non-string values fail validation"""
+        from openfga_sdk.exceptions import FgaValidationException
+
+        config = Configuration(
+            api_url="https://fga.example",
+            headers={"key": 456, "valid": "value"},
+        )
+
+        with pytest.raises(
+            FgaValidationException, match="header values must be strings"
+        ):
+            config.is_valid()
+
+    def test_configuration_headers_validation_passes_with_valid_headers(self):
+        """Test that valid headers pass validation"""
+        config = Configuration(
+            api_url="https://fga.example",
+            headers={"X-Custom": "value", "X-Another": "another-value"},
+        )
+
+        # Should not raise any exception
+        config.is_valid()
+
+
 class TestConfigurationMiscellaneous:
     def test_configuration_get_api_key_with_prefix(self, configuration):
         configuration.api_key = {"api_key": "123"}

--- a/config/clients/python/template/test/sync/client/client_test.py.mustache
+++ b/config/clients/python/template/test/sync/client/client_test.py.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+import copy
 import json
 import uuid
 
@@ -7,6 +8,7 @@ from datetime import datetime
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import ANY, patch
 
+import pytest
 import urllib3
 
 from {{packageName}}.client import ClientConfiguration
@@ -3709,3 +3711,230 @@ class TestOpenFgaClient(IsolatedAsyncioTestCase):
             self.assertFalse(api_response[1].allowed)
 
             api_client.close()
+
+    def test_sync_client_initialization_without_headers(self):
+        """Test that sync client initializes correctly without headers"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+        from openfga_sdk.sync.client.client import OpenFgaClient
+
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        )
+
+        with OpenFgaClient(config) as client:
+            assert client._client_configuration == config
+            assert "User-Agent" in client._api_client.default_headers
+
+    def test_sync_client_initialization_with_headers(self):
+        """Test that sync client applies headers from configuration on initialization"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+        from openfga_sdk.sync.client.client import OpenFgaClient
+
+        headers = {
+            "X-Custom-Header": "custom-value",
+            "X-Request-Source": "test-app",
+        }
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+
+        with OpenFgaClient(config) as client:
+            # Verify headers were set on the API client
+            assert "X-Custom-Header" in client._api_client.default_headers
+            assert (
+                client._api_client.default_headers["X-Custom-Header"] == "custom-value"
+            )
+            assert "X-Request-Source" in client._api_client.default_headers
+            assert client._api_client.default_headers["X-Request-Source"] == "test-app"
+
+    def test_sync_client_initialization_with_empty_headers(self):
+        """Test sync client initialization with empty headers dict"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+        from openfga_sdk.sync.client.client import OpenFgaClient
+
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={},
+        )
+
+        with OpenFgaClient(config) as client:
+            # Only default User-Agent header should be present
+            assert "User-Agent" in client._api_client.default_headers
+            # No custom headers should be set
+            assert (
+                len(
+                    [k for k in client._api_client.default_headers if k != "User-Agent"]
+                )
+                == 0
+            )
+
+    def test_sync_client_initialization_with_multiple_headers(self):
+        """Test sync client initialization with multiple custom headers"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+        from openfga_sdk.sync.client.client import OpenFgaClient
+
+        headers = {
+            "X-Request-ID": "123e4567-e89b-12d3-a456-426614174000",
+            "X-API-Key": "secret-key",
+            "X-Tenant-ID": "tenant-123",
+            "X-User-Agent": "custom-agent/1.0",
+        }
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+
+        with OpenFgaClient(config) as client:
+            for header_name, header_value in headers.items():
+                assert header_name in client._api_client.default_headers
+                assert client._api_client.default_headers[header_name] == header_value
+
+    def test_sync_client_initialization_headers_with_none(self):
+        """Test sync client initialization with headers=None"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+        from openfga_sdk.sync.client.client import OpenFgaClient
+
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=None,
+        )
+
+        with OpenFgaClient(config) as client:
+            # Should only have default User-Agent header
+            assert "User-Agent" in client._api_client.default_headers
+
+    def test_sync_correlation_id_tracking(self):
+        """Test using headers for correlation ID tracking in sync client"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+        from openfga_sdk.sync.client.client import OpenFgaClient
+
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={
+                "X-Correlation-ID": "correlation-123",
+                "X-Request-Source": "api-gateway",
+            },
+        )
+
+        with OpenFgaClient(config) as client:
+            assert (
+                client._api_client.default_headers["X-Correlation-ID"]
+                == "correlation-123"
+            )
+            assert (
+                client._api_client.default_headers["X-Request-Source"] == "api-gateway"
+            )
+
+    def test_sync_multi_tenant_headers(self):
+        """Test using headers for multi-tenant applications in sync client"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+        from openfga_sdk.sync.client.client import OpenFgaClient
+
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers={
+                "X-Tenant-ID": "tenant-abc-123",
+                "X-Organization-ID": "org-xyz-789",
+                "X-Environment": "production",
+            },
+        )
+
+        with OpenFgaClient(config) as client:
+            assert client._api_client.default_headers["X-Tenant-ID"] == "tenant-abc-123"
+            assert (
+                client._api_client.default_headers["X-Organization-ID"] == "org-xyz-789"
+            )
+            assert client._api_client.default_headers["X-Environment"] == "production"
+
+
+@pytest.fixture
+def client_configuration():
+    """Fixture for creating a basic ClientConfiguration"""
+    from openfga_sdk.client.configuration import ClientConfiguration
+
+    return ClientConfiguration(
+        api_url="https://api.fga.example",
+        store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    )
+
+
+class TestSyncClientConfigurationHeaders:
+    """Tests for ClientConfiguration headers parameter in sync client"""
+
+    def test_sync_client_configuration_headers_default_none(self, client_configuration):
+        """Test that headers default to an empty dict in ClientConfiguration"""
+        assert client_configuration.headers == {}
+
+    def test_sync_client_configuration_headers_initialization_with_dict(self):
+        """Test initializing ClientConfiguration with headers"""
+        headers = {
+            "X-Custom-Header": "custom-value",
+            "X-Request-Source": "test-app",
+        }
+        from openfga_sdk.client.configuration import ClientConfiguration
+
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+        assert config.headers == headers
+        assert config.headers["X-Custom-Header"] == "custom-value"
+        assert config.headers["X-Request-Source"] == "test-app"
+
+    def test_sync_client_configuration_headers_initialization_with_none(self):
+        """Test initializing ClientConfiguration with headers=None"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            headers=None,
+        )
+        assert config.headers == {}
+
+    def test_sync_client_configuration_headers_setter(self, client_configuration):
+        """Test setting headers via property setter"""
+        headers = {"X-Test": "test-value"}
+        client_configuration.headers = headers
+        assert client_configuration.headers == headers
+
+    def test_sync_client_configuration_headers_with_authorization_model_id(self):
+        """Test ClientConfiguration with headers and authorization_model_id"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+
+        headers = {"X-Model": "test"}
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            authorization_model_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+        assert config.headers == headers
+        assert config.authorization_model_id == "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+    def test_sync_client_configuration_headers_deepcopy(self):
+        """Test that headers are properly deep copied in ClientConfiguration"""
+        from openfga_sdk.client.configuration import ClientConfiguration
+
+        headers = {"X-Test": "value"}
+        config = ClientConfiguration(
+            api_url="https://api.fga.example",
+            store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            headers=headers,
+        )
+
+        copied_config = copy.deepcopy(config)
+
+        assert copied_config.headers == config.headers
+        assert copied_config.headers is not config.headers
+
+        config.headers["X-New"] = "new-value"
+        assert "X-New" not in copied_config.headers


### PR DESCRIPTION
This pull request adds a `headers` property to the SDK's client configuration class, allowing developers to pass headers that are automatically included in all API requests by default.

This pattern aligns the Python SDK with behavior already present in the other SDKs.

```python
from openfga_sdk.client import ClientConfiguration, OpenFgaClient

# Configure default headers that apply to ALL requests
config = ClientConfiguration(
    api_url="https://api.fga.example",
    store_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
    headers={
        "X-Tenant-ID": "tenant-123",
        "X-App-Version": "1.0.0",
        "X-Request-Priority": "normal"
    }
)

async with OpenFgaClient(config) as client:
    # Default headers are automatically included in all requests
    await client.read_authorization_models()
    # Includes: X-Tenant-ID: tenant-123, X-App-Version: 1.0.0, X-Request-Priority: normal

    # Add per-request headers (merged with defaults)
    await client.check(
        user="user:alice",
        relation="viewer",
        object="document:roadmap",
        options={
            "headers": {
                "X-Request-ID": "req-456",
                "X-Correlation-ID": "corr-789"
            }
        }
    )
    # Includes: X-Tenant-ID: tenant-123, X-App-Version: 1.0.0, X-Request-Priority: normal,
    #           X-Request-ID: req-456, X-Correlation-ID: corr-789

    # Override default headers with per-request values
    await client.check(
        user="user:bob",
        relation="admin",
        object="document:secrets",
        options={
            "headers": {
                "X-Request-Priority": "high", # Overrides default "normal" priority
                "X-Request-ID": "req-789"
            }
        }
    )
    # Includes: X-Tenant-ID: tenant-123, X-App-Version: 1.0.0,
    #           X-Request-Priority: high (OVERRIDDEN), X-Request-ID: req-789
```

## References

https://github.com/openfga/python-sdk/pull/233

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

