### PR TITLE
feat(js): add supportsStreamedListObjects config flag support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,13 @@ test-client-js: build-client-js
 
 .PHONY: build-client-js
 build-client-js:
-	make build-client-streamed sdk_language=js tmpdir=${TMP_DIR}
+	@if grep -q '"supportsStreamedListObjects": true' config/clients/js/config.overrides.json; then \
+		echo "Building JS SDK with streaming support..."; \
+		make build-client-streamed sdk_language=js tmpdir=${TMP_DIR}; \
+	else \
+		echo "Building JS SDK without streaming support..."; \
+		make build-client-non-streamed sdk_language=js tmpdir=${TMP_DIR}; \
+	fi
 	sed -i -e "s|_this|this|g" ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*.ts
 	sed -i -e "s|_this|this|g" ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*.md
 	rm -rf  ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*-e

--- a/config/clients/js/config.overrides.json
+++ b/config/clients/js/config.overrides.json
@@ -12,6 +12,7 @@
   "modelPropertyNaming": "original",
   "openTelemetryDocumentation": "docs/opentelemetry.md",
   "enumNameSuffix": "",
+  "supportsStreamedListObjects": false,
   "files": {
     "constants.mustache": {
       "destinationFilename": "constants/index.ts",


### PR DESCRIPTION
# Add supportsStreamedListObjects Config Flag Support for JS SDK

## Problem

The JS SDK generator always builds with streaming support enabled, ignoring any potential configuration flag. This is inconsistent with the dotnet SDK approach and provides no flexibility to disable streaming during development.

The Makefile unconditionally calls `build-client-streamed` for JS SDK:

```makefile
.PHONY: build-client-js
build-client-js:
	make build-client-streamed sdk_language=js tmpdir=${TMP_DIR}
```

## Solution

Apply the same conditional streaming support pattern implemented for dotnet SDK to the JS SDK.

## Changes

### 1. config/clients/js/config.overrides.json

Added `supportsStreamedListObjects` flag:

```json
{
  ...
  "enumNameSuffix": "",
  "supportsStreamedListObjects": false,
  "files": {
    ...
  }
}
```

**Default**: `false` (streaming disabled until implementation is merged)

### 2. Makefile

Updated `build-client-js` to conditionally build based on flag:

```makefile
.PHONY: build-client-js
build-client-js:
	@if grep -q '"supportsStreamedListObjects": true' config/clients/js/config.overrides.json; then \
		echo "Building JS SDK with streaming support..."; \
		make build-client-streamed sdk_language=js tmpdir=${TMP_DIR}; \
	else \
		echo "Building JS SDK without streaming support..."; \
		make build-client-non-streamed sdk_language=js tmpdir=${TMP_DIR}; \
	fi
	sed -i -e "s|_this|this|g" ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*.ts
	sed -i -e "s|_this|this|g" ${CLIENTS_OUTPUT_DIR}/fga-js-sdk/*.md
```

## Result

The flag now works correctly for JS SDK:

**With flag = false (current default):**
```bash
$ make build-client-js
Building JS SDK without streaming support...
# Streaming endpoint removed from generated SDK
```

**With flag = true (when streaming is ready):**
```bash
$ make build-client-js
Building JS SDK with streaming support...
# Streaming endpoint included in generated SDK
```

## Cross-SDK Consistency

| SDK | Has Flag | Conditional Build | Default |
|-----|----------|-------------------|---------|
| Dotnet | Yes | Yes | `false` |
| JS | Yes | Yes | `false` |
| Python | Yes (method name) | N/A | Enabled |

Both dotnet and JS now follow the same pattern for streaming support configuration.

## Testing

Verified that:
- JS SDK builds successfully with flag = true
- Conditional logic correctly routes to streamed/non-streamed build targets
- Matches dotnet SDK behavior

## Impact

This change:
- Provides consistency across SDK generators
- Allows independent control of streaming support per SDK
- Enables cleaner development workflow (can disable streaming until ready)
- Follows the established pattern from dotnet SDK

## Files Modified

- `Makefile`
- `config/clients/js/config.overrides.json`

## Related PRs

- Dotnet streaming flag support: #662
- JS streaming implementation: openfga/js-sdk#280



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build process updated to conditionally select between client implementation variants at build time based on configuration settings.

* **New Features**
  * Added new configuration property to control streaming support for the JavaScript client.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->