### PR TITLE
feat(java-sdk): route generated json handling

### DIFF
--- a/config/clients/java/template/libraries/native/BaseStreamingApi.mustache
+++ b/config/clients/java/template/libraries/native/BaseStreamingApi.mustache
@@ -3,9 +3,9 @@ package {{apiPackage}};
 
 import static {{basePackage}}.util.StringUtil.isNullOrWhitespace;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import {{clientPackage}}.ApiClient;
+import {{clientPackage}}.JsonSerializer;
+import {{clientPackage}}.SdkTypeToken;
 import {{configPackage}}.Configuration;
 import {{errorsPackage}}.ApiException;
 import {{errorsPackage}}.FgaInvalidParameterException;
@@ -27,24 +27,24 @@ import java.util.stream.Stream;
 public abstract class BaseStreamingApi<T> {
     protected final Configuration configuration;
     protected final ApiClient apiClient;
-    protected final ObjectMapper objectMapper;
-    protected final TypeReference<StreamResult<T>> streamResultTypeRef;
+    protected final JsonSerializer jsonSerializer;
+    protected final SdkTypeToken<StreamResult<T>> streamResultType;
 
     /**
      * Constructor for BaseStreamingApi
      *
      * @param configuration The API configuration
      * @param apiClient The API client for making HTTP requests
-     * @param streamResultTypeRef TypeReference for deserializing StreamResult<T>
+     * @param streamResultType SDK type token for deserializing StreamResult<T>
      */
     protected BaseStreamingApi(
             Configuration configuration,
             ApiClient apiClient,
-            TypeReference<StreamResult<T>> streamResultTypeRef) {
+            SdkTypeToken<StreamResult<T>> streamResultType) {
         this.configuration = configuration;
         this.apiClient = apiClient;
-        this.objectMapper = apiClient.getObjectMapper();
-        this.streamResultTypeRef = streamResultTypeRef;
+        this.jsonSerializer = apiClient.getJsonSerializer();
+        this.streamResultType = streamResultType;
     }
 
     /**
@@ -117,7 +117,7 @@ public abstract class BaseStreamingApi<T> {
     private void processLine(String line, Consumer<T> consumer, Consumer<Throwable> errorConsumer) {
         try {
             // Parse the JSON line to extract the object
-            StreamResult<T> streamResult = objectMapper.readValue(line, streamResultTypeRef);
+            StreamResult<T> streamResult = jsonSerializer.readValue(line, streamResultType);
 
             if (streamResult.getError() != null) {
                 // Handle error in stream
@@ -156,7 +156,7 @@ public abstract class BaseStreamingApi<T> {
     protected HttpRequest buildHttpRequest(String method, String path, Object body, Configuration configuration)
             throws ApiException, FgaInvalidParameterException {
         try {
-            byte[] bodyBytes = objectMapper.writeValueAsBytes(body);
+            byte[] bodyBytes = jsonSerializer.writeValueAsBytes(body);
             HttpRequest.Builder requestBuilder = ApiClient.requestBuilder(method, path, bodyBytes, configuration);
 
             apiClient.applyAuthHeader(requestBuilder, configuration);

--- a/config/clients/java/template/libraries/native/StreamedListObjectsApi.mustache
+++ b/config/clients/java/template/libraries/native/StreamedListObjectsApi.mustache
@@ -3,8 +3,8 @@ package {{apiPackage}};
 
 import static {{basePackage}}.util.Validation.assertParamExists;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import {{clientPackage}}.ApiClient;
+import {{clientPackage}}.SdkTypeToken;
 import {{configPackage}}.Configuration;
 import {{configPackage}}.ConfigurationOverride;
 import {{modelPackage}}.ListObjectsRequest;
@@ -25,7 +25,10 @@ import java.util.function.Consumer;
 public class StreamedListObjectsApi extends BaseStreamingApi<StreamedListObjectsResponse> {
 
     public StreamedListObjectsApi(Configuration configuration, ApiClient apiClient) {
-        super(configuration, apiClient, new TypeReference<StreamResult<StreamedListObjectsResponse>>() {});
+        super(
+                configuration,
+                apiClient,
+                SdkTypeToken.parameterized(StreamResult.class, StreamedListObjectsResponse.class));
     }
 
     /**

--- a/config/clients/java/template/libraries/native/api.mustache
+++ b/config/clients/java/template/libraries/native/api.mustache
@@ -16,10 +16,6 @@ import {{errorsPackage}}.*;
 {{#imports}}
 import {{import}};
 {{/imports}}
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 {{#hasFormParamsInSpec}}
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
@@ -294,7 +290,7 @@ public class OpenFgaApi {
     private <T> HttpRequest buildHttpRequest(String method, String path, T body, Configuration configuration)
             throws ApiException, FgaInvalidParameterException {
         try {
-            byte[] localVarPostBody = apiClient.getObjectMapper().writeValueAsBytes(body);
+            byte[] localVarPostBody = apiClient.getJsonSerializer().writeValueAsBytes(body);
             var bodyPublisher = HttpRequest.BodyPublishers.ofByteArray(localVarPostBody);
             return buildHttpRequestWithPublisher(method, path, bodyPublisher, configuration);
         } catch (IOException e) {


### PR DESCRIPTION
## Description

Updates the generated Java API carriers for the Jackson 2 compatibility bridge. The generated code now uses the SDK-owned serialization API instead of Jackson mapper types.

#### What problem is being solved?

The Java SDK bridge changes generated request and streaming classes. Without matching template changes, the next generator sync would restore direct Jackson 2 dependencies.

#### How is it being solved?

The three affected Java templates now use `JsonSerializer` and `SdkTypeToken`, which the Java SDK owns.

#### What changes are made to solve it?

- Route generated request bodies through `ApiClient.getJsonSerializer()`.
- Route streaming request and response values through `JsonSerializer`.
- Replace generated Jackson `TypeReference` construction with `SdkTypeToken`.

## References

- https://github.com/openfga/rfcs/pull/36
- https://github.com/openfga/java-sdk/pull/387

## Test plan

- `make build-client-java`
- `make shellcheck`
- Confirm regeneration changes only release-managed version fields after the Java SDK commit.

## Review Checklist

- [x] I have clicked on "allow edits by maintainers".
- [x] The correct base branch is being used.
- [x] The generated Java SDK changes are included in the linked SDK PR.
- [x] The Java SDK tests cover serialization compatibility and wire parity.