### PR TITLE
feat(dotnet-sdk): Added support for generating a client interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Main config
 OPENFGA_DOCKER_TAG = v1
-OPEN_API_REF ?= e53c69cc55317404d02a6d8e418d626268f28a59
+OPEN_API_REF ?= 0ac19aac54f21f3c78970126b84b4c69c6e3b9a2
 OPEN_API_URL = https://raw.githubusercontent.com/openfga/api/${OPEN_API_REF}/docs/openapiv2/apidocs.swagger.json
-OPENAPI_GENERATOR_CLI_DOCKER_TAG ?= v6.4.0
+OPENAPI_GENERATOR_CLI_DOCKER_TAG ?= v7.15.0
 NODE_DOCKER_TAG = 20-alpine
 GO_DOCKER_TAG = 1
 DOTNET_DOCKER_TAG = 9.0

--- a/config/clients/dotnet/config.overrides.json
+++ b/config/clients/dotnet/config.overrides.json
@@ -66,6 +66,10 @@
       "destinationFilename": "src/OpenFga.Sdk/Client/Client.cs",
       "templateType": "SupportingFiles"
     },
+    "Client/IClient.mustache": {
+      "destinationFilename": "src/OpenFga.Sdk/Client/IClient.cs",
+      "templateType": "SupportingFiles"
+    },
     "Client/ClientConfiguration.mustache": {
       "destinationFilename": "src/OpenFga.Sdk/Client/ClientConfiguration.cs",
       "templateType": "SupportingFiles"

--- a/config/clients/dotnet/template/Client/Client.mustache
+++ b/config/clients/dotnet/template/Client/Client.mustache
@@ -19,7 +19,7 @@ using {{packageName}}.Model;
 
 namespace {{packageName}}.Client;
 
-public class {{appShortName}}Client : IDisposable {
+public class {{appShortName}}Client : I{{appShortName}}Client, IDisposable {
     private readonly ClientConfiguration _configuration;
     protected {{appShortName}}Api api;
     private string CLIENT_BULK_REQUEST_ID_HEADER = "{{clientBulkRequestIdHeader}}";

--- a/config/clients/dotnet/template/Client/IClient.mustache
+++ b/config/clients/dotnet/template/Client/IClient.mustache
@@ -1,0 +1,190 @@
+{{>partial_header}}
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using {{packageName}}.Api;
+using {{packageName}}.ApiClient;
+using {{packageName}}.Client.Model;
+#if NETSTANDARD2_0 || NET48
+using {{packageName}}.Client.Extensions;
+#endif
+using {{packageName}}.Exceptions;
+using {{packageName}}.Model;
+
+namespace {{packageName}}.Client;
+
+public interface I{{appShortName}}Client {
+    /// <summary>
+    ///     Store ID
+    /// </summary>
+    string? StoreId { get; set; }
+
+    /// <summary>
+    ///     Authorization Model ID
+    /// </summary>
+    string? AuthorizationModelId { get; set; }
+
+    /**********
+     * Stores *
+     **********/
+
+    /**
+   * ListStores - Get a paginated list of stores.
+   */
+    Task<ListStoresResponse> ListStores(IClientListStoresRequest? body, IClientListStoresOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+   * CreateStore - Initialize a store
+   */
+    Task<CreateStoreResponse> CreateStore(ClientCreateStoreRequest body,
+        IClientRequestOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+   * GetStore - Get information about the current store
+   */
+    Task<GetStoreResponse> GetStore(IClientRequestOptionsWithStoreId? options = default, CancellationToken cancellationToken = default);
+
+    /**
+   * DeleteStore - Delete a store
+   */
+    Task DeleteStore(IClientRequestOptionsWithStoreId? options = default, CancellationToken cancellationToken = default);
+
+    /************************
+     * Authorization Models *
+     ************************/
+
+    /**
+     * ReadAuthorizationModels - Read all authorization models
+     */
+    Task<ReadAuthorizationModelsResponse> ReadAuthorizationModels(
+        IClientReadAuthorizationModelsOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * WriteAuthorizationModel - Create a new version of the authorization model
+     */
+    Task<WriteAuthorizationModelResponse> WriteAuthorizationModel(ClientWriteAuthorizationModelRequest body,
+        IClientRequestOptionsWithStoreId? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * ReadAuthorizationModel - Read the current authorization model
+     */
+    Task<ReadAuthorizationModelResponse> ReadAuthorizationModel(
+        IClientReadAuthorizationModelOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * ReadLatestAuthorizationModel - Read the latest authorization model for the current store
+     */
+    Task<ReadAuthorizationModelResponse?> ReadLatestAuthorizationModel(
+        IClientRequestOptionsWithAuthZModelId? options = default,
+        CancellationToken cancellationToken = default);
+
+    /***********************
+     * Relationship Tuples *
+     ***********************/
+
+    /**
+     * Read Changes - Read the list of historical relationship tuple writes and deletes
+     */
+    Task<ReadChangesResponse> ReadChanges(ClientReadChangesRequest? body = default,
+        ClientReadChangesOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * Read - Read tuples previously written to the store (does not evaluate)
+     */
+    Task<ReadResponse> Read(ClientReadRequest? body = default, IClientReadOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * Write - Create or delete relationship tuples
+     */
+    Task<ClientWriteResponse> Write(ClientWriteRequest body, IClientWriteOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * WriteTuples - Utility method to write tuples, wraps Write
+     */
+    Task<ClientWriteResponse> WriteTuples(List<ClientTupleKey> body, IClientWriteOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * DeleteTuples - Utility method to delete tuples, wraps Write
+     */
+    Task<ClientWriteResponse> DeleteTuples(List<ClientTupleKeyWithoutCondition> body, IClientWriteOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /************************
+     * Relationship Queries *
+     ************************/
+
+    /**
+   * Check - Check if a user has a particular relation with an object (evaluates)
+   */
+    Task<CheckResponse> Check(IClientCheckRequest body,
+        IClientCheckOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+   * BatchCheck - Run a set of checks (evaluates)
+   */
+    Task<ClientBatchCheckClientResponse> BatchCheck(List<ClientCheckRequest> body,
+        IClientBatchCheckOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+   * Expand - Expands the relationships in userset tree format (evaluates)
+   */
+    Task<ExpandResponse> Expand(IClientExpandRequest body,
+        IClientExpandOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * ListObjects - List the objects of a particular type that the user has a certain relation to (evaluates)
+     */
+    Task<ListObjectsResponse> ListObjects(IClientListObjectsRequest body,
+        IClientListObjectsOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+
+    /**
+     * ListRelations - List all the relations a user has with an object (evaluates)
+     */
+    Task<ListRelationsResponse> ListRelations(IClientListRelationsRequest body,
+        IClientListRelationsOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * ListUsers - List all users of the given type that the object has a relation with (evaluates)
+     */
+    Task<ListUsersResponse> ListUsers(IClientListUsersRequest body,
+        IClientListUsersOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**************
+     * Assertions *
+     **************/
+
+    /**
+   * ReadAssertions - Read assertions for a particular authorization model
+   */
+    Task<ReadAssertionsResponse> ReadAssertions(IClientReadAssertionsOptions? options = default,
+        CancellationToken cancellationToken = default);
+
+    /**
+     * WriteAssertions - Updates assertions for a particular authorization model
+     */
+    Task WriteAssertions(List<ClientAssertion> body,
+        IClientWriteAssertionsOptions? options = default,
+        CancellationToken cancellationToken = default);
+}

--- a/config/clients/dotnet/template/modelWriteRequestDeletes.mustache
+++ b/config/clients/dotnet/template/modelWriteRequestDeletes.mustache
@@ -1,0 +1,338 @@
+{{>partial_header}}
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+{{#validatable}}
+using System.ComponentModel.DataAnnotations;
+{{/validatable}}
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+
+namespace {{packageName}}.{{modelPackage}}
+{
+{{#models}}
+{{#model}}
+    /// <summary>
+    /// {{description}}{{^description}}{{classname}}{{/description}}
+    /// </summary>
+    [DataContract(Name = "{{{name}}}")]
+    {{#discriminator}}
+    [JsonConverter(typeof(JsonSubtypes), "{{{discriminatorName}}}")]
+    {{#mappedModels}}
+    [JsonSubtypes.KnownSubType(typeof({{{modelName}}}), "{{{mappingName}}}")]
+    {{/mappedModels}}
+    {{/discriminator}}
+    public {{#isEnum}}{{^isArray}}{{>visibility}}{{/isArray}}{{/isEnum}}{{^isEnum}}partial {{/isEnum}}class {{{classname}}}{{#parent}} : {{{.}}}{{/parent}}{{^parent}} : IEquatable<{{classname}}>{{#validatable}}, IValidatableObject{{/validatable}}{{/parent}}
+    {
+        /// <summary>
+        /// Defines OnMissing behavior
+        /// </summary>
+        public enum OnMissingEnum
+        {
+            /// <summary>
+            /// Enum Error for value: error
+            /// </summary>
+            [EnumMember(Value = "error")]
+            Error = 1,
+
+            /// <summary>
+            /// Enum Ignore for value: ignore
+            /// </summary>
+            [EnumMember(Value = "ignore")]
+            Ignore = 2
+        }
+
+{{#vars}}
+{{#isEnum}}
+{{#allowableValues}}
+        /// <summary>
+        /// {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+        /// </summary>
+{{#description}}
+        /// <value>{{.}}</value>
+{{/description}}
+{{#isContainer}}
+        [DataMember(Name="{{baseName}}", EmitDefaultValue={{emitDefaultValue}})]
+{{/isContainer}}
+        public {{#isArray}}{{#uniqueItems}}HashSet{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}{{#isMap}}Dictionary{{/isMap}}<string, {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{dataType}}}{{/datatypeWithEnum}}>{{^isContainer}}{{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{dataType}}}{{/datatypeWithEnum}}{{/isContainer}} {{name}} { get; set; }
+{{^isContainer}}
+{{>modelInnerEnum}}
+{{/isContainer}}
+{{/allowableValues}}
+{{/isEnum}}
+{{/vars}}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}" /> class.
+        /// </summary>
+        [JsonConstructor]
+        public {{{classname}}}()
+        {
+            {{#vars}}
+            {{#defaultValue}}
+            {{^isReadOnly}}
+            {{^isContainer}}
+            this.{{name}} = {{{defaultValue}}};
+            {{/isContainer}}
+            {{/isReadOnly}}
+            {{/defaultValue}}
+            {{/vars}}
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}" /> class.
+        /// </summary>
+{{#vars}}
+{{^isReadOnly}}
+        /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{#description}}{{.}}{{/description}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{^required}} (default to {{defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}.</param>
+{{/isReadOnly}}
+{{/vars}}
+        public {{{classname}}}({{#readWriteVars}}{{{dataType}}} {{#lambda.camelcase_param}}{{{name}}}{{/lambda.camelcase_param}} = default{{^-last}}, {{/-last}}{{/readWriteVars}})
+        {
+{{#vars}}
+{{#required}}
+            {{^defaultValue}}
+            {{^isReadOnly}}
+            {{^isNullable}}
+            // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
+            if ({{#lambda.camelcase_param}}{{{name}}}{{/lambda.camelcase_param}} == null)
+            {
+                throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+            }
+            {{/isNullable}}
+            {{/isReadOnly}}
+            {{/defaultValue}}
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+{{/required}}
+{{/vars}}
+{{#vars}}
+{{^required}}
+            {{#defaultValue}}
+            {{^isReadOnly}}
+            // use default value if no "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" provided
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? {{{defaultValue}}};
+            {{/isReadOnly}}
+            {{/defaultValue}}
+            {{^defaultValue}}
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            {{/defaultValue}}
+{{/required}}
+{{/vars}}
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
+
+{{#vars}}
+        /// <summary>
+        /// {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+        /// </summary>{{#description}}
+        /// <value>{{.}}</value>{{/description}}
+{{^isEnum}}
+        [DataMember(Name = "{{baseName}}", {{#required}}IsRequired = true, {{/required}}EmitDefaultValue = {{emitDefaultValue}})]
+{{/isEnum}}
+{{#deprecated}}
+        [Obsolete]
+{{/deprecated}}
+{{#minimum}}
+{{#maximum}}
+        [Range({{minimum}}, {{maximum}})]
+{{/maximum}}
+{{/minimum}}
+{{#minLength}}
+{{#maxLength}}
+        [StringLength({{maxLength}}, MinimumLength={{minLength}})]
+{{/maxLength}}
+{{^maxLength}}
+        [MinLength({{.}})]
+{{/maxLength}}
+{{/minLength}}
+{{^minLength}}
+{{#maxLength}}
+        [MaxLength({{.}})]
+{{/maxLength}}
+{{/minLength}}
+{{#pattern}}
+        [RegularExpression("{{.}}")]
+{{/pattern}}
+        [JsonPropertyName("{{baseName}}")]
+{{#isNullable}}
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+{{/isNullable}}
+        public {{{dataType}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
+
+{{/vars}}
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+{{#vendorExtensions.x-serialization-methods}}
+
+        /// <summary>
+        /// Returns the JSON string presentation of the object
+        /// </summary>
+        /// <returns>JSON string presentation of the object</returns>
+        public virtual string ToJson()
+        {
+            return JsonSerializer.Serialize(this);
+        }
+
+        /// <summary>
+        /// Builds a {{classname}} from the JSON string presentation of the object
+        /// </summary>
+        /// <returns>{{classname}}</returns>
+        public static {{classname}} FromJson(string jsonString) {
+            return JsonSerializer.Deserialize<{{classname}}>(jsonString) ?? throw new InvalidOperationException();
+        }
+
+{{/vendorExtensions.x-serialization-methods}}
+{{^isEnum}}
+{{^parent}}
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            {{#useCompareNetObjects}}
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as {{classname}}).AreEqual;
+            {{/useCompareNetObjects}}
+            {{^useCompareNetObjects}}
+            return this.Equals(input as {{classname}});
+            {{/useCompareNetObjects}}
+        }
+
+        /// <summary>
+        /// Returns true if {{classname}} instances are equal
+        /// </summary>
+        /// <param name="input">Instance of {{classname}} to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals({{classname}} input)
+        {
+            {{#useCompareNetObjects}}
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+            {{/useCompareNetObjects}}
+            {{^useCompareNetObjects}}
+            if (input == null)
+            {
+                return false;
+            }
+            return {{#vars}}{{#parent}}base.Equals(input) && {{/parent}}{{^isContainer}}
+                (
+                    this.{{name}} == input.{{name}} ||
+                    {{^vendorExtensions.x-is-value-type}}
+                    {{#required}}
+                    {{^isNullable}}
+                    this.{{name}} != null &&
+                    {{/isNullable}}
+                    {{/required}}
+                    {{^required}}
+                    (this.{{name}} != null &&
+                    {{/required}}
+                    {{/vendorExtensions.x-is-value-type}}
+                    this.{{name}}.Equals(input.{{name}}){{^vendorExtensions.x-is-value-type}}){{/vendorExtensions.x-is-value-type}}
+                ){{^-last}} && {{/-last}}{{/isContainer}}{{#isContainer}}
+                (
+                    this.{{name}} == input.{{name}} ||
+                    {{^vendorExtensions.x-is-value-type}}
+                    this.{{name}} != null &&
+                    input.{{name}} != null &&
+                    {{/vendorExtensions.x-is-value-type}}
+                    this.{{name}}.SequenceEqual(input.{{name}})
+                ){{^-last}} && {{/-last}}{{/isContainer}}{{/vars}}
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && this.AdditionalProperties.All(kv => input.AdditionalProperties.ContainsKey(kv.Key) && Equals(kv.Value, input.AdditionalProperties[kv.Key])));
+            {{/useCompareNetObjects}}
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = {{hashCodeBasePrimeNumber}};
+{{#vars}}
+                if (this.{{name}} != null)
+                {
+                    hashCode = (hashCode * {{hashCodeMultiplierPrimeNumber}}) + this.{{name}}.GetHashCode();
+                }
+{{/vars}}
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * {{hashCodeMultiplierPrimeNumber}}) + this.AdditionalProperties.GetHashCode();
+                }
+                return hashCode;
+            }
+        }
+
+{{/parent}}
+{{/isEnum}}
+{{#validatable}}
+{{^parent}}
+        /// <summary>
+        /// To validate all properties of the instance
+        /// </summary>
+        /// <param name="validationContext">Validation context</param>
+        /// <returns>Validation Result</returns>
+        public IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(ValidationContext validationContext)
+        {
+{{#vars}}
+{{#hasValidation}}
+{{#maxLength}}
+            // {{{name}}} ({{{dataType}}}) maxLength
+            if (this.{{{name}}} != null && this.{{{name}}}.Length > {{maxLength}})
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, length must be less than {{maxLength}}.", new [] { "{{{name}}}" });
+            }
+
+{{/maxLength}}
+{{#minLength}}
+            // {{{name}}} ({{{dataType}}}) minLength
+            if (this.{{{name}}} != null && this.{{{name}}}.Length < {{minLength}})
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, length must be greater than {{minLength}}.", new [] { "{{{name}}}" });
+            }
+
+{{/minLength}}
+{{#maximum}}
+            // {{{name}}} ({{{dataType}}}) maximum
+            if (this.{{{name}}} > ({{{dataType}}}){{maximum}})
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must be a value less than or equal to {{maximum}}.", new [] { "{{{name}}}" });
+            }
+
+{{/maximum}}
+{{#minimum}}
+            // {{{name}}} ({{{dataType}}}) minimum
+            if (this.{{{name}}} < ({{{dataType}}}){{minimum}})
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must be a value greater than or equal to {{minimum}}.", new [] { "{{{name}}}" });
+            }
+
+{{/minimum}}
+{{#pattern}}
+            // {{{name}}} ({{{dataType}}}) pattern
+            Regex regex{{{name}}} = new Regex(@"{{{vendorExtensions.x-regex}}}"{{#vendorExtensions.x-modifiers}}{{#-first}}, {{/-first}}RegexOptions.{{{.}}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}});
+            if (false == regex{{{name}}}.Match(this.{{{name}}}).Success)
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must match a pattern of " + regex{{{name}}}, new [] { "{{{name}}}" });
+            }
+
+{{/pattern}}
+{{/hasValidation}}
+{{/vars}}
+            yield break;
+        }
+{{/parent}}
+{{/validatable}}
+    }
+{{/model}}
+{{/models}}
+}

--- a/config/clients/dotnet/template/modelWriteRequestWrites.mustache
+++ b/config/clients/dotnet/template/modelWriteRequestWrites.mustache
@@ -1,0 +1,338 @@
+{{>partial_header}}
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+{{#validatable}}
+using System.ComponentModel.DataAnnotations;
+{{/validatable}}
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+
+namespace {{packageName}}.{{modelPackage}}
+{
+{{#models}}
+{{#model}}
+    /// <summary>
+    /// {{description}}{{^description}}{{classname}}{{/description}}
+    /// </summary>
+    [DataContract(Name = "{{{name}}}")]
+    {{#discriminator}}
+    [JsonConverter(typeof(JsonSubtypes), "{{{discriminatorName}}}")]
+    {{#mappedModels}}
+    [JsonSubtypes.KnownSubType(typeof({{{modelName}}}), "{{{mappingName}}}")]
+    {{/mappedModels}}
+    {{/discriminator}}
+    public {{#isEnum}}{{^isArray}}{{>visibility}}{{/isArray}}{{/isEnum}}{{^isEnum}}partial {{/isEnum}}class {{{classname}}}{{#parent}} : {{{.}}}{{/parent}}{{^parent}} : IEquatable<{{classname}}>{{#validatable}}, IValidatableObject{{/validatable}}{{/parent}}
+    {
+        /// <summary>
+        /// Defines OnDuplicate behavior
+        /// </summary>
+        public enum OnDuplicateEnum
+        {
+            /// <summary>
+            /// Enum Error for value: error
+            /// </summary>
+            [EnumMember(Value = "error")]
+            Error = 1,
+
+            /// <summary>
+            /// Enum Ignore for value: ignore
+            /// </summary>
+            [EnumMember(Value = "ignore")]
+            Ignore = 2
+        }
+
+{{#vars}}
+{{#isEnum}}
+{{#allowableValues}}
+        /// <summary>
+        /// {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+        /// </summary>
+{{#description}}
+        /// <value>{{.}}</value>
+{{/description}}
+{{#isContainer}}
+        [DataMember(Name="{{baseName}}", EmitDefaultValue={{emitDefaultValue}})]
+{{/isContainer}}
+        public {{#isArray}}{{#uniqueItems}}HashSet{{/uniqueItems}}{{^uniqueItems}}List{{/uniqueItems}}{{/isArray}}{{#isMap}}Dictionary{{/isMap}}<string, {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{dataType}}}{{/datatypeWithEnum}}>{{^isContainer}}{{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{dataType}}}{{/datatypeWithEnum}}{{/isContainer}} {{name}} { get; set; }
+{{^isContainer}}
+{{>modelInnerEnum}}
+{{/isContainer}}
+{{/allowableValues}}
+{{/isEnum}}
+{{/vars}}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}" /> class.
+        /// </summary>
+        [JsonConstructor]
+        public {{{classname}}}()
+        {
+            {{#vars}}
+            {{#defaultValue}}
+            {{^isReadOnly}}
+            {{^isContainer}}
+            this.{{name}} = {{{defaultValue}}};
+            {{/isContainer}}
+            {{/isReadOnly}}
+            {{/defaultValue}}
+            {{/vars}}
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}" /> class.
+        /// </summary>
+{{#vars}}
+{{^isReadOnly}}
+        /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{#description}}{{.}}{{/description}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{^required}} (default to {{defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}.</param>
+{{/isReadOnly}}
+{{/vars}}
+        public {{{classname}}}({{#readWriteVars}}{{{dataType}}} {{#lambda.camelcase_param}}{{{name}}}{{/lambda.camelcase_param}} = default{{^-last}}, {{/-last}}{{/readWriteVars}})
+        {
+{{#vars}}
+{{#required}}
+            {{^defaultValue}}
+            {{^isReadOnly}}
+            {{^isNullable}}
+            // to ensure "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" is required (not null)
+            if ({{#lambda.camelcase_param}}{{{name}}}{{/lambda.camelcase_param}} == null)
+            {
+                throw new ArgumentNullException("{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} is a required property for {{classname}} and cannot be null");
+            }
+            {{/isNullable}}
+            {{/isReadOnly}}
+            {{/defaultValue}}
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+{{/required}}
+{{/vars}}
+{{#vars}}
+{{^required}}
+            {{#defaultValue}}
+            {{^isReadOnly}}
+            // use default value if no "{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}" provided
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}} ?? {{{defaultValue}}};
+            {{/isReadOnly}}
+            {{/defaultValue}}
+            {{^defaultValue}}
+            this.{{name}} = {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}};
+            {{/defaultValue}}
+{{/required}}
+{{/vars}}
+            this.AdditionalProperties = new Dictionary<string, object>();
+        }
+
+{{#vars}}
+        /// <summary>
+        /// {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+        /// </summary>{{#description}}
+        /// <value>{{.}}</value>{{/description}}
+{{^isEnum}}
+        [DataMember(Name = "{{baseName}}", {{#required}}IsRequired = true, {{/required}}EmitDefaultValue = {{emitDefaultValue}})]
+{{/isEnum}}
+{{#deprecated}}
+        [Obsolete]
+{{/deprecated}}
+{{#minimum}}
+{{#maximum}}
+        [Range({{minimum}}, {{maximum}})]
+{{/maximum}}
+{{/minimum}}
+{{#minLength}}
+{{#maxLength}}
+        [StringLength({{maxLength}}, MinimumLength={{minLength}})]
+{{/maxLength}}
+{{^maxLength}}
+        [MinLength({{.}})]
+{{/maxLength}}
+{{/minLength}}
+{{^minLength}}
+{{#maxLength}}
+        [MaxLength({{.}})]
+{{/maxLength}}
+{{/minLength}}
+{{#pattern}}
+        [RegularExpression("{{.}}")]
+{{/pattern}}
+        [JsonPropertyName("{{baseName}}")]
+{{#isNullable}}
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+{{/isNullable}}
+        public {{{dataType}}} {{name}} { get; {{#isReadOnly}}private {{/isReadOnly}}set; }
+
+{{/vars}}
+        /// <summary>
+        /// Gets or Sets additional properties
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
+
+{{#vendorExtensions.x-serialization-methods}}
+
+        /// <summary>
+        /// Returns the JSON string presentation of the object
+        /// </summary>
+        /// <returns>JSON string presentation of the object</returns>
+        public virtual string ToJson()
+        {
+            return JsonSerializer.Serialize(this);
+        }
+
+        /// <summary>
+        /// Builds a {{classname}} from the JSON string presentation of the object
+        /// </summary>
+        /// <returns>{{classname}}</returns>
+        public static {{classname}} FromJson(string jsonString) {
+            return JsonSerializer.Deserialize<{{classname}}>(jsonString) ?? throw new InvalidOperationException();
+        }
+
+{{/vendorExtensions.x-serialization-methods}}
+{{^isEnum}}
+{{^parent}}
+        /// <summary>
+        /// Returns true if objects are equal
+        /// </summary>
+        /// <param name="input">Object to be compared</param>
+        /// <returns>Boolean</returns>
+        public override bool Equals(object input)
+        {
+            {{#useCompareNetObjects}}
+            return OpenAPIClientUtils.compareLogic.Compare(this, input as {{classname}}).AreEqual;
+            {{/useCompareNetObjects}}
+            {{^useCompareNetObjects}}
+            return this.Equals(input as {{classname}});
+            {{/useCompareNetObjects}}
+        }
+
+        /// <summary>
+        /// Returns true if {{classname}} instances are equal
+        /// </summary>
+        /// <param name="input">Instance of {{classname}} to be compared</param>
+        /// <returns>Boolean</returns>
+        public bool Equals({{classname}} input)
+        {
+            {{#useCompareNetObjects}}
+            return OpenAPIClientUtils.compareLogic.Compare(this, input).AreEqual;
+            {{/useCompareNetObjects}}
+            {{^useCompareNetObjects}}
+            if (input == null)
+            {
+                return false;
+            }
+            return {{#vars}}{{#parent}}base.Equals(input) && {{/parent}}{{^isContainer}}
+                (
+                    this.{{name}} == input.{{name}} ||
+                    {{^vendorExtensions.x-is-value-type}}
+                    {{#required}}
+                    {{^isNullable}}
+                    this.{{name}} != null &&
+                    {{/isNullable}}
+                    {{/required}}
+                    {{^required}}
+                    (this.{{name}} != null &&
+                    {{/required}}
+                    {{/vendorExtensions.x-is-value-type}}
+                    this.{{name}}.Equals(input.{{name}}){{^vendorExtensions.x-is-value-type}}){{/vendorExtensions.x-is-value-type}}
+                ){{^-last}} && {{/-last}}{{/isContainer}}{{#isContainer}}
+                (
+                    this.{{name}} == input.{{name}} ||
+                    {{^vendorExtensions.x-is-value-type}}
+                    this.{{name}} != null &&
+                    input.{{name}} != null &&
+                    {{/vendorExtensions.x-is-value-type}}
+                    this.{{name}}.SequenceEqual(input.{{name}})
+                ){{^-last}} && {{/-last}}{{/isContainer}}{{/vars}}
+                && (this.AdditionalProperties.Count == input.AdditionalProperties.Count && this.AdditionalProperties.All(kv => input.AdditionalProperties.ContainsKey(kv.Key) && Equals(kv.Value, input.AdditionalProperties[kv.Key])));
+            {{/useCompareNetObjects}}
+        }
+
+        /// <summary>
+        /// Gets the hash code
+        /// </summary>
+        /// <returns>Hash code</returns>
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine, just wrap
+            {
+                int hashCode = {{hashCodeBasePrimeNumber}};
+{{#vars}}
+                if (this.{{name}} != null)
+                {
+                    hashCode = (hashCode * {{hashCodeMultiplierPrimeNumber}}) + this.{{name}}.GetHashCode();
+                }
+{{/vars}}
+                if (this.AdditionalProperties != null)
+                {
+                    hashCode = (hashCode * {{hashCodeMultiplierPrimeNumber}}) + this.AdditionalProperties.GetHashCode();
+                }
+                return hashCode;
+            }
+        }
+
+{{/parent}}
+{{/isEnum}}
+{{#validatable}}
+{{^parent}}
+        /// <summary>
+        /// To validate all properties of the instance
+        /// </summary>
+        /// <param name="validationContext">Validation context</param>
+        /// <returns>Validation Result</returns>
+        public IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(ValidationContext validationContext)
+        {
+{{#vars}}
+{{#hasValidation}}
+{{#maxLength}}
+            // {{{name}}} ({{{dataType}}}) maxLength
+            if (this.{{{name}}} != null && this.{{{name}}}.Length > {{maxLength}})
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, length must be less than {{maxLength}}.", new [] { "{{{name}}}" });
+            }
+
+{{/maxLength}}
+{{#minLength}}
+            // {{{name}}} ({{{dataType}}}) minLength
+            if (this.{{{name}}} != null && this.{{{name}}}.Length < {{minLength}})
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, length must be greater than {{minLength}}.", new [] { "{{{name}}}" });
+            }
+
+{{/minLength}}
+{{#maximum}}
+            // {{{name}}} ({{{dataType}}}) maximum
+            if (this.{{{name}}} > ({{{dataType}}}){{maximum}})
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must be a value less than or equal to {{maximum}}.", new [] { "{{{name}}}" });
+            }
+
+{{/maximum}}
+{{#minimum}}
+            // {{{name}}} ({{{dataType}}}) minimum
+            if (this.{{{name}}} < ({{{dataType}}}){{minimum}})
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must be a value greater than or equal to {{minimum}}.", new [] { "{{{name}}}" });
+            }
+
+{{/minimum}}
+{{#pattern}}
+            // {{{name}}} ({{{dataType}}}) pattern
+            Regex regex{{{name}}} = new Regex(@"{{{vendorExtensions.x-regex}}}"{{#vendorExtensions.x-modifiers}}{{#-first}}, {{/-first}}RegexOptions.{{{.}}}{{^-last}} | {{/-last}}{{/vendorExtensions.x-modifiers}});
+            if (false == regex{{{name}}}.Match(this.{{{name}}}).Success)
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for {{{name}}}, must match a pattern of " + regex{{{name}}}, new [] { "{{{name}}}" });
+            }
+
+{{/pattern}}
+{{/hasValidation}}
+{{/vars}}
+            yield break;
+        }
+{{/parent}}
+{{/validatable}}
+    }
+{{/model}}
+{{/models}}
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

- Added a new template to generate an interface `IOpenFgaClient` for the `OpenFgaClient`.
- See: https://github.com/openfga/dotnet-sdk/issues/56

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

It is currently not possible to mock the `OpenFgaClient` in unit tests in .NET as its methods are not virtual and it does not provide an interface for mocking

#### How is it being solved?

This PR adds a template to generate an interface and adds the interface to the generated `OpenFgaClient` which will allow unit tests to provide a mock using the interface `IOpenFgaClient` instead.

#### What changes are made to solve it?

- Added a new template file `config/clients/dotnet/template/Client/IClient.mustache`
- Updated `config/clients/dotnet/config.overrides.json` to include the new `.mustache` file
- Updated `config/clients/dotnet/template/Client/Client.mustache` to implement the interface
- Updated the `Makefile` to use latest OpenAPI generator which includes support for .NET 9

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

Closes: https://github.com/openfga/dotnet-sdk/issues/56
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * .NET SDK now exposes a client interface contract, enabling easier unit testing and custom implementations.

* **Chores**
  * Updated OpenAPI code generator version and related dependencies.
  * Enhanced code generation templates for improved .NET SDK client and model scaffolding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->