### PR TITLE
feat(js): use build-client-streamed for JS SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-client-js: build-client-js
 
 .PHONY: build-client-js
 build-client-js:
-	make build-client sdk_language=js tmpdir=${TMP_DIR}
+	make build-client-streamed sdk_language=js tmpdir=${TMP_DIR}
 	sed -i -e "s|_this|this|g" ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*.ts
 	sed -i -e "s|_this|this|g" ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*.md
 	rm -rf  ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*-e


### PR DESCRIPTION
## Summary
Use `build-client-streamed` for JavaScript SDK to include streaming endpoints.

## Changes
- Makefile: Switch `build-client-js` to use `build-client-streamed` (aligns with Python SDK)

## Related
- openfga/js-sdk#280
- openfga/sdk-generator#76



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process infrastructure for the JavaScript client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->