### PR TITLE
release(java-sdk): v0.9.1

### DIFF
--- a/config/clients/java/CHANGELOG.md.mustache
+++ b/config/clients/java/CHANGELOG.md.mustache
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://{{gitHost}}/{{gitUserId}}/{{gitRepoId}}/compare/v{{packageVersion}}...HEAD)
 
+## v0.9.1
+
+### [0.9.1](https://github.com/openfga/java-sdk/compare/v0.9.0...v0.9.1) (2025-10-07)
+
+### Fixed
+
+- Override `defaultHeaders` in `ClientConfiguration` to return correct type when using method (#226)
+- Correctly handle options with no modelID set in `readAuthorizationModel` (#226)
+- Include headers when converting from `ClientListRelationsOptions` to `ClientBatchCheckOptions` (#226)
+
 ## v0.9.0
 
 ### [0.9.0](https://github.com/openfga/java-sdk/compare/v0.8.3...v0.9.0) (2025-08-15)

--- a/config/clients/java/config.overrides.json
+++ b/config/clients/java/config.overrides.json
@@ -3,7 +3,7 @@
   "gitRepoId": "java-sdk",
   "artifactId": "openfga-sdk",
   "groupId": "dev.openfga",
-  "packageVersion": "0.9.0",
+  "packageVersion": "0.9.1",
   "apiPackage": "dev.openfga.sdk.api",
   "authPackage": "dev.openfga.sdk.api.auth",
   "clientPackage": "dev.openfga.sdk.api.client",


### PR DESCRIPTION
## Description

Cuts a release of the java sdk with header fixes

```
## v0.9.1

### [0.9.1](https://github.com/openfga/java-sdk/compare/v0.9.0...v0.9.1) (2025-10-07)

### Fixed

- Override `defaultHeaders` in `ClientConfiguration` to return correct type when using method (#226)
- Correctly handle options with no modelID set in `readAuthorizationModel` (#226)
- Include headers when converting from `ClientListRelationsOptions` to `ClientBatchCheckOptions` (#226)
```


## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected configuration typing issues.
  - Resolved option handling for readAuthorizationModel.
  - Ensured headers are preserved when converting options.

- Documentation
  - Added a 0.9.1 section to the changelog summarizing the above fixes.

- Chores
  - Bumped Java client version to 0.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->