### PR TITLE
replace errgroup with conc pool in WriteExecute method

### DIFF
--- a/config/clients/go/template/client/client.mustache
+++ b/config/clients/go/template/client/client.mustache
@@ -4,6 +4,7 @@ package client
 import (
 	_context "context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	_nethttp "net/http"
@@ -1778,18 +1779,14 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
     if request.GetBody() != nil {
         for i := 0; i < len(request.GetBody().Writes); i += writeChunkSize {
             end := int(math.Min(float64(i+writeChunkSize), float64(len(request.GetBody().Writes))))
-
             writeChunks = append(writeChunks, (request.GetBody().Writes)[i:end])
         }
     }
 
-	writeGroup, ctx := errgroup.WithContext(request.GetContext())
-
-	writeGroup.SetLimit(int(maxParallelReqs))
-	writeResponses := make([]ClientWriteResponse, len(writeChunks))
-	for index, writeBody := range writeChunks {
-		index, writeBody := index, writeBody
-		writeGroup.Go(func() error {
+	writePool := pool.NewWithResults[*ClientWriteResponse]().WithContext(request.GetContext()).WithMaxGoroutines(int(maxParallelReqs))
+	for _, writeBody := range writeChunks {
+		writeBody := writeBody
+		writePool.Go(func(ctx _context.Context) (*ClientWriteResponse, error) {
 			singleResponse, err := client.WriteExecute(&SdkClientWriteRequest{
 				ctx:    ctx,
 				Client: client,
@@ -1800,22 +1797,18 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 					RequestOptions:       options.RequestOptions,
 					AuthorizationModelId: authorizationModelId,
 					StoreId:              request.GetStoreIdOverride(),
-                    Conflict:             options.Conflict,
+					Conflict:             options.Conflict,
 				},
 			})
-
-			if _, ok := err.(fgaSdk.FgaApiAuthenticationError); ok {
-				return err
+			var authErr fgaSdk.FgaApiAuthenticationError
+			if errors.As(err, &authErr) {
+				return nil, err
 			}
 
-			writeResponses[index] = *singleResponse
-
-			return nil
+			return singleResponse, nil
 		})
 	}
-
-	err = writeGroup.Wait()
-	// If an error was returned then it will be an authentication error so we want to return
+	writeResponses, err := writePool.Wait()
 	if err != nil {
 		return &response, err
 	}
@@ -1825,17 +1818,14 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
     if request.GetBody() != nil {
         for i := 0; i < len(request.GetBody().Deletes); i += deleteChunkSize {
             end := int(math.Min(float64(i+writeChunkSize), float64(len(request.GetBody().Deletes))))
-
             deleteChunks = append(deleteChunks, (request.GetBody().Deletes)[i:end])
         }
     }
 
-	deleteGroup, ctx := errgroup.WithContext(request.GetContext())
-	deleteGroup.SetLimit(int(maxParallelReqs))
-	deleteResponses := make([]ClientWriteResponse, len(deleteChunks))
-	for index, deleteBody := range deleteChunks {
-		index, deleteBody := index, deleteBody
-		deleteGroup.Go(func() error {
+	deletePool := pool.NewWithResults[*ClientWriteResponse]().WithContext(request.GetContext()).WithMaxGoroutines(int(maxParallelReqs))
+	for _, deleteBody := range deleteChunks {
+		deleteBody := deleteBody
+		deletePool.Go(func(ctx _context.Context) (*ClientWriteResponse, error) {
 			singleResponse, err := client.WriteExecute(&SdkClientWriteRequest{
 				ctx:    ctx,
 				Client: client,
@@ -1846,23 +1836,20 @@ func (client *{{appShortName}}Client) WriteExecute(request SdkClientWriteRequest
 					RequestOptions:       options.RequestOptions,
 					AuthorizationModelId: authorizationModelId,
 					StoreId:              request.GetStoreIdOverride(),
-                    Conflict:             options.Conflict,
+					Conflict:             options.Conflict,
 				},
 			})
 
-			if _, ok := err.(fgaSdk.FgaApiAuthenticationError); ok {
-				return err
+			var authErr fgaSdk.FgaApiAuthenticationError
+			if errors.As(err, &authErr) {
+				return nil, err
 			}
-
-			deleteResponses[index] = *singleResponse
-
-			return nil
+			return singleResponse, nil
 		})
 	}
 
-	err = deleteGroup.Wait()
+	deleteResponses, err := deletePool.Wait()
 	if err != nil {
-		// If an error was returned then it will be an authentication error so we want to return
 		return &response, err
 	}
 


### PR DESCRIPTION
Replace errgroup with conc pool in WriteExecute method
## Description
- Replace errgroup with conc pool for parallel write/delete operations
- Use errors.As() instead of type assertion for authentication error detection
- Handle wrapped errors from conc pool using errors.As() in both client and test
- Add nil check before dereferencing singleResponse to prevent panics
- Update test to use errors.As() for proper error unwrapping

This PR only moved "Write" to use Conc 
 
## References
https://github.com/openfga/go-sdk/issues/193


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced concurrent request processing with improved error handling and resource management for better reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->